### PR TITLE
Initial implementation of distributed shared memory based on

### DIFF
--- a/base/base_switches.cc
+++ b/base/base_switches.cc
@@ -59,6 +59,9 @@ const char kNoErrorDialogs[]                = "noerrdialogs";
 #if defined(CASTANETS)
 // Specify distributed chrome server address.
 const char kServerAddress[]                 = "server-address";
+#if defined(NFS_SHARED_MEMORY)
+const char kSharedMemoryNFSPath[]           = "shared-memory-nfs-path";
+#endif
 #endif
 
 // When running certain tests that spawn child processes, this switch indicates

--- a/base/base_switches.h
+++ b/base/base_switches.h
@@ -25,6 +25,9 @@ extern const char kNoErrorDialogs[];
 extern const char kProfilingFile[];
 #if defined(CASTANETS)
 extern const char kServerAddress[];
+#if defined(NFS_SHARED_MEMORY)
+extern const char kSharedMemoryNFSPath[];
+#endif
 #endif
 extern const char kTestChildProcess[];
 extern const char kTestDoNotInitializeIcu[];

--- a/base/files/file_util.h
+++ b/base/files/file_util.h
@@ -261,7 +261,12 @@ BASE_EXPORT FILE* CreateAndOpenTemporaryFile(FilePath* path);
 
 // Similar to CreateAndOpenTemporaryFile, but the file is created in |dir|.
 BASE_EXPORT FILE* CreateAndOpenTemporaryFileInDir(const FilePath& dir,
+#if defined(NFS_SHARED_MEMORY)
+                                                  FilePath* path,
+                                                  int* id = NULL);
+#else
                                                   FilePath* path);
+#endif
 
 // Create a new directory. If prefix is provided, the new directory name is in
 // the format of prefixyyyy.

--- a/base/memory/shared_memory.h
+++ b/base/memory/shared_memory.h
@@ -215,6 +215,10 @@ class BASE_EXPORT SharedMemory {
   // Closed, as long as the region is not unmapped.
   const UnguessableToken& mapped_id() const { return mapped_id_; }
 
+#if defined(NFS_SHARED_MEMORY)
+  int GetMemoryId() { return shared_memory_id_; }
+  void SetMemoryId(int id) { shared_memory_id_ = id; }
+#endif
  private:
 #if defined(OS_POSIX) && !defined(OS_NACL) && !defined(OS_ANDROID) && \
     !defined(OS_FUCHSIA) && (!defined(OS_MACOSX) || defined(OS_IOS))
@@ -247,6 +251,9 @@ class BASE_EXPORT SharedMemory {
   size_t requested_size_ = 0;
   base::UnguessableToken mapped_id_;
 
+#if defined(NFS_SHARED_MEMORY)
+  int shared_memory_id_;
+#endif
   DISALLOW_COPY_AND_ASSIGN(SharedMemory);
 };
 

--- a/base/memory/shared_memory_helper.h
+++ b/base/memory/shared_memory_helper.h
@@ -20,7 +20,12 @@ namespace base {
 bool CreateAnonymousSharedMemory(const SharedMemoryCreateOptions& options,
                                  ScopedFILE* fp,
                                  ScopedFD* readonly_fd,
+#if defined(NFS_SHARED_MEMORY)
+                                 FilePath* path,
+                                 int* id = NULL);
+#else
                                  FilePath* path);
+#endif
 
 // Takes the outputs of CreateAnonymousSharedMemory and maps them properly to
 // |mapped_file| or |readonly_mapped_file|, depending on which one is populated.

--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -61,6 +61,9 @@ config("feature_flags") {
   if (enable_castanets) {
     defines += [ "CASTANETS" ]
   }
+  if (enable_nfs_shared_memory) {
+    defines += [ "NFS_SHARED_MEMORY" ]
+  }
   if (dcheck_always_on) {
     defines += [ "DCHECK_ALWAYS_ON=1" ]
   }

--- a/build/config/features.gni
+++ b/build/config/features.gni
@@ -24,6 +24,7 @@ declare_args() {
 
   # Enables CASTANETS.
   enable_castanets = false
+  enable_nfs_shared_memory = false
 
   # Enables proprietary codecs and demuxers; e.g. H264, AAC, MP3, and MP4.
   # We always build Google Chrome and Chromecast with proprietary codecs.


### PR DESCRIPTION
Network file system.

Steps:
1. Configure NFS server (browser process host), NFS client (renderer
process host) based on [1].
2. Enable build flag enable_nfs_shared_memory in args.gn
3. Browser process:
   ./out/mybuild/chrome <url> --shared-memory-nfs-path=<nfs server file path>
4. Renderer process:
   ./out/mybuild/chrome --type=renderer --server-address=<server ip> --shared-memory-nfs-path=<nfs client mount path>
   (Note: shared-memory-nfs-path has to be used, else will result in
    creation of shared memory files on current path)
5. Usage reference: https://github.com/suyambulingamrm/Castanets/commits/

[1] https://www.digitalocean.com/community/tutorials/how-to-set-up-an-nfs-mount-on-ubuntu-16-04

Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>