### PR TITLE
Set mailbox size explicitly in Canvas2DLayerBridge.

### DIFF
--- a/third_party/WebKit/Source/platform/graphics/Canvas2DLayerBridge.cpp
+++ b/third_party/WebKit/Source/platform/graphics/Canvas2DLayerBridge.cpp
@@ -464,8 +464,17 @@ bool Canvas2DLayerBridge::PrepareMailboxFromImage(
   mailbox_info->image_->EnsureMailbox(kUnverifiedSyncToken);
 
   *out_mailbox =
+#if defined(CASTANETS)
+      // As we are using ScopedReadLockSkImage in GLRenderer, it is necessary
+      // to set mailbox size explicitly. It will be used during compositing of
+      // texture quads.
+      viz::TextureMailbox(mailbox_info->image_->GetMailbox(),
+                          mailbox_info->image_->GetSyncToken(), GL_TEXTURE_2D,
+                          gfx::Size(size_), false);
+#else
       viz::TextureMailbox(mailbox_info->image_->GetMailbox(),
                           mailbox_info->image_->GetSyncToken(), GL_TEXTURE_2D);
+#endif
 
   if (IsHidden()) {
     // With hidden canvases, we release the SkImage immediately because


### PR DESCRIPTION
We are using DisplayResourceProvider::ScopedReadLockSkImage in
GLRenderer inorder to composite bitmap raster data using gpu.
For compositing texture quads, ScopedReadLockSkImage needs the size of
quad, which has to be set on Canvas2DLayerBridge.

Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>