### PR TITLE
nacl: Align implementation to new shared_memory API

### DIFF
--- a/base/memory/shared_memory_nacl.cc
+++ b/base/memory/shared_memory_nacl.cc
@@ -55,7 +55,7 @@ bool SharedMemory::CreateAndMapAnonymous(size_t size) {
   return false;
 }
 
-bool SharedMemory::Create(const SharedMemoryCreateOptions& options) {
+bool SharedMemory::Create(const SharedMemoryCreateOptions& options, int sid) {
   // Untrusted code can't create descriptors or handles.
   return false;
 }


### PR DESCRIPTION
API has been changed to add shmem id (for network rendering):

* 806a6e36b1009e4c4e09531e88f8fbc6efc94ce5

It should be also done in NaCL implementation

Change-Id: Iefa31df4c21dff9a853e3436fad7a2ada1cfd6c9
Relate-to: https://github.com/Samsung/Castanets/pull/28
Signed-off-by: Philippe Coval <p.coval@samsung.com>