### PR TITLE
tool: Add docker support for building and running

### DIFF
--- a/.dockerfile
+++ b/.dockerfile
@@ -1,0 +1,2 @@
+# .gitignore
+*~

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,81 @@
+#!/bin/echo docker build . -f
+# -*- coding: utf-8 -*-
+# Copyright: 2018-present Samsung Electronics France SAS, and other contributors
+
+FROM ubuntu:16.04
+MAINTAINER Philippe Coval (p.coval@samsung.com)
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL en_US.UTF-8
+ENV LANG ${LC_ALL}
+
+RUN echo "# log: Configuring locales" \
+  && set -x \
+  && apt-get update -y \
+  && apt-get install -y locales \
+  && echo "${LC_ALL} UTF-8" | tee /etc/locale.gen \
+  && locale-gen ${LC_ALL} \
+  && dpkg-reconfigure locales \
+  && sync
+
+RUN echo "# log: Setup system" \
+  && set -x \
+  && apt-get update -y \
+  && apt-get install -y \
+     apt-transport-https \
+     git \
+     lsb-release \
+     sudo \
+     ttf-mscorefonts-installer \
+  && apt-get clean \
+  && sync
+
+WORKDIR /usr/local/opt/depot_tools
+RUN echo "# log: ${project}: Preparing sources" \
+  && set -x \
+  && git clone --recursive --depth 1 \
+     https://chromium.googlesource.com/chromium/tools/depot_tools . \
+  && sync
+
+ENV project castanets
+ADD . /usr/local/opt/${project}/src/${project}/src
+WORKDIR /usr/local/opt/${project}/src/${project}/src
+RUN echo "# log: ${project}: Preparing sources" \
+  && set -x \
+  && git checkout castanets_63 \
+  || git checkout -b castanets_63 remotes/origin/castanets_63 \
+  && sync
+
+WORKDIR /usr/local/opt/${project}/src/${project}/src
+RUN echo "# log: ${project}: Preparing sources" \
+  && set -x \
+  && export PATH="${PATH}:/usr/local/opt/depot_tools" \
+  && yes | build/install-build-deps.sh \
+  && sync
+
+WORKDIR /usr/local/opt/${project}/src/${project}/src
+RUN echo "# log: ${project}: Preparing sources" \
+  && set -x \
+  && export PATH="${PATH}:/usr/local/opt/depot_tools" \
+  && build/create_gclient.sh \
+  && sync
+
+WORKDIR /usr/local/opt/${project}/src/${project}/src
+RUN echo "# log: ${project}: Preparing sources" \
+  && set -x \
+  && export PATH="${PATH}:/usr/local/opt/depot_tools" \
+  && gclient sync --with_branch_head \
+  && sync
+
+WORKDIR /usr/local/opt/${project}/src/${project}/src
+RUN echo "# log: ${project}: Preparing sources" \
+  && set -x \
+  && export PATH="${PATH}:/usr/local/opt/depot_tools" \
+  && gn gen out/Default \
+  && echo 'enable_castanets=true' | tee out/Default/args.gn \
+  && echo 'enable_nacl=false' | tee -a out/Default/args.gn \
+  && gn args --list out/Default \
+  && cat out/Default/args.gn \
+  && ninja -C out/Default chrome \
+  && ./out/Default/chrome -version \
+  && sync


### PR DESCRIPTION
It was tested on using docker-18.06.1-0ubuntu1~18.04.1
on current Ubuntu-18.04 (LTS)

Usage to run 2 chrome instances in same container:

```sh
url='https://github.com/Samsung/castanets'
project="castanets"
image="${project}"
name="${project}"
net_name="${project}_net"
hostname="server"
dir="/usr/local/opt/${project}/src/${project}/src"
exe="$dir/out/Default/chrome"

docker build -t "${name}" .

docker network create "${net_name}"

docker run \
  --network "${net_name}" \
  --network-alias "${hostname}"  \
  -ti --rm  \
  "${name}" \
  ip addr show

xhost +

docker run \
  -e DISPLAY="$DISPLAY"  \
  -v /tmp/.X11-unix:/tmp/.X11-unix  \
  --network ${net_name} \
  --network-alias ${hostname}  \
  -ti --rm \
  ${name} \
  ${exe} --no-sandbox ${url}

docker run \
  --network "${net_name}" \
  -e DISPLAY="$DISPLAY"  \
  -v /tmp/.X11-unix:/tmp/.X11-unix  \
  -ti \
  "$name" \
  "$exe" \
  --no-sandbox \
  --type=renderer \
  --server-address="$host"
```

Note, hostname is currently using ip, but hostname
could be used if source patched.

If merged README will need to be updated.

Relate-to: https://github.com/Samsung/Castanets/pull/32
Change-Id: I0837d8417ff5da283448d7d55ee91188fa0280a6
Signed-off-by: Philippe Coval <p.coval@samsung.com>