### PR TITLE
Wrap the fileid used for distributed shared memory inside

### DIFF
--- a/base/base_switches.cc
+++ b/base/base_switches.cc
@@ -59,8 +59,8 @@ const char kNoErrorDialogs[]                = "noerrdialogs";
 #if defined(CASTANETS)
 // Specify distributed chrome server address.
 const char kServerAddress[]                 = "server-address";
-#if defined(NFS_SHARED_MEMORY)
-const char kSharedMemoryNFSPath[]           = "shared-memory-nfs-path";
+#if defined(NETWORK_SHARED_MEMORY)
+const char kNetworkSharedMemoryPath[]           = "network-shared-memory-path";
 #endif
 #endif
 

--- a/base/base_switches.h
+++ b/base/base_switches.h
@@ -25,8 +25,8 @@ extern const char kNoErrorDialogs[];
 extern const char kProfilingFile[];
 #if defined(CASTANETS)
 extern const char kServerAddress[];
-#if defined(NFS_SHARED_MEMORY)
-extern const char kSharedMemoryNFSPath[];
+#if defined(NETWORK_SHARED_MEMORY)
+extern const char kNetworkSharedMemoryPath[];
 #endif
 #endif
 extern const char kTestChildProcess[];

--- a/base/files/file_util.h
+++ b/base/files/file_util.h
@@ -261,7 +261,7 @@ BASE_EXPORT FILE* CreateAndOpenTemporaryFile(FilePath* path);
 
 // Similar to CreateAndOpenTemporaryFile, but the file is created in |dir|.
 BASE_EXPORT FILE* CreateAndOpenTemporaryFileInDir(const FilePath& dir,
-#if defined(NFS_SHARED_MEMORY)
+#if defined(NETWORK_SHARED_MEMORY)
                                                   FilePath* path,
                                                   int* id = NULL);
 #else

--- a/base/files/file_util_posix.cc
+++ b/base/files/file_util_posix.cc
@@ -56,7 +56,7 @@
 #include <grp.h>
 #endif
 
-#if defined(NFS_SHARED_MEMORY)
+#if defined(NETWORK_SHARED_MEMORY)
 #include "base/base_switches.h"
 #include "base/command_line.h"
 #endif
@@ -143,7 +143,7 @@ std::string TempFileName() {
 #endif
 }
 
-#if defined(NFS_SHARED_MEMORY)
+#if defined(NETWORK_SHARED_MEMORY)
 // Creates and opens a temporary file in |directory|, returning the
 // file descriptor. |path| is set to the temporary file path.
 // This function does NOT unlink() the file.
@@ -687,7 +687,7 @@ bool CreateTemporaryFile(FilePath* path) {
   return true;
 }
 
-#if defined(NFS_SHARED_MEMORY)
+#if defined(NETWORK_SHARED_MEMORY)
 FILE* CreateAndOpenTemporaryFileInDir(const FilePath& dir, FilePath* path, int* id) {
   int fd = CreateAndOpenFdForTemporaryFile(dir, path, id);
 #else
@@ -711,7 +711,7 @@ bool CreateTemporaryFileInDir(const FilePath& dir, FilePath* temp_file) {
 
 static bool CreateTemporaryDirInDirImpl(const FilePath& base_dir,
                                         const FilePath::StringType& name_tmpl,
-#if defined(NFS_SHARED_MEMORY)
+#if defined(NETWORK_SHARED_MEMORY)
                                         FilePath* new_dir,
                                         int *id = NULL) {
 #else
@@ -1039,13 +1039,13 @@ bool GetShmemTempDir(bool executable, FilePath* path) {
   if (use_dev_shm) {
     // Use mountpoint for browser process and actual folder for renderer process
     // assuming NFS server is renderer and browser is its client.
-#if !defined(NFS_SHARED_MEMORY)
+#if !defined(NETWORK_SHARED_MEMORY)
     *path = FilePath("/dev/shm");
 #else
   std::string shared_memory_file_path;
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  if (command_line->HasSwitch(switches::kSharedMemoryNFSPath)) {
-    shared_memory_file_path = command_line->GetSwitchValueASCII(switches::kSharedMemoryNFSPath);
+  if (command_line->HasSwitch(switches::kNetworkSharedMemoryPath)) {
+    shared_memory_file_path = command_line->GetSwitchValueASCII(switches::kNetworkSharedMemoryPath);
     /* Use actual folder for browser (nfs-server) */
     /* Use mnt folder for renderer (nfs-client) */
     *path = FilePath(shared_memory_file_path.c_str());

--- a/base/memory/shared_memory.h
+++ b/base/memory/shared_memory.h
@@ -215,10 +215,6 @@ class BASE_EXPORT SharedMemory {
   // Closed, as long as the region is not unmapped.
   const UnguessableToken& mapped_id() const { return mapped_id_; }
 
-#if defined(NFS_SHARED_MEMORY)
-  int GetMemoryId() const { return shared_memory_id_; }
-  void SetMemoryId(int id) { shared_memory_id_ = id; }
-#endif
  private:
 #if defined(OS_POSIX) && !defined(OS_NACL) && !defined(OS_ANDROID) && \
     !defined(OS_FUCHSIA) && (!defined(OS_MACOSX) || defined(OS_IOS))
@@ -251,9 +247,6 @@ class BASE_EXPORT SharedMemory {
   size_t requested_size_ = 0;
   base::UnguessableToken mapped_id_;
 
-#if defined(NFS_SHARED_MEMORY)
-  int shared_memory_id_;
-#endif
   DISALLOW_COPY_AND_ASSIGN(SharedMemory);
 };
 

--- a/base/memory/shared_memory_castanets_helper.h
+++ b/base/memory/shared_memory_castanets_helper.h
@@ -9,7 +9,7 @@ namespace base {
 
 namespace nfs_util {
 
-#if defined(NFS_SHARED_MEMORY)
+#if defined(NETWORK_SHARED_MEMORY)
 // This method flushes the changes on memory mapped region to
 // the underlying network file system.
 inline void FlushToDisk(int fd) {

--- a/base/memory/shared_memory_handle.h
+++ b/base/memory/shared_memory_handle.h
@@ -159,13 +159,21 @@ class BASE_EXPORT SharedMemoryHandle {
   // when trying to map the SharedMemoryHandle at a later point in time.
   SharedMemoryHandle(const base::FileDescriptor& file_descriptor,
                      size_t size,
+#if !defined(NETWORK_SHARED_MEMORY)
                      const base::UnguessableToken& guid);
+#else
+                     const base::UnguessableToken& guid, int shared_memory_file_id = 0);
+#endif
 
   // Creates a SharedMemoryHandle from an |fd| supplied from an external
   // service.
   // Passing the wrong |size| has no immediate consequence, but may cause errors
   // when trying to map the SharedMemoryHandle at a later point in time.
+#if !defined(NETWORK_SHARED_MEMORY)
   static SharedMemoryHandle ImportHandle(int fd, size_t size);
+#else
+  static SharedMemoryHandle ImportHandle(int fd, size_t size, int shared_memory_file_id = 0);
+#endif
 
   // Returns the underlying OS resource.
   int GetHandle() const;
@@ -173,6 +181,10 @@ class BASE_EXPORT SharedMemoryHandle {
   // Invalidates [but doesn't close] the underlying OS resource. This will leak
   // unless the caller is careful.
   int Release();
+#endif
+#if defined(NETWORK_SHARED_MEMORY)
+  int GetMemoryFileId() const { return shared_memory_file_id_; }
+  void SetMemoryFileId(int id) { shared_memory_file_id_ = id; }
 #endif
 
  private:
@@ -216,6 +228,9 @@ class BASE_EXPORT SharedMemoryHandle {
 
   // The size of the region referenced by the SharedMemoryHandle.
   size_t size_ = 0;
+#if defined(NETWORK_SHARED_MEMORY)
+  int shared_memory_file_id_;
+#endif
 };
 
 }  // namespace base

--- a/base/memory/shared_memory_helper.cc
+++ b/base/memory/shared_memory_helper.cc
@@ -32,7 +32,7 @@ using ScopedPathUnlinker =
 bool CreateAnonymousSharedMemory(const SharedMemoryCreateOptions& options,
                                  ScopedFILE* fp,
                                  ScopedFD* readonly_fd,
-#if defined(NFS_SHARED_MEMORY)
+#if defined(NETWORK_SHARED_MEMORY)
                                  FilePath* path,
                                  int *id) {
 #else
@@ -49,7 +49,7 @@ bool CreateAnonymousSharedMemory(const SharedMemoryCreateOptions& options,
   if (!GetShmemTempDir(options.executable, &directory))
     return false;
 
-#if defined(NFS_SHARED_MEMORY)
+#if defined(NETWORK_SHARED_MEMORY)
   fp->reset(base::CreateAndOpenTemporaryFileInDir(directory, path, id));
 #else
   fp->reset(base::CreateAndOpenTemporaryFileInDir(directory, path));
@@ -61,7 +61,7 @@ bool CreateAnonymousSharedMemory(const SharedMemoryCreateOptions& options,
   // Deleting the file prevents anyone else from mapping it in (making it
   // private), and prevents the need for cleanup (once the last fd is
   // closed, it is truly freed).
-#if !defined(NFS_SHARED_MEMORY)
+#if !defined(NETWORK_SHARED_MEMORY)
   path_unlinker.reset(path);
 #endif
 

--- a/base/memory/shared_memory_helper.h
+++ b/base/memory/shared_memory_helper.h
@@ -20,7 +20,7 @@ namespace base {
 bool CreateAnonymousSharedMemory(const SharedMemoryCreateOptions& options,
                                  ScopedFILE* fp,
                                  ScopedFD* readonly_fd,
-#if defined(NFS_SHARED_MEMORY)
+#if defined(NETWORK_SHARED_MEMORY)
                                  FilePath* path,
                                  int* id = NULL);
 #else

--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -61,8 +61,8 @@ config("feature_flags") {
   if (enable_castanets) {
     defines += [ "CASTANETS" ]
   }
-  if (enable_nfs_shared_memory) {
-    defines += [ "NFS_SHARED_MEMORY" ]
+  if (enable_network_shared_memory) {
+    defines += [ "NETWORK_SHARED_MEMORY" ]
   }
   if (dcheck_always_on) {
     defines += [ "DCHECK_ALWAYS_ON=1" ]

--- a/build/config/features.gni
+++ b/build/config/features.gni
@@ -24,7 +24,7 @@ declare_args() {
 
   # Enables CASTANETS.
   enable_castanets = false
-  enable_nfs_shared_memory = false
+  enable_network_shared_memory = false
 
   # Enables proprietary codecs and demuxers; e.g. H264, AAC, MP3, and MP4.
   # We always build Google Chrome and Chromecast with proprietary codecs.

--- a/content/browser/loader/async_resource_handler.cc
+++ b/content/browser/loader/async_resource_handler.cc
@@ -33,7 +33,7 @@
 #include "net/base/upload_progress.h"
 #include "net/url_request/redirect_info.h"
 
-#if defined(NFS_SHARED_MEMORY)
+#if defined(NETWORK_SHARED_MEMORY)
 #include "base/memory/shared_memory_castanets_helper.h"
 #endif
 
@@ -295,23 +295,19 @@ void AsyncResourceHandler::OnReadCompleted(
     }
     filter->Send(new ResourceMsg_SetDataBuffer(
         GetRequestID(), handle, buffer_->GetSharedMemory().mapped_size(),
-#if defined(NFS_SHARED_MEMORY)
-        buffer_->GetSharedMemory().GetMemoryId(), filter->peer_pid()));
-#else
         filter->peer_pid()));
-#endif
     sent_data_buffer_msg_ = true;
   }
 
   int data_offset = buffer_->GetLastAllocationOffset();
-#if defined(CASTANETS) && !defined(NFS_SHARED_MEMORY)
+#if defined(CASTANETS) && !defined(NETWORK_SHARED_MEMORY)
   const uint8_t* start_ptr = static_cast<uint8_t*>(buffer_->GetSharedMemory().memory()) + data_offset;
   std::vector<uint8_t> bytes(start_ptr, start_ptr + bytes_read);
   filter->Send(new ResourceMsg_DataReceived(GetRequestID(), data_offset,
                                             bytes_read, encoded_data_length,
                                             bytes));
 #else
-#if defined(NFS_SHARED_MEMORY)
+#if defined(NETWORK_SHARED_MEMORY)
   // TODO: Its needs to manually flush the opened files to the network filesystem.
   base::nfs_util::FlushToDisk(buffer_->GetSharedMemory().handle().GetHandle());
 #endif

--- a/content/browser/renderer_host/media/audio_renderer_host.cc
+++ b/content/browser/renderer_host/media/audio_renderer_host.cc
@@ -129,9 +129,6 @@ void AudioRendererHost::OnStreamCreated(
   }
 
   Send(new AudioMsg_NotifyStreamCreated(stream_id, foreign_memory_handle,
-#if defined(NFS_SHARED_MEMORY)
-                                        shared_memory->GetMemoryId(),
-#endif
                                         socket_descriptor));
 }
 

--- a/content/child/resource_dispatcher.h
+++ b/content/child/resource_dispatcher.h
@@ -232,11 +232,8 @@ class CONTENT_EXPORT ResourceDispatcher : public IPC::Listener {
   void OnSetDataBuffer(int request_id,
                        base::SharedMemoryHandle shm_handle,
                        int shm_size,
-#if defined(NFS_SHARED_MEMORY)
-                       int id,
-#endif
                        base::ProcessId renderer_pid);
-#if defined(CASTANETS) && !defined(NFS_SHARED_MEMORY)
+#if defined(CASTANETS) && !defined(NETWORK_SHARED_MEMORY)
   void OnReceivedData(int request_id,
                       int data_offset,
                       int data_length,

--- a/content/common/media/audio_messages.h
+++ b/content/common/media/audio_messages.h
@@ -51,9 +51,6 @@ IPC_MESSAGE_CONTROL4(AudioMsg_NotifyDeviceAuthorized,
 IPC_MESSAGE_CONTROL(AudioMsg_NotifyStreamCreated,
                     int /* stream id */,
                     base::SharedMemoryHandle /* handle */,
-#if defined(NFS_SHARED_MEMORY)
-                    int /* id */,
-#endif
                     base::SyncSocket::TransitDescriptor /* socket descriptor */)
 
 // Tell the renderer process that an audio input stream has been created.

--- a/content/common/resource_messages.h
+++ b/content/common/resource_messages.h
@@ -336,25 +336,16 @@ IPC_MESSAGE_CONTROL3(ResourceMsg_ReceivedRedirect,
 // TODO(darin): The |renderer_pid| parameter is just a temporary parameter,
 // added to help in debugging crbug/160401.
 //
-#if defined(NFS_SHARED_MEMORY)
-IPC_MESSAGE_CONTROL5(ResourceMsg_SetDataBuffer,
-                     int /* request_id */,
-                     base::SharedMemoryHandle /* shm_handle */,
-                     int /* shm_size */,
-                     int /* shm id */,
-                     base::ProcessId /* renderer_pid */)
-#else
 IPC_MESSAGE_CONTROL4(ResourceMsg_SetDataBuffer,
                      int /* request_id */,
                      base::SharedMemoryHandle /* shm_handle */,
                      int /* shm_size */,
                      base::ProcessId /* renderer_pid */)
-#endif
 
 // Sent when some data from a resource request is ready.  The data offset and
 // length specify a byte range into the shared memory buffer provided by the
 // SetDataBuffer message.
-#if defined(CASTANETS) && !defined(NFS_SHARED_MEMORY)
+#if defined(CASTANETS) && !defined(NETWORK_SHARED_MEMORY)
 IPC_MESSAGE_CONTROL5(ResourceMsg_DataReceived,
                      int /* request_id */,
                      int /* data_offset */,

--- a/content/renderer/media/audio_message_filter.cc
+++ b/content/renderer/media/audio_message_filter.cc
@@ -197,9 +197,6 @@ void AudioMessageFilter::OnDeviceAuthorized(
 void AudioMessageFilter::OnStreamCreated(
     int stream_id,
     base::SharedMemoryHandle handle,
-#if defined(NFS_SHARED_MEMORY)
-    int id,
-#endif
     base::SyncSocket::TransitDescriptor socket_descriptor) {
   DCHECK(io_task_runner_->BelongsToCurrentThread());
 
@@ -218,11 +215,7 @@ void AudioMessageFilter::OnStreamCreated(
     base::SyncSocket socket(socket_handle);
     return;
   }
-#if defined(NFS_SHARED_MEMORY)
-  delegate->OnStreamCreated(id, handle, socket_handle);
-#else
   delegate->OnStreamCreated(handle, socket_handle);
-#endif
 }
 
 void AudioMessageFilter::OnStreamError(int stream_id) {

--- a/content/renderer/media/audio_message_filter.h
+++ b/content/renderer/media/audio_message_filter.h
@@ -81,9 +81,6 @@ class CONTENT_EXPORT AudioMessageFilter : public IPC::MessageFilter {
   // Received when browser process has created an audio output stream.
   void OnStreamCreated(int stream_id,
                        base::SharedMemoryHandle handle,
-#if defined(NFS_SHARED_MEMORY)
-                       int id,
-#endif
                        base::SyncSocket::TransitDescriptor socket_descriptor);
 
   // Received when internal state of browser process' audio output device has

--- a/content/renderer/media/mojo_audio_output_ipc.cc
+++ b/content/renderer/media/mojo_audio_output_ipc.cc
@@ -210,11 +210,7 @@ void MojoAudioOutputIPC::StreamCreated(
   DCHECK_EQ(result, MOJO_RESULT_OK);
   DCHECK(!read_only);
 
-#if defined(NFS_SHARED_MEMORY)
-  delegate_->OnStreamCreated(0, memory_handle, socket_handle);
-#else
   delegate_->OnStreamCreated(memory_handle, socket_handle);
-#endif
 }
 
 }  // namespace content

--- a/content/renderer/pepper/pepper_platform_audio_output.cc
+++ b/content/renderer/pepper/pepper_platform_audio_output.cc
@@ -89,9 +89,6 @@ void PepperPlatformAudioOutput::OnDeviceAuthorized(
 }
 
 void PepperPlatformAudioOutput::OnStreamCreated(
-#if defined(NFS_SHARED_MEMORY)
-    int id,
-#endif
     base::SharedMemoryHandle handle,
     base::SyncSocket::Handle socket_handle) {
   DCHECK(handle.IsValid());
@@ -111,9 +108,6 @@ void PepperPlatformAudioOutput::OnStreamCreated(
     main_task_runner_->PostTask(
         FROM_HERE, base::BindOnce(&PepperPlatformAudioOutput::OnStreamCreated,
                                   this,
-#if defined(NFS_SHARED_MEMORY)
-                                  id,
-#endif
                                   handle, socket_handle));
   }
 }

--- a/content/renderer/pepper/pepper_platform_audio_output.h
+++ b/content/renderer/pepper/pepper_platform_audio_output.h
@@ -57,11 +57,7 @@ class PepperPlatformAudioOutput
   void OnDeviceAuthorized(media::OutputDeviceStatus device_status,
                           const media::AudioParameters& output_params,
                           const std::string& matched_device_id) override;
-  void OnStreamCreated(
-#if defined(NFS_SHARED_MEMORY)
-                       int id,
-#endif
-                       base::SharedMemoryHandle handle,
+  void OnStreamCreated(base::SharedMemoryHandle handle,
                        base::SyncSocket::Handle socket_handle) override;
   void OnIPCClosed() override;
 

--- a/content/renderer/pepper/pepper_platform_audio_output_dev.cc
+++ b/content/renderer/pepper/pepper_platform_audio_output_dev.cc
@@ -181,9 +181,6 @@ void PepperPlatformAudioOutputDev::OnDeviceAuthorized(
 }
 
 void PepperPlatformAudioOutputDev::OnStreamCreated(
-#if defined(NFS_SHARED_MEMORY)
-    int id,
-#endif
     base::SharedMemoryHandle handle,
     base::SyncSocket::Handle socket_handle) {
   DCHECK(handle.IsValid());
@@ -211,9 +208,6 @@ void PepperPlatformAudioOutputDev::OnStreamCreated(
     main_task_runner_->PostTask(
         FROM_HERE,
         base::BindOnce(&PepperPlatformAudioOutputDev::OnStreamCreated, this,
-#if defined(NFS_SHARED_MEMORY)
-                       id,
-#endif
                        handle, socket_handle));
   }
 }

--- a/content/renderer/pepper/pepper_platform_audio_output_dev.h
+++ b/content/renderer/pepper/pepper_platform_audio_output_dev.h
@@ -63,11 +63,7 @@ class PepperPlatformAudioOutputDev
   void OnDeviceAuthorized(media::OutputDeviceStatus device_status,
                           const media::AudioParameters& output_params,
                           const std::string& matched_device_id) override;
-  void OnStreamCreated(
-#if defined(NFS_SHARED_MEMORY)
-                       int id,
-#endif
-                       base::SharedMemoryHandle handle,
+  void OnStreamCreated(base::SharedMemoryHandle handle,
                        base::SyncSocket::Handle socket_handle) override;
   void OnIPCClosed() override;
 

--- a/media/audio/audio_device_thread.cc
+++ b/media/audio/audio_device_thread.cc
@@ -34,9 +34,6 @@ namespace media {
 
 AudioDeviceThread::Callback::Callback(const AudioParameters& audio_parameters,
                                       base::SharedMemoryHandle memory,
-#if defined(NFS_SHARED_MEMORY)
-                                      int id,
-#endif
                                       uint32_t segment_length,
                                       uint32_t total_segments)
     : audio_parameters_(audio_parameters),
@@ -46,12 +43,8 @@ AudioDeviceThread::Callback::Callback(const AudioParameters& audio_parameters,
       segment_length_(segment_length),
       // CHECK that the shared memory is large enough. The memory allocated
       // must be at least as large as expected.
-#if defined(NFS_SHARED_MEMORY)
-      id_(id) {
-#else
       shared_memory_((CHECK(memory_length_ <= memory.GetSize()), memory),
                      false) {
-#endif
   CHECK_GT(total_segments_, 0u);
   thread_checker_.DetachFromThread();
 }
@@ -136,7 +129,7 @@ void AudioDeviceThread::ThreadMain() {
     // expects. For more details on how this works see
     // AudioSyncReader::WaitUntilDataIsReady().
     ++buffer_index;
-#if defined(NFS_SHARED_MEMORY)
+#if defined(NETWORK_SHARED_MEMORY)
     fdatasync(callback_->shared_memory().GetHandle());
 #endif
 #if defined(CASTANETS)

--- a/media/audio/audio_device_thread.h
+++ b/media/audio/audio_device_thread.h
@@ -35,9 +35,6 @@ class MEDIA_EXPORT AudioDeviceThread : public base::PlatformThread::Delegate {
    public:
     Callback(const AudioParameters& audio_parameters,
              base::SharedMemoryHandle memory,
-#if defined(NFS_SHARED_MEMORY)
-             int id,
-#endif
              uint32_t segment_length,
              uint32_t total_segments);
 
@@ -51,7 +48,7 @@ class MEDIA_EXPORT AudioDeviceThread : public base::PlatformThread::Delegate {
     // Called whenever we receive notifications about pending input data.
     virtual void Process(uint32_t pending_data) = 0;
 
-#if defined(NFS_SHARED_MEMORY)
+#if defined(NETWORK_SHARED_MEMORY)
     const base::SharedMemoryHandle shared_memory() {
       return shared_memory_.handle();
     }
@@ -68,9 +65,6 @@ class MEDIA_EXPORT AudioDeviceThread : public base::PlatformThread::Delegate {
     const uint32_t total_segments_;
     const uint32_t segment_length_;
 
-#if defined(NFS_SHARED_MEMORY)
-    int id_;
-#endif
     base::SharedMemory shared_memory_;
 
     // Detached in constructor and attached in InitializeOnAudioThread() which

--- a/media/audio/audio_input_device.cc
+++ b/media/audio/audio_input_device.cc
@@ -54,9 +54,6 @@ class AudioInputDevice::AudioThreadCallback
  public:
   AudioThreadCallback(const AudioParameters& audio_parameters,
                       base::SharedMemoryHandle memory,
-#if defined(NFS_SHARED_MEMORY)
-                      int id,
-#endif
                       uint32_t total_segments,
                       CaptureCallback* capture_callback,
                       base::RepeatingClosure got_data_callback);
@@ -207,9 +204,6 @@ void AudioInputDevice::OnStreamCreated(base::SharedMemoryHandle handle,
   // Unretained is safe since |alive_checker_| outlives |audio_callback_|.
   audio_callback_ = std::make_unique<AudioInputDevice::AudioThreadCallback>(
       audio_parameters_, handle,
-#if defined(NFS_SHARED_MEMORY)
-      0,
-#endif
       kRequestedSharedMemoryCount, callback_,
       base::BindRepeating(&AliveChecker::NotifyAlive,
                           base::Unretained(alive_checker_.get())));
@@ -362,18 +356,12 @@ void AudioInputDevice::DetectedDeadInputStream() {
 AudioInputDevice::AudioThreadCallback::AudioThreadCallback(
     const AudioParameters& audio_parameters,
     base::SharedMemoryHandle memory,
-#if defined(NFS_SHARED_MEMORY)
-    int id,
-#endif
     uint32_t total_segments,
     CaptureCallback* capture_callback,
     base::RepeatingClosure got_data_callback_)
     : AudioDeviceThread::Callback(
           audio_parameters,
           memory,
-#if defined(NFS_SHARED_MEMORY)
-          id,
-#endif
           ComputeAudioInputBufferSize(audio_parameters, 1u),
           total_segments),
       bytes_per_ms_(static_cast<double>(audio_parameters.GetBytesPerSecond()) /

--- a/media/audio/audio_output_device.h
+++ b/media/audio/audio_output_device.h
@@ -118,11 +118,7 @@ class MEDIA_EXPORT AudioOutputDevice : public AudioRendererSink,
   void OnDeviceAuthorized(OutputDeviceStatus device_status,
                           const media::AudioParameters& output_params,
                           const std::string& matched_device_id) override;
-  void OnStreamCreated(
-#if defined(NFS_SHARED_MEMORY)
-                       int id,
-#endif
-                       base::SharedMemoryHandle handle,
+  void OnStreamCreated(base::SharedMemoryHandle handle,
                        base::SyncSocket::Handle socket_handle) override;
   void OnIPCClosed() override;
 

--- a/media/audio/audio_output_ipc.h
+++ b/media/audio/audio_output_ipc.h
@@ -39,11 +39,7 @@ class MEDIA_EXPORT AudioOutputIPCDelegate {
   // audio data to be written into the shared memory. The AudioOutputIPCDelegate
   // must read from this socket and provide audio whenever data (search for
   // "pending_bytes") is received.
-  virtual void OnStreamCreated(
-#if defined(NFS_SHARED_MEMORY)
-                               int id,
-#endif
-                               base::SharedMemoryHandle handle,
+  virtual void OnStreamCreated(base::SharedMemoryHandle handle,
                                base::SyncSocket::Handle socket_handle) = 0;
 
   // Called when the AudioOutputIPC object is going away and/or when the IPC


### PR DESCRIPTION
SharedMemoryHandle object.

This change,
1. Wraps fileid used for network shared memory inside
SharedMemoryHandle, so that there is not needed for sharing fileid
separately.
2. Handle fileid param in IPC.
3. Rename enable-nfs-shared-memory => enable-network-shared-memory
4. Rename runtime flag shared-memory-nfs-path => network-shared-memory-path
5. Updates resource loading, web audio module based on above changes.

Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>