### PR TITLE
Chromium can be compiled when Castanets is disabled.

### DIFF
--- a/components/viz/service/display_embedder/shared_bitmap_allocation_notifier_impl.cc
+++ b/components/viz/service/display_embedder/shared_bitmap_allocation_notifier_impl.cc
@@ -46,11 +46,11 @@ void SharedBitmapAllocationNotifierImpl::DidAllocateSharedBitmap(
     observer.DidAllocateSharedBitmap(last_sequence_number_);
 }
 
-#if defined(CASTANETS)
 void SharedBitmapAllocationNotifierImpl::DidRasterizeSharedBitmap(int32_t size, const std::vector<uint8_t>& pixels_vec, const gpu::Mailbox& id) {
+#if defined(CASTANETS)
   manager_->ChildRasterizedSharedBitmap(size, pixels_vec.data(), id);
-}
 #endif
+}
 
 void SharedBitmapAllocationNotifierImpl::DidDeleteSharedBitmap(
     const SharedBitmapId& id) {

--- a/components/viz/service/display_embedder/shared_bitmap_allocation_notifier_impl.h
+++ b/components/viz/service/display_embedder/shared_bitmap_allocation_notifier_impl.h
@@ -39,9 +39,9 @@ class VIZ_SERVICE_EXPORT SharedBitmapAllocationNotifierImpl
   void DidAllocateSharedBitmap(mojo::ScopedSharedBufferHandle buffer,
                                const SharedBitmapId& id) override;
   void DidDeleteSharedBitmap(const SharedBitmapId& id) override;
-#if defined(CASTANETS)
+
+  // Used only in Castanets.
   void DidRasterizeSharedBitmap(int32_t size, const std::vector<uint8_t>& pixels_vec, const gpu::Mailbox& id) override;
-#endif
 
   void ChildAllocatedSharedBitmap(size_t buffer_size,
                                   const base::SharedMemoryHandle& handle,

--- a/services/viz/public/interfaces/compositing/shared_bitmap_allocation_notifier.mojom
+++ b/services/viz/public/interfaces/compositing/shared_bitmap_allocation_notifier.mojom
@@ -14,6 +14,6 @@ interface SharedBitmapAllocationNotifier {
 
   // Informs the display compositor that the child deleted a shared bitmap.
   DidDeleteSharedBitmap(gpu.mojom.Mailbox id);
-  // Chromie
+  // Castanets
   DidRasterizeSharedBitmap(int32 size, array<uint8> pixels_vec, gpu.mojom.Mailbox id);
 };


### PR DESCRIPTION
This commit makes chromium be compiled when Castanets is disabled.
This is necessary for testing and debugging.