### PR TITLE
Enable Media Element to run using shared bitmap transmission.

### DIFF
--- a/cc/layers/video_frame_provider_client_impl.h
+++ b/cc/layers/video_frame_provider_client_impl.h
@@ -16,6 +16,12 @@
 
 namespace media { class VideoFrame; }
 
+#if defined(CASTANETS)
+namespace base {
+class TickClock;
+}
+#endif
+
 namespace cc {
 class VideoLayerImpl;
 
@@ -71,6 +77,10 @@ class CC_EXPORT VideoFrameProviderClientImpl
   VideoFrameProvider* provider_;
   VideoFrameControllerClient* client_;
   VideoLayerImpl* active_video_layer_;
+#if defined(CASTANETS)
+  std::unique_ptr<base::TickClock> tick_clock_;
+#endif
+
   bool stopped_;
   bool rendering_;
   bool needs_put_current_frame_;

--- a/cc/resources/video_resource_updater.cc
+++ b/cc/resources/video_resource_updater.cc
@@ -413,6 +413,9 @@ VideoFrameExternalResources VideoResourceUpdater::CreateForSoftwarePlanes(
         // This is software path, so canvas and video_frame are always backed
         // by software.
         video_renderer_->Copy(video_frame, &canvas, media::Context3D());
+#if defined(CASTANETS)
+        lock.NotifyRasterizedTile(lock.sk_bitmap().height()*lock.sk_bitmap().rowBytes(), lock.sk_bitmap().getPixels());
+#endif
       } else {
         size_t bytes_per_row = ResourceUtil::CheckedWidthInBytes<size_t>(
             video_frame->coded_size().width(), viz::ResourceFormat::RGBA_8888);


### PR DESCRIPTION
Share a video texture using TCP socket. If a video texture is created
on renderer process, it is sent in shared bitmap format.
And adjust frame time for the rendering frame decision algorithm.

Signed-off-by: Sunwoo Nam <jegalzz88@gmail.com>