### PR TITLE
Use Hash for IPC Message instead of __LINE__

### DIFF
--- a/ipc/ipc_message_macros.h
+++ b/ipc/ipc_message_macros.h
@@ -252,7 +252,7 @@
   struct IPC_MESSAGE_EXPORT msg_name##_Meta {                       \
     using InTuple = in_tuple;                                       \
     using OutTuple = out_tuple;                                     \
-    enum { ID = IPC_MESSAGE_ID() };                                 \
+    enum { ID = IPC_MESSAGE_ID(#msg_name) };                        \
     static const IPC::MessageKind kKind = IPC::MessageKind::kind;   \
     static const char kName[];                                      \
   };                                                                \
@@ -310,9 +310,43 @@
 // Note: we currently use __LINE__ to give unique IDs to messages within
 // a file.  They're globally unique since each file defines its own
 // IPC_MESSAGE_START.
-#define IPC_MESSAGE_ID() ((IPC_MESSAGE_START << 16) + __LINE__)
+#if defined(CASTANETS)
+// Use HASH_MSG_NAME() instead of __LINE__ for unique IDs.
+// If hash IDs of messages have collisions, a build error will occur. The
+// HASH_MSG_NAME() function should ensure unique IDs without hash collisions
+constexpr uint32_t HASH_MSG_NAME(const char* s) {
+  uint32_t hash = 0;
+  const int prime = 2;
+  for (; *s; s++) {
+    if (*s == '_') {
+      s++;
+      break;
+    }
+  }
+  for (; *s; s++) {
+    int ch = *s;
+    if ('a' <= ch && ch <= 'z')
+      ch -= 'a';
+    else if ('A' <= ch && ch <= 'Z')
+      ch -= 'A';
+    else if ('0' <= ch && ch <= '9')
+      ch -= '0' + 26;
+    else
+      continue;
+    hash += hash * prime + ch;
+  }
+
+  return hash;
+}
+#define IPC_MESSAGE_ID(msg_name) \
+  ((IPC_MESSAGE_START << 25) | (HASH_MSG_NAME(msg_name) & 0x1ffffff))
+#define IPC_MESSAGE_ID_CLASS(id) ((id) >> 25)
+#define IPC_MESSAGE_ID_LINE(id) ((id)&0x1ffffff)
+#else
+#define IPC_MESSAGE_ID(msg_name) ((IPC_MESSAGE_START << 16) + __LINE__)
 #define IPC_MESSAGE_ID_CLASS(id) ((id) >> 16)
 #define IPC_MESSAGE_ID_LINE(id) ((id) & 0xffff)
+#endif
 
 // Message crackers and handlers. Usage:
 //


### PR DESCRIPTION
Unique ID of IPC Message is given by __LINE__. It caused a IPC message compatibility issue between different chromium versions. The IPC Unique ID consists of class ID and line number. Class IDs are defined in ipc_message_start.h file, and the number is 127 or less.
This patch resuces length of the class ID and uses the hash of IPC Message instead of line number(__LINE__) to give unique IDs.

Before : [16bit: CLASS ID][16bit: __LINE__]
After  : [ 7bit: CLASS ID][25bit: HASH of Message]