### PR TITLE
Enable GLRenderer.

### DIFF
--- a/cc/resources/display_resource_provider.h
+++ b/cc/resources/display_resource_provider.h
@@ -95,11 +95,18 @@ class CC_EXPORT DisplayResourceProvider : public ResourceProvider {
     const SkImage* sk_image() const { return sk_image_.get(); }
 
     bool valid() const { return !!sk_image_; }
+#if defined(CASTANETS)
+    const gfx::ColorSpace& color_space() const { return color_space_; }
+#endif
 
    private:
     DisplayResourceProvider* const resource_provider_;
     const viz::ResourceId resource_id_;
     sk_sp<SkImage> sk_image_;
+#if defined(CASTANETS)
+    gfx::ColorSpace color_space_;
+    bool manual_texture_allocation_;
+#endif
 
     DISALLOW_COPY_AND_ASSIGN(ScopedReadLockSkImage);
   };

--- a/content/app/content_main_runner.cc
+++ b/content/app/content_main_runner.cc
@@ -531,8 +531,7 @@ class ContentMainRunnerImpl : public ContentMainRunner {
     base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoSandbox);
     base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoZygote);
 
-    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kDisableGpu);
-    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kDisableGpuCompositing);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kInProcessGPU);
     base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kDisableAcceleratedVideoDecode);
 
     base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kProcessPerTab);


### PR DESCRIPTION
This CL
i. Adds method to retrieve texture backed SkImage from bitmap pixels.
ii. Enable GL Renderer to composite bitmap raster data.

Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>