### PR TITLE
fixup! Enable Media Element to run using shared bitmap transmission.

### DIFF
--- a/media/renderers/BUILD.gn
+++ b/media/renderers/BUILD.gn
@@ -26,6 +26,7 @@ source_set("renderers") {
   deps = [
     "//base",
     "//cc/paint",
+    "//content/public/common:static_switches",
     "//gpu/command_buffer/client:gles2_interface",
     "//gpu/command_buffer/common",
     "//media/base",

--- a/media/renderers/skcanvas_video_renderer.cc
+++ b/media/renderers/skcanvas_video_renderer.cc
@@ -28,6 +28,10 @@
 #include "third_party/skia/include/gpu/gl/GrGLTypes.h"
 #include "ui/gfx/geometry/rect_f.h"
 #include "ui/gfx/skia_util.h"
+#if defined(CASTANETS)
+#include "base/command_line.h"
+#include "content/public/common/content_switches.h"
+#endif
 
 // Skia internal format depends on a platform. On Android it is ABGR, on others
 // it is ARGB.
@@ -228,6 +232,13 @@ class VideoImageGenerator : public cc::PaintImageGenerator {
  public:
   VideoImageGenerator(const scoped_refptr<VideoFrame>& frame)
       : cc::PaintImageGenerator(
+#if defined(CASTANETS)
+            !base::CommandLine::ForCurrentProcess()->HasSwitch(
+                                switches::kDisableGpuCompositing) ?
+            SkImageInfo::Make(frame->visible_rect().width(),
+                              frame->visible_rect().height(),
+                              kRGBA_8888_SkColorType, kPremul_SkAlphaType) :
+#endif
             SkImageInfo::MakeN32Premul(frame->visible_rect().width(),
                                        frame->visible_rect().height())),
         frame_(frame) {


### PR DESCRIPTION
Video has a SkColorType issue with GLRenderer. (R <-> B)
Generate paint image with RGBA_8888 color type if GPU compositing is enabled.

Signed-off-by: Sunwoo Nam <jegalzz88@gmail.com>