### PR TITLE
adding support for the install build script to handle working on Linu…

### DIFF
--- a/build/install-build-deps.sh
+++ b/build/install-build-deps.sh
@@ -112,7 +112,7 @@ fi
 
 distro_codename=$(lsb_release --codename --short)
 distro_id=$(lsb_release --id --short)
-supported_codenames="(trusty|xenial|yakkety|zesty)"
+supported_codenames="(trusty|xenial|yakkety|zesty|sarah)"
 supported_ids="(Debian)"
 if [ 0 -eq "${do_unsupported-0}" ] && [ 0 -eq "${do_quick_check-0}" ] ; then
   if [[ ! $distro_codename =~ $supported_codenames &&
@@ -122,6 +122,7 @@ if [ 0 -eq "${do_unsupported-0}" ] && [ 0 -eq "${do_quick_check-0}" ] ; then
       "\tUbuntu 16.04 (xenial)\n" \
       "\tUbuntu 16.10 (yakkety)\n" \
       "\tUbuntu 17.04 (zesty)\n" \
+      "\tLinuxMint 18 (sarah)\n" \
       "\tDebian 8 (jessie) or later" >&2
     exit 1
   fi


### PR DESCRIPTION
Adding support to the install build script to allow building of the project on Linux Mint 18 (Sarah).
Linux Mint Sarah is based on Ubuntu 16LTS - The build script was tested on 2 Linux mint machines, one base on AMD the other INTEL.