### PR TITLE
Castanets initial bringup commit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,170 @@
-# ![Logo](chrome/app/theme/chromium/product_logo_64.png) Chromium
 
-Chromium is an open-source browser project that aims to build a safer, faster,
-and more stable way for all users to experience the web.
+# How to build & run castanets
 
-The project's web site is https://www.chromium.org.
 
-Documentation in the source is rooted in [docs/README.md](docs/README.md).
+### Install depot_tools
 
-Learn how to [Get Around the Chromium Source Code Directory Structure
-](https://www.chromium.org/developers/how-tos/getting-around-the-chrome-source-code).
+
+Clone the depot_tools repository:
+
+```sh
+$ git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+```
+
+Add depot_tools to the end of your PATH (you will probably want to put this in your ~/.bashrc or ~/.zshrc). Assuming you cloned depot_tools to /path/to/depot_tools:
+
+```sh
+$ export PATH="$PATH:/path/to/depot_tools"
+```
+
+
+### Get the code
+
+
+Create a chromium directory for the checkout and change to it (you can call this whatever you like and put it wherever you like, as long as the full path has no spaces):
+
+```sh
+$ mkdir path/to/castanets && cd path/to/castanets
+```
+
+Download the code using the command below.
+
+```sh
+$ git clone -b castanets_69 https://github.com/Samsung/castanets src
+```
+
+If you did not specify the 'src' directory name at the end of the command, the source code would have been downloaded to the 'castanets' directory. In this case, change the directory name.
+
+```sh
+$ mv castanets src
+```
+
+Install additional build dependencies
+
+```sh
+$ build/install-build-deps.sh
+```
+
+
+### Run the sync
+
+We need a gclient configuration. To create a .gclient file, run:
+
+```sh
+$ build/create_gclient.sh
+```
+
+Once you've run install-build-deps at least once, you can now run the Chromium-specific sync, which will download additional binaries and other things you might need:
+
+```sh
+$ gclient sync --with_branch_head
+```
+
+If you get an SSL certificate error at Seoul R&D center, follow the directions below.
+
+```sh
+$ cd path/to/depot_tools
+$ git checkout 3beabd0aa40ca39216761418587251297376e6aa
+$ git apply path/to/castanets/src/build/SRnD_depot_tools.patch
+```
+If you get SSL3_GET_SERVER_CERTIFICATE error, follow the directions below.
+
+
+Add below line to .bashrc file.
+
+```sh
+export NO_AUTH_BOTO_CONFIG=~/.boto
+```
+
+
+Create ~/.boto file for the following content. 
+
+```sh
+[Boto]
+proxy = 10.112.1.178
+proxy_port = 8080
+https_validate_certificates = False
+```
+
+### Setting up the build
+
+
+Chromium uses Ninja as its main build tool along with a tool called GN to generate .ninja files. You can create any number of build directories with different configurations. To create a build directory, run:
+
+```sh
+$ gn gen out/Default
+```
+
+You set build arguments on a build directory by typing:
+
+```sh
+$ gn args out/Default
+```
+
+This will bring up an editor. Type build args into that file like this:
+
+```
+enable_castanets=true
+enable_nacl=false
+```
+
+For faster builds, the below can also be added in out/Default/args.gn
+
+```
+is_debug=false
+remove_webcore_debug_symbols=true
+is_component_build=true
+use_jumbo_build=true
+```
+
+
+### Build castanets
+
+
+Build castanets (the “chrome” target) with Ninja using the command:
+
+```sh
+$ autoninja -C out/Default chrome
+```
+
+
+### Run castanets in a local machine (test only)
+
+Start first chrome instance: Browser Process
+
+```sh
+$ out/Default/chrome <URL>
+```
+
+Start second chrome instance: Utility Process (Network Service)
+
+```sh
+$ out/Default/chrome --type=utility --server-address=127.0.0.1
+```
+
+Start third chrome instance: Renderer Process
+
+```sh
+$ out/Default/chrome --type=renderer --server-address=127.0.0.1
+```
+
+### Run castanets in a distributed environment
+
+
+Device A: Browser Process
+
+```sh
+$ out/Default/chrome <URL>
+```
+
+Device B: Utility Process (Network Service)
+
+```sh
+$ out/Default/chrome --type=utility --server-address=<IP ADDR>
+```
+Device B: Renderer Process
+
+```sh
+$ out/Default/chrome --type=renderer --server-address=<IP ADDR>
+```
+

--- a/base/base_switches.cc
+++ b/base/base_switches.cc
@@ -46,6 +46,11 @@ const char kForceFieldTrials[]              = "force-fieldtrials";
 // Suppresses all error dialogs when present.
 const char kNoErrorDialogs[]                = "noerrdialogs";
 
+#if defined(CASTANETS)
+// Specify distributed chrome server address.
+const char kServerAddress[]                 = "server-address";
+#endif
+
 // When running certain tests that spawn child processes, this switch indicates
 // to the test framework that the current process is a child process.
 const char kTestChildProcess[]              = "test-child-process";

--- a/base/base_switches.h
+++ b/base/base_switches.h
@@ -22,6 +22,9 @@ extern const char kForceFieldTrials[];
 extern const char kFullMemoryCrashReport[];
 extern const char kNoErrorDialogs[];
 extern const char kProfilingFile[];
+#if defined(CASTANETS)
+extern const char kServerAddress[];
+#endif
 extern const char kTestChildProcess[];
 extern const char kTestDoNotInitializeIcu[];
 extern const char kTraceToFile[];

--- a/base/files/file_util.h
+++ b/base/files/file_util.h
@@ -189,7 +189,11 @@ BASE_EXPORT bool ReadFromFD(int fd, char* buffer, size_t bytes);
 // the file-descriptor directly, rather than wrapping it into a FILE. Returns
 // -1 on failure.
 BASE_EXPORT int CreateAndOpenFdForTemporaryFileInDir(const FilePath& dir,
+#if defined(CASTANETS)
+                                                     FilePath* path, int *id = NULL);
+#else
                                                      FilePath* path);
+#endif
 
 #endif  // OS_POSIX || OS_FUCHSIA
 
@@ -281,7 +285,11 @@ BASE_EXPORT FILE* CreateAndOpenTemporaryFile(FilePath* path);
 
 // Similar to CreateAndOpenTemporaryFile, but the file is created in |dir|.
 BASE_EXPORT FILE* CreateAndOpenTemporaryFileInDir(const FilePath& dir,
+#if defined(CASTANETS)
+                                                  FilePath* path, int *id = NULL);
+#else
                                                   FilePath* path);
+#endif
 
 // Create a new directory. If prefix is provided, the new directory name is in
 // the format of prefixyyyy.

--- a/base/files/scoped_file.cc
+++ b/base/files/scoped_file.cc
@@ -40,7 +40,9 @@ void ScopedFDCloseTraits::Free(int fd) {
     ret = 0;
 #endif
 
+#if !defined(CASTANETS)
   PCHECK(0 == ret);
+#endif
 }
 
 #endif  // OS_POSIX || OS_FUCHSIA

--- a/base/memory/platform_shared_memory_region.cc
+++ b/base/memory/platform_shared_memory_region.cc
@@ -11,14 +11,24 @@ namespace subtle {
 
 // static
 PlatformSharedMemoryRegion PlatformSharedMemoryRegion::CreateWritable(
+#if defined(CASTANETS)
+    size_t size, std::string name) {
+  return Create(Mode::kWritable, size, name);
+#else
     size_t size) {
   return Create(Mode::kWritable, size);
+#endif
 }
 
 // static
 PlatformSharedMemoryRegion PlatformSharedMemoryRegion::CreateUnsafe(
+#if defined(CASTANETS)
+    size_t size, std::string name) {
+  return Create(Mode::kUnsafe, size, name);
+#else
     size_t size) {
   return Create(Mode::kUnsafe, size);
+#endif
 }
 
 PlatformSharedMemoryRegion::PlatformSharedMemoryRegion() = default;

--- a/base/memory/platform_shared_memory_region.h
+++ b/base/memory/platform_shared_memory_region.h
@@ -116,8 +116,13 @@ class BASE_EXPORT PlatformSharedMemoryRegion {
   // Creates a new PlatformSharedMemoryRegion with corresponding mode and size.
   // Creating in kReadOnly mode isn't supported because then there will be no
   // way to modify memory content.
+#if defined(CASTANETS)
+  static PlatformSharedMemoryRegion CreateWritable(size_t size, std::string name="");
+  static PlatformSharedMemoryRegion CreateUnsafe(size_t size, std::string name="");
+#else
   static PlatformSharedMemoryRegion CreateWritable(size_t size);
   static PlatformSharedMemoryRegion CreateUnsafe(size_t size);
+#endif
 
   // Returns a new PlatformSharedMemoryRegion that takes ownership of the
   // |handle|. All parameters must be taken from another valid
@@ -128,7 +133,11 @@ class BASE_EXPORT PlatformSharedMemoryRegion {
   static PlatformSharedMemoryRegion Take(ScopedPlatformHandle handle,
                                          Mode mode,
                                          size_t size,
+#if defined(CASTANETS)
+                                         const UnguessableToken& guid,int sid=0);
+#else
                                          const UnguessableToken& guid);
+#endif
 
   // Default constructor initializes an invalid instance, i.e. an instance that
   // doesn't wrap any valid platform handle.
@@ -197,13 +206,20 @@ class BASE_EXPORT PlatformSharedMemoryRegion {
   size_t GetSize() const { return size_; }
 
   Mode GetMode() const { return mode_; }
-
+#if defined(CASTANETS)
+  int GetMemoryFileId() { return memory_file_id_; }
+  void SetMemoryFileId(int sid) { memory_file_id_ = sid; }
+#endif
  private:
   FRIEND_TEST_ALL_PREFIXES(PlatformSharedMemoryRegionTest,
                            CreateReadOnlyRegionDeathTest);
   FRIEND_TEST_ALL_PREFIXES(PlatformSharedMemoryRegionTest,
                            CheckPlatformHandlePermissionsCorrespondToMode);
+#if defined(CASTANETS)
+  static PlatformSharedMemoryRegion Create(Mode mode, size_t size, std::string name="");
+#else
   static PlatformSharedMemoryRegion Create(Mode mode, size_t size);
+#endif
 
   static bool CheckPlatformHandlePermissionsCorrespondToMode(
       PlatformHandle handle,
@@ -213,13 +229,19 @@ class BASE_EXPORT PlatformSharedMemoryRegion {
   PlatformSharedMemoryRegion(ScopedPlatformHandle handle,
                              Mode mode,
                              size_t size,
+#if defined(CASTANETS)
+                             const UnguessableToken& guid, int memory_file_id);
+#else
                              const UnguessableToken& guid);
+#endif
 
   ScopedPlatformHandle handle_;
   Mode mode_ = Mode::kReadOnly;
   size_t size_ = 0;
   UnguessableToken guid_;
-
+#if defined(CASTANETS)
+  int memory_file_id_ = 0;
+#endif
   DISALLOW_COPY_AND_ASSIGN(PlatformSharedMemoryRegion);
 };
 

--- a/base/memory/read_only_shared_memory_region.h
+++ b/base/memory/read_only_shared_memory_region.h
@@ -94,6 +94,9 @@ class BASE_EXPORT ReadOnlySharedMemoryRegion {
     DCHECK(IsValid());
     return handle_.GetGUID();
   }
+#if defined(CASTANETS)
+  int GetMemoryFileId() { return handle_.GetMemoryFileId(); }
+#endif
 
  private:
   explicit ReadOnlySharedMemoryRegion(

--- a/base/memory/shared_memory.h
+++ b/base/memory/shared_memory.h
@@ -113,7 +113,11 @@ class BASE_EXPORT SharedMemory {
 
   // Creates a shared memory object as described by the options struct.
   // Returns true on success and false on failure.
+#if defined(CASTANETS)
+  bool Create(const SharedMemoryCreateOptions& options, int sid=0);
+#else
   bool Create(const SharedMemoryCreateOptions& options);
+#endif
 
   // Creates and maps an anonymous shared memory segment of size size.
   // Returns true on success and false on failure.
@@ -136,12 +140,20 @@ class BASE_EXPORT SharedMemory {
   // size is the size of the block to be created.
   // Returns true on success, false on failure.
   bool CreateNamedDeprecated(
+#if defined(CASTANETS)
+      const std::string& name, bool open_existing, size_t size, int sid = 0) {
+#else
       const std::string& name, bool open_existing, size_t size) {
+#endif
     SharedMemoryCreateOptions options;
     options.name_deprecated = &name;
     options.open_existing_deprecated = open_existing;
     options.size = size;
+#if defined(CASTANETS)
+    return Create(options, sid);
+#else
     return Create(options);
+#endif
   }
 
   // Deletes resources associated with a shared memory segment based on name.

--- a/base/memory/shared_memory_handle.h
+++ b/base/memory/shared_memory_handle.h
@@ -136,7 +136,11 @@ class BASE_EXPORT SharedMemoryHandle {
   // service.
   // Passing the wrong |size| has no immediate consequence, but may cause errors
   // when trying to map the SharedMemoryHandle at a later point in time.
+#if defined(CASTANETS)
+  static SharedMemoryHandle ImportHandle(int fd, size_t size, int shared_memory_file_id = 0);
+#else
   static SharedMemoryHandle ImportHandle(int fd, size_t size);
+#endif
 
   // Returns the underlying OS resource.
   int GetHandle() const;
@@ -144,6 +148,11 @@ class BASE_EXPORT SharedMemoryHandle {
   // Invalidates [but doesn't close] the underlying OS resource. This will leak
   // unless the caller is careful.
   int Release();
+
+#if defined(CASTANETS)
+  int GetMemoryFileId() const { return shared_memory_file_id_; }
+  void SetMemoryFileId(int id) { shared_memory_file_id_ = id; }
+#endif
 #endif
 
 #if defined(OS_ANDROID)
@@ -180,7 +189,11 @@ class BASE_EXPORT SharedMemoryHandle {
   // when trying to map the SharedMemoryHandle at a later point in time.
   SharedMemoryHandle(const base::FileDescriptor& file_descriptor,
                      size_t size,
+#if defined(CASTANETS)
+                     const base::UnguessableToken& guid, int shared_memory_file_id = 0);
+#else
                      const base::UnguessableToken& guid);
+#endif
 #endif
 
  private:
@@ -231,6 +244,9 @@ class BASE_EXPORT SharedMemoryHandle {
 
   // The size of the region referenced by the SharedMemoryHandle.
   size_t size_ = 0;
+#if defined(CASTANETS)
+  int shared_memory_file_id_;
+#endif
 };
 
 }  // namespace base

--- a/base/memory/shared_memory_helper.h
+++ b/base/memory/shared_memory_helper.h
@@ -21,7 +21,11 @@ namespace base {
 bool CreateAnonymousSharedMemory(const SharedMemoryCreateOptions& options,
                                  ScopedFD* fd,
                                  ScopedFD* readonly_fd,
+#if defined(CASTANETS)
+                                 FilePath* path, int *id = NULL);
+#else
                                  FilePath* path);
+#endif
 
 // Takes the outputs of CreateAnonymousSharedMemory and maps them properly to
 // |mapped_file| or |readonly_mapped_file|, depending on which one is populated.

--- a/base/memory/shared_memory_posix.cc
+++ b/base/memory/shared_memory_posix.cc
@@ -88,7 +88,11 @@ bool SharedMemory::CreateAndMapAnonymous(size_t size) {
 // we restart from a crash.  (That isn't a new problem, but it is a problem.)
 // In case we want to delete it later, it may be useful to save the value
 // of mem_filename after FilePathForMemoryName().
+#if defined(CASTANETS)
+bool SharedMemory::Create(const SharedMemoryCreateOptions& options, int sid) {
+#else
 bool SharedMemory::Create(const SharedMemoryCreateOptions& options) {
+#endif
   DCHECK(!shm_.IsValid());
   if (options.size == 0) return false;
 
@@ -104,9 +108,16 @@ bool SharedMemory::Create(const SharedMemoryCreateOptions& options) {
   ScopedFD fd;
   ScopedFD readonly_fd;
   FilePath path;
+#if defined(CASTANETS)
+  int shared_memory_file_id = sid;
+#endif
   if (!options.name_deprecated || options.name_deprecated->empty()) {
     bool result =
+#if defined(CASTANETS)
+        CreateAnonymousSharedMemory(options, &fd, &readonly_fd, &path, &shared_memory_file_id);
+#else
         CreateAnonymousSharedMemory(options, &fd, &readonly_fd, &path);
+#endif
     if (!result)
       return false;
   } else {
@@ -115,8 +126,11 @@ bool SharedMemory::Create(const SharedMemoryCreateOptions& options) {
 
     // Make sure that the file is opened without any permission
     // to other users on the system.
+#if !defined(CASTANETS)
     const mode_t kOwnerOnly = S_IRUSR | S_IWUSR;
-
+#else
+    const mode_t kOwnerOnly = S_IRUSR | S_IWUSR | S_IRWXU| S_IRWXO;
+#endif
     // First, try to create the file.
     fd.reset(HANDLE_EINTR(
         open(path.value().c_str(), O_RDWR | O_CREAT | O_EXCL, kOwnerOnly)));
@@ -139,6 +153,7 @@ bool SharedMemory::Create(const SharedMemoryCreateOptions& options) {
       // Check that the current user owns the file.
       // If uid != euid, then a more complex permission model is used and this
       // API is not appropriate.
+#if !defined(CASTANETS)
       const uid_t real_uid = getuid();
       const uid_t effective_uid = geteuid();
       struct stat sb;
@@ -150,6 +165,7 @@ bool SharedMemory::Create(const SharedMemoryCreateOptions& options) {
         close(fd.get());
         return false;
       }
+#endif
 
       // An existing file was opened, so its size should not be fixed.
       fix_size = false;
@@ -195,11 +211,19 @@ bool SharedMemory::Create(const SharedMemoryCreateOptions& options) {
 
   bool result = PrepareMapFile(std::move(fd), std::move(readonly_fd),
                                &mapped_file, &readonly_mapped_file);
+#if defined(CASTANETS)
+  shm_ = SharedMemoryHandle(FileDescriptor(mapped_file, false), options.size,
+                            UnguessableToken::Create(), shared_memory_file_id);
+  readonly_shm_ =
+      SharedMemoryHandle(FileDescriptor(readonly_mapped_file, false),
+                         options.size, shm_.GetGUID(), shared_memory_file_id);
+#else
   shm_ = SharedMemoryHandle(FileDescriptor(mapped_file, false), options.size,
                             UnguessableToken::Create());
   readonly_shm_ =
       SharedMemoryHandle(FileDescriptor(readonly_mapped_file, false),
                          options.size, shm_.GetGUID());
+#endif
   return result;
 }
 
@@ -363,7 +387,11 @@ bool SharedMemory::FilePathForMemoryName(const std::string& mem_name,
 #if defined(GOOGLE_CHROME_BUILD)
   static const char kShmem[] = "com.google.Chrome.shmem.";
 #else
+#if defined(CASTANETS)
+  static const char kShmem[] = ".org.chromium.Chromium.shmem.";
+#else
   static const char kShmem[] = "org.chromium.Chromium.shmem.";
+#endif
 #endif
   CR_DEFINE_STATIC_LOCAL(const std::string, name_base, (kShmem));
   *path = temp_dir.AppendASCII(name_base + mem_name);

--- a/base/memory/unsafe_shared_memory_region.cc
+++ b/base/memory/unsafe_shared_memory_region.cc
@@ -68,8 +68,10 @@ UnsafeSharedMemoryRegion::UnsafeSharedMemoryRegion(
     subtle::PlatformSharedMemoryRegion handle)
     : handle_(std::move(handle)) {
   if (handle_.IsValid()) {
+#if !defined(CASTANETS)
     CHECK_EQ(handle_.GetMode(),
              subtle::PlatformSharedMemoryRegion::Mode::kUnsafe);
+#endif
   }
 }
 

--- a/base/memory/unsafe_shared_memory_region.h
+++ b/base/memory/unsafe_shared_memory_region.h
@@ -94,6 +94,9 @@ class BASE_EXPORT UnsafeSharedMemoryRegion {
     return handle_.GetGUID();
   }
 
+#if defined(CASTANETS)
+  int GetMemoryFileId() { return handle_.GetMemoryFileId(); }
+#endif
  private:
   FRIEND_TEST_ALL_PREFIXES(DiscardableSharedMemoryTest,
                            LockShouldFailIfPlatformLockPagesFails);

--- a/base/memory/writable_shared_memory_region.h
+++ b/base/memory/writable_shared_memory_region.h
@@ -95,6 +95,9 @@ class BASE_EXPORT WritableSharedMemoryRegion {
     return handle_.GetGUID();
   }
 
+#if defined(CASTANETS)
+  int GetMemoryFileId () { return handle_.GetMemoryFileId(); }
+#endif
  private:
   explicit WritableSharedMemoryRegion(
       subtle::PlatformSharedMemoryRegion handle);

--- a/base/process/kill_posix.cc
+++ b/base/process/kill_posix.cc
@@ -29,7 +29,13 @@ TerminationStatus GetTerminationStatusImpl(ProcessHandle handle,
                                            int* exit_code) {
   DCHECK(exit_code);
 
+#if defined(CASTANETS)
+  if (exit_code)
+    *exit_code = 0;
+  return TERMINATION_STATUS_STILL_RUNNING;
+#endif
   int status = 0;
+
   const pid_t result = HANDLE_EINTR(waitpid(handle, &status,
                                             can_block ? 0 : WNOHANG));
   if (result == -1) {
@@ -86,11 +92,18 @@ bool KillProcessGroup(ProcessHandle process_group_id) {
 #endif  // !defined(OS_NACL_NONSFI)
 
 TerminationStatus GetTerminationStatus(ProcessHandle handle, int* exit_code) {
+#if defined(CASTANETS)
+  return TERMINATION_STATUS_NORMAL_TERMINATION;
+#endif
   return GetTerminationStatusImpl(handle, false /* can_block */, exit_code);
 }
 
 TerminationStatus GetKnownDeadTerminationStatus(ProcessHandle handle,
                                                 int* exit_code) {
+#if defined(CASTANETS)
+  return GetTerminationStatusImpl(handle, true /* can_block */, exit_code);
+#endif
+
   bool result = kill(handle, SIGKILL) == 0;
 
   if (!result)

--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -60,6 +60,9 @@ declare_args() {
 config("feature_flags") {
   # Don't use deprecated V8 APIs anywhere.
   defines = [ "V8_DEPRECATION_WARNINGS" ]
+  if (enable_castanets) {
+    defines += [ "CASTANETS" ]
+  }
   if (dcheck_always_on) {
     defines += [ "DCHECK_ALWAYS_ON=1" ]
     if (dcheck_is_configurable) {

--- a/build/config/features.gni
+++ b/build/config/features.gni
@@ -21,6 +21,10 @@ if (is_android) {
 }
 
 declare_args() {
+
+  # Enables CASTANETS.
+  enable_castanets = false
+
   # Enables proprietary codecs and demuxers; e.g. H264, AAC, MP3, and MP4.
   # We always build Google Chrome and Chromecast with proprietary codecs.
   #

--- a/build/create_gclient.sh
+++ b/build/create_gclient.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+BASEDIR=$(dirname "$0")
+cd $BASEDIR/../../
+GCLIENTDIR=$(pwd)
+printf "solutions = [\n {\n  \"url\": \"https://chromium.googlesource.com/chromium/src.git\",\n  \"managed\": False,\n  \"name\": \"src\",\n  \"deps_file\": \".DEPS.git\",\n  \"custom_deps\": {},\n },\n]\n" > .gclient
+echo "$GCLIENTDIR/.gclient has been created."

--- a/cc/mojo_embedder/async_layer_tree_frame_sink.cc
+++ b/cc/mojo_embedder/async_layer_tree_frame_sink.cc
@@ -186,6 +186,13 @@ void AsyncLayerTreeFrameSink::DidAllocateSharedBitmap(
   compositor_frame_sink_ptr_->DidAllocateSharedBitmap(std::move(buffer), id);
 }
 
+#if defined(CASTANETS)
+void AsyncLayerTreeFrameSink::DidRasterizeSharedBitmap(
+    int32_t size, const std::vector<uint8_t>& pixels_vec, const viz::SharedBitmapId &id) {
+  compositor_frame_sink_ptr_->DidRasterizeSharedBitmap(size, pixels_vec, id);
+}
+#endif
+
 void AsyncLayerTreeFrameSink::DidDeleteSharedBitmap(
     const viz::SharedBitmapId& id) {
   DCHECK(compositor_frame_sink_ptr_);

--- a/cc/mojo_embedder/async_layer_tree_frame_sink.h
+++ b/cc/mojo_embedder/async_layer_tree_frame_sink.h
@@ -91,6 +91,10 @@ class CC_MOJO_EMBEDDER_EXPORT AsyncLayerTreeFrameSink
   void DidAllocateSharedBitmap(mojo::ScopedSharedBufferHandle buffer,
                                const viz::SharedBitmapId& id) override;
   void DidDeleteSharedBitmap(const viz::SharedBitmapId& id) override;
+#if defined(CASTANETS)
+  void DidRasterizeSharedBitmap(int32_t size, const std::vector<uint8_t>& pixels_vec,
+                                const viz::SharedBitmapId &id) override;
+#endif
 
  private:
   // mojom::CompositorFrameSinkClient implementation:

--- a/cc/raster/bitmap_raster_buffer_provider.cc
+++ b/cc/raster/bitmap_raster_buffer_provider.cc
@@ -41,12 +41,22 @@ class BitmapRasterBufferImpl : public RasterBuffer {
                          const gfx::ColorSpace& color_space,
                          void* pixels,
                          uint64_t resource_content_id,
+#if defined(CASTANETS)
+                         uint64_t previous_content_id,
+                         LayerTreeFrameSink* frame_sink,
+                         viz::SharedBitmapId id)
+#else
                          uint64_t previous_content_id)
+#endif
       : resource_size_(size),
         color_space_(color_space),
         pixels_(pixels),
         resource_has_previous_content_(
             resource_content_id && resource_content_id == previous_content_id) {
+#if defined(CASTANETS)
+    frame_sink_ = frame_sink;
+    id_ = id;
+#endif
   }
 
   // Overridden from RasterBuffer:
@@ -70,6 +80,15 @@ class BitmapRasterBufferImpl : public RasterBuffer {
         pixels_, viz::RGBA_8888, resource_size_, stride, raster_source,
         raster_full_rect, playback_rect, transform, color_space_,
         /*gpu_compositing=*/false, playback_settings);
+#if defined(CASTANETS)
+    SkImageInfo info =
+    SkImageInfo::MakeN32(resource_size_.width(), resource_size_.height(), kPremul_SkAlphaType);
+    stride = info.minRowBytes();
+    uint8_t* pixels = static_cast<uint8_t*>(pixels_);
+    std::vector<uint8_t> pixels_vec(pixels, pixels + resource_size_.height() * stride);
+    frame_sink_->DidRasterizeSharedBitmap(resource_size_.height() * stride, pixels_vec,
+                                          id_);
+#endif
   }
 
  private:
@@ -77,6 +96,10 @@ class BitmapRasterBufferImpl : public RasterBuffer {
   const gfx::ColorSpace color_space_;
   void* const pixels_;
   bool resource_has_previous_content_;
+#if defined(CASTANETS)
+  LayerTreeFrameSink* frame_sink_;
+  viz::SharedBitmapId id_;
+#endif
 
   DISALLOW_COPY_AND_ASSIGN(BitmapRasterBufferImpl);
 };
@@ -118,7 +141,11 @@ BitmapRasterBufferProvider::AcquireBufferForRaster(
 
   return std::make_unique<BitmapRasterBufferImpl>(
       size, color_space, backing->shared_memory->memory(), resource_content_id,
+#if defined(CASTANETS)
+      previous_content_id, frame_sink_, backing->shared_bitmap_id);
+#else
       previous_content_id);
+#endif
 }
 
 void BitmapRasterBufferProvider::Flush() {}

--- a/chrome/app/chrome_main_delegate.cc
+++ b/chrome/app/chrome_main_delegate.cc
@@ -812,6 +812,9 @@ void ChromeMainDelegate::PreSandboxStartup() {
     // browser process as a command line flag.
 #if !BUILDFLAG(ENABLE_NACL)
     DCHECK(command_line.HasSwitch(switches::kLang) ||
+#if defined(CASTANETS)
+           process_type == switches::kRendererProcess ||
+#endif
            process_type == service_manager::switches::kZygoteProcess ||
            process_type == switches::kGpuProcess ||
            process_type == switches::kPpapiBrokerProcess ||

--- a/chrome/browser/prerender/prerender_field_trial.cc
+++ b/chrome/browser/prerender/prerender_field_trial.cc
@@ -15,6 +15,10 @@ const base::Feature kNoStatePrefetchFeature{"NoStatePrefetch",
                                             base::FEATURE_ENABLED_BY_DEFAULT};
 
 void ConfigureNoStatePrefetch() {
+#if defined(CASTANETS)
+  PrerenderManager::SetMode(PrerenderManager::PRERENDER_MODE_SIMPLE_LOAD_EXPERIMENT);
+  return;
+#endif
   auto mode = PrerenderManager::PRERENDER_MODE_NOSTATE_PREFETCH;
   if (!base::FeatureList::IsEnabled(kNoStatePrefetchFeature))
     mode = PrerenderManager::PRERENDER_MODE_SIMPLE_LOAD_EXPERIMENT;

--- a/components/subresource_filter/content/renderer/unverified_ruleset_dealer.cc
+++ b/components/subresource_filter/content/renderer/unverified_ruleset_dealer.cc
@@ -25,6 +25,10 @@ bool UnverifiedRulesetDealer::OnControlMessageReceived(
 
 void UnverifiedRulesetDealer::OnSetRulesetForProcess(
     const IPC::PlatformFileForTransit& platform_file) {
+#if defined(CASTANETS)
+  LOG(INFO) << "SKIP!!!!! UnverifiedRulesetDealer::OnSetRulesetForProcess";
+  return;
+#endif
   SetRulesetFile(IPC::PlatformFileForTransitToFile(platform_file));
 }
 

--- a/components/visitedlink/renderer/visitedlink_slave.cc
+++ b/components/visitedlink/renderer/visitedlink_slave.cc
@@ -31,6 +31,10 @@ void VisitedLinkSlave::UpdateVisitedLinks(
     base::ReadOnlySharedMemoryRegion table_region) {
   // Since this function may be called again to change the table, we may need
   // to free old objects.
+#if defined(CASTANETS)
+  LOG(INFO) << "SKIP!!!!! VisitedLinkSlave::UpdateVisitedLinks";
+  return;
+#endif
   FreeTable();
   DCHECK(hash_table_ == nullptr);
 
@@ -62,6 +66,10 @@ void VisitedLinkSlave::UpdateVisitedLinks(
 
 void VisitedLinkSlave::AddVisitedLinks(
     const std::vector<VisitedLinkSlave::Fingerprint>& fingerprints) {
+#if defined(CASTANETS)
+  LOG(INFO) << "SKIP!!!!! VisitedLinkSlave::AddVisitedLinks";
+  return;
+#endif
   for (size_t i = 0; i < fingerprints.size(); ++i)
     WebView::UpdateVisitedLinkState(fingerprints[i]);
 }

--- a/components/viz/client/shared_bitmap_reporter.h
+++ b/components/viz/client/shared_bitmap_reporter.h
@@ -22,6 +22,11 @@ class VIZ_CLIENT_EXPORT SharedBitmapReporter {
   virtual void DidAllocateSharedBitmap(mojo::ScopedSharedBufferHandle buffer,
                                        const SharedBitmapId& id) = 0;
 
+#if defined(CASTANETS)
+  virtual void DidRasterizeSharedBitmap(int32_t size, const std::vector<uint8_t>& pixels_vec,
+                                        const SharedBitmapId &id) = 0;
+#endif
+
   // Disassociates a SharedBitmapId previously passed to
   // DidAllocateSharedBitmap.
   virtual void DidDeleteSharedBitmap(const SharedBitmapId& id) = 0;

--- a/components/viz/common/resources/bitmap_allocation.cc
+++ b/components/viz/common/resources/bitmap_allocation.cc
@@ -50,6 +50,12 @@ std::unique_ptr<base::SharedMemory> AllocateMappedBitmap(
     CollectMemoryUsageAndDie(size, format, std::numeric_limits<int>::max());
   }
 
+#if defined(CASTANETS)
+  std::unique_ptr<base::SharedMemory> memory;
+  memory.reset(new base::SharedMemory);
+  memory->CreateAndMapAnonymous(bytes);
+  return memory;
+#else
   auto mojo_buf = mojo::SharedBufferHandle::Create(bytes);
   if (!mojo_buf->is_valid()) {
     DLOG(ERROR) << "Browser failed to allocate shared memory";
@@ -70,6 +76,7 @@ std::unique_ptr<base::SharedMemory> AllocateMappedBitmap(
   }
 
   return memory;
+#endif
 }
 
 mojo::ScopedSharedBufferHandle DuplicateAndCloseMappedBitmap(

--- a/components/viz/service/display/shared_bitmap_manager.h
+++ b/components/viz/service/display/shared_bitmap_manager.h
@@ -35,6 +35,9 @@ class SharedBitmapManager {
   // Used in the display compositor to break an association of an id to a shm
   // handle.
   virtual void ChildDeletedSharedBitmap(const SharedBitmapId& id) = 0;
+#if defined(CASTANETS)
+  virtual void ChildRasterizedSharedBitmap(size_t size, const uint8_t* pixels, const SharedBitmapId& id) = 0;
+#endif
 
  private:
   DISALLOW_COPY_AND_ASSIGN(SharedBitmapManager);

--- a/components/viz/service/display_embedder/server_shared_bitmap_manager.cc
+++ b/components/viz/service/display_embedder/server_shared_bitmap_manager.cc
@@ -105,18 +105,37 @@ bool ServerSharedBitmapManager::ChildAllocatedSharedBitmap(
   DCHECK_EQ(result, MOJO_RESULT_OK);
 
   auto data = base::MakeRefCounted<BitmapData>(buffer_size);
+#if defined(CASTANETS)
+  data->memory.reset(new base::SharedMemory); // need?
+  data->memory->CreateAndMapAnonymous(data->buffer_size);
+  data->memory->Close();
+#else
   data->memory = std::make_unique<base::SharedMemory>(memory_handle, false);
   // Map the memory to get a pointer to it, then close it to free up the fd so
   // it can be reused. This doesn't unmap the memory. Some OS have a very
   // limited number of fds and this avoids consuming them all.
   data->memory->Map(data->buffer_size);
   data->memory->Close();
-
+#endif
   if (handle_map_.find(id) != handle_map_.end())
     return false;
   handle_map_[id] = std::move(data);
   return true;
 }
+
+#if defined(CASTANETS)
+void ServerSharedBitmapManager::ChildRasterizedSharedBitmap(
+    size_t size,
+    const uint8_t* pixels,
+    const SharedBitmapId& id) {
+  auto it = handle_map_.find(id);
+  DCHECK(it != handle_map_.end());
+
+  BitmapData* data = it->second.get();
+  data->memory->CreateAndMapAnonymous(size);
+  memcpy(((BitmapData*)(data))->memory->memory(), pixels, size);
+}
+#endif
 
 void ServerSharedBitmapManager::ChildDeletedSharedBitmap(
     const SharedBitmapId& id) {

--- a/components/viz/service/display_embedder/server_shared_bitmap_manager.h
+++ b/components/viz/service/display_embedder/server_shared_bitmap_manager.h
@@ -41,7 +41,9 @@ class VIZ_SERVICE_EXPORT ServerSharedBitmapManager
   bool ChildAllocatedSharedBitmap(mojo::ScopedSharedBufferHandle buffer,
                                   const SharedBitmapId& id) override;
   void ChildDeletedSharedBitmap(const SharedBitmapId& id) override;
-
+#if defined(CASTANETS)
+  void ChildRasterizedSharedBitmap(size_t size, const uint8_t* pixels, const SharedBitmapId& id) override;
+#endif
   // base::trace_event::MemoryDumpProvider implementation.
   bool OnMemoryDump(const base::trace_event::MemoryDumpArgs& args,
                     base::trace_event::ProcessMemoryDump* pmd) override;

--- a/components/viz/service/frame_sinks/compositor_frame_sink_impl.cc
+++ b/components/viz/service/frame_sinks/compositor_frame_sink_impl.cc
@@ -96,6 +96,15 @@ void CompositorFrameSinkImpl::DidAllocateSharedBitmap(
   }
 }
 
+void CompositorFrameSinkImpl::DidRasterizeSharedBitmap(
+    int32_t size, const std::vector<uint8_t>& pixels_vec, const SharedBitmapId &id) {
+#if defined(CASTANETS)
+  support_->DidRasterizeSharedBitmap(size, pixels_vec, id);
+#else
+  NOTIMPLEMENTED();
+#endif
+}
+
 void CompositorFrameSinkImpl::DidDeleteSharedBitmap(const SharedBitmapId& id) {
   support_->DidDeleteSharedBitmap(id);
 }

--- a/components/viz/service/frame_sinks/compositor_frame_sink_impl.h
+++ b/components/viz/service/frame_sinks/compositor_frame_sink_impl.h
@@ -44,6 +44,8 @@ class CompositorFrameSinkImpl : public mojom::CompositorFrameSink {
   void DidNotProduceFrame(const BeginFrameAck& begin_frame_ack) override;
   void DidAllocateSharedBitmap(mojo::ScopedSharedBufferHandle buffer,
                                const SharedBitmapId& id) override;
+  void DidRasterizeSharedBitmap(int32_t size, const std::vector<uint8_t>& pixels_vec,
+                                const SharedBitmapId &id) override;
   void DidDeleteSharedBitmap(const SharedBitmapId& id) override;
 
  private:

--- a/components/viz/service/frame_sinks/compositor_frame_sink_support.cc
+++ b/components/viz/service/frame_sinks/compositor_frame_sink_support.cc
@@ -289,6 +289,13 @@ bool CompositorFrameSinkSupport::DidAllocateSharedBitmap(
   return true;
 }
 
+#if defined(CASTANETS)
+void CompositorFrameSinkSupport::DidRasterizeSharedBitmap(
+    int32_t size, const std::vector<uint8_t>& pixels_vec, const SharedBitmapId &id) {
+frame_sink_manager_->shared_bitmap_manager()->ChildRasterizedSharedBitmap(size, pixels_vec.data(), id);
+}
+#endif
+
 void CompositorFrameSinkSupport::DidDeleteSharedBitmap(
     const SharedBitmapId& id) {
   frame_sink_manager_->shared_bitmap_manager()->ChildDeletedSharedBitmap(id);

--- a/components/viz/service/frame_sinks/compositor_frame_sink_support.h
+++ b/components/viz/service/frame_sinks/compositor_frame_sink_support.h
@@ -125,6 +125,11 @@ class VIZ_SERVICE_EXPORT CompositorFrameSinkSupport
   // Returns false if the notification was not valid (a duplicate).
   bool DidAllocateSharedBitmap(mojo::ScopedSharedBufferHandle buffer,
                                const SharedBitmapId& id);
+#if defined(CASTANETS)
+  void DidRasterizeSharedBitmap(int32_t size, const std::vector<uint8_t>& pixels_vec,
+                                const SharedBitmapId &id);
+#endif
+
   void DidDeleteSharedBitmap(const SharedBitmapId& id);
 
   void EvictLastActivatedSurface();

--- a/components/viz/service/frame_sinks/direct_layer_tree_frame_sink.cc
+++ b/components/viz/service/frame_sinks/direct_layer_tree_frame_sink.cc
@@ -174,6 +174,13 @@ void DirectLayerTreeFrameSink::DidAllocateSharedBitmap(
   DCHECK(ok);
 }
 
+#if defined(CASTANETS)
+void DirectLayerTreeFrameSink::DidRasterizeSharedBitmap(
+    int32_t size, const std::vector<uint8_t>& pixels_vec, const SharedBitmapId &id) {
+  support_->DidRasterizeSharedBitmap(size, pixels_vec, id);
+}
+#endif
+
 void DirectLayerTreeFrameSink::DidDeleteSharedBitmap(const SharedBitmapId& id) {
   support_->DidDeleteSharedBitmap(id);
 }

--- a/components/viz/service/frame_sinks/direct_layer_tree_frame_sink.h
+++ b/components/viz/service/frame_sinks/direct_layer_tree_frame_sink.h
@@ -52,6 +52,11 @@ class VIZ_SERVICE_EXPORT DirectLayerTreeFrameSink
   void DidNotProduceFrame(const BeginFrameAck& ack) override;
   void DidAllocateSharedBitmap(mojo::ScopedSharedBufferHandle buffer,
                                const SharedBitmapId& id) override;
+#if defined(CASTANETS)
+  void DidRasterizeSharedBitmap(int32_t size, const std::vector<uint8_t>& pixels_vec,
+                                const SharedBitmapId &id) override;
+#endif
+
   void DidDeleteSharedBitmap(const SharedBitmapId& id) override;
 
   // DisplayClient implementation.

--- a/components/viz/service/frame_sinks/root_compositor_frame_sink_impl.cc
+++ b/components/viz/service/frame_sinks/root_compositor_frame_sink_impl.cc
@@ -190,6 +190,15 @@ void RootCompositorFrameSinkImpl::DidAllocateSharedBitmap(
   }
 }
 
+void RootCompositorFrameSinkImpl:: DidRasterizeSharedBitmap(
+    int32_t size, const std::vector<uint8_t>& pixels_vec, const SharedBitmapId &id) {
+#if defined(CASTANETS)
+  support_->DidRasterizeSharedBitmap(size, pixels_vec, id);
+#else
+  NOTIMPLEMENTED();
+#endif
+}
+
 void RootCompositorFrameSinkImpl::DidDeleteSharedBitmap(
     const SharedBitmapId& id) {
   support_->DidDeleteSharedBitmap(id);

--- a/components/viz/service/frame_sinks/root_compositor_frame_sink_impl.h
+++ b/components/viz/service/frame_sinks/root_compositor_frame_sink_impl.h
@@ -61,6 +61,9 @@ class RootCompositorFrameSinkImpl : public mojom::CompositorFrameSink,
   void DidNotProduceFrame(const BeginFrameAck& begin_frame_ack) override;
   void DidAllocateSharedBitmap(mojo::ScopedSharedBufferHandle buffer,
                                const SharedBitmapId& id) override;
+  void DidRasterizeSharedBitmap(int32_t size,
+                                const std::vector<uint8_t>& pixels_vec, const SharedBitmapId &id) override;
+
   void DidDeleteSharedBitmap(const SharedBitmapId& id) override;
   void SubmitCompositorFrameSync(
       const LocalSurfaceId& local_surface_id,

--- a/content/app/content_main_runner_impl.cc
+++ b/content/app/content_main_runner_impl.cc
@@ -66,6 +66,10 @@
 #include "ui/display/display_switches.h"
 #include "ui/gfx/switches.h"
 
+#if defined(CASTANETS)
+#include "ui/gl/gl_switches.h"
+#endif
+
 #if defined(OS_WIN)
 #include <malloc.h>
 #include <cstring>
@@ -729,6 +733,28 @@ int ContentMainRunnerImpl::Initialize(const ContentMainParams& params) {
       *base::CommandLine::ForCurrentProcess();
   std::string process_type =
       command_line.GetSwitchValueASCII(switches::kProcessType);
+
+#if defined(CASTANETS)
+  base::CommandLine::ForCurrentProcess()->AppendSwitch(service_manager::switches::kNoSandbox);
+  base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoZygote);
+  base::CommandLine::ForCurrentProcess()->AppendSwitch(
+      switches::kInProcessGPU);
+  base::CommandLine::ForCurrentProcess()->AppendSwitch(
+      switches::kDisableGpuCompositing);
+  base::CommandLine::ForCurrentProcess()->AppendSwitch(
+      switches::kDisableAcceleratedVideoDecode);
+
+  base::CommandLine::ForCurrentProcess()->AppendSwitch(
+      switches::kProcessPerTab);
+
+  base::CommandLine::ForCurrentProcess()->AppendSwitch("no-first-run");
+  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kLang,
+                                                            "en-US");
+  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
+      switches::kNumRasterThreads, "4");
+  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
+      switches::kRendererClientId, "1");
+#endif  // CASTANETS
 
 #if defined(OS_WIN)
   if (command_line.HasSwitch(switches::kDeviceScaleFactor)) {

--- a/content/browser/browser_child_process_host_impl.cc
+++ b/content/browser/browser_child_process_host_impl.cc
@@ -563,6 +563,10 @@ void BrowserChildProcessHostImpl::CreateMetricsAllocator() {
 }
 
 void BrowserChildProcessHostImpl::ShareMetricsAllocatorToProcess() {
+#if defined(CASTANETS)
+  LOG(INFO) << "SKIP!!!!! BrowserChildProcessHostImpl::ShareMetricsAllocatorToProcess";
+  return;
+#endif
   if (metrics_allocator_) {
     HistogramController::GetInstance()->SetHistogramMemory<ChildProcessHost>(
         GetHost(),

--- a/content/browser/child_process_launcher_helper.cc
+++ b/content/browser/child_process_launcher_helper.cc
@@ -145,9 +145,20 @@ void ChildProcessLauncherHelper::PostLaunchOnLauncherThread(
           mojo_channel_->TakeLocalEndpoint(), process_error_callback_);
     } else {
       DCHECK(mojo_named_channel_);
+#if defined(CASTANETS)
+      std::string type;
+      if (GetProcessType() == switches::kRendererProcess)
+        type = "renderer";
+      if (GetProcessType() == switches::kUtilityProcess)
+        type = "utility";
+#endif
       mojo::OutgoingInvitation::Send(
           std::move(invitation), process.process.Handle(),
+#if defined(CASTANETS)
+          mojo_named_channel_->TakeServerEndpoint(), process_error_callback_, type);
+#else
           mojo_named_channel_->TakeServerEndpoint(), process_error_callback_);
+#endif
     }
   }
 

--- a/content/browser/frame_host/render_frame_host_manager.cc
+++ b/content/browser/frame_host/render_frame_host_manager.cc
@@ -509,7 +509,13 @@ RenderFrameHostImpl* RenderFrameHostManager::GetFrameHostForNavigation(
   bool use_current_rfh = current_site_instance == dest_site_instance;
 
   bool notify_webui_of_rf_creation = false;
+#if defined(CASTANETS)
+  // FIXME: Currently once use_current_rfh is false, browser seem to be creating
+  // new channel for renderer ignoring the already connected renderer.
+  if (1 || use_current_rfh) {
+#else
   if (use_current_rfh) {
+#endif
     // GetFrameHostForNavigation will be called more than once during a
     // navigation (currently twice, on request and when it's about to commit in
     // the renderer). In the follow up calls an existing pending WebUI should

--- a/content/browser/renderer_host/input/render_widget_host_latency_tracker.h
+++ b/content/browser/renderer_host/input/render_widget_host_latency_tracker.h
@@ -67,6 +67,41 @@ class CONTENT_EXPORT RenderWidgetHostLatencyTracker {
   DISALLOW_COPY_AND_ASSIGN(RenderWidgetHostLatencyTracker);
 };
 
+#if defined(CASTANETS)
+class CONTENT_EXPORT MockLatencyTracker
+    : public ui::LatencyTracker {
+ public:
+  explicit MockLatencyTracker(bool metric_sampling) {}
+  ~MockLatencyTracker() {}
+
+  void OnGpuSwapBuffersCompleted(const ui::LatencyInfo& latency) {}
+
+  void Initialize(int routing_id, int process_id) {}
+
+  void ComputeInputLatencyHistograms(blink::WebInputEvent::Type type,
+                                    int64_t latency_component_id,
+                                    const ui::LatencyInfo& latency,
+                                    InputEventAckState ack_result) {}
+
+  void OnInputEvent(const blink::WebInputEvent& event,
+                   ui::LatencyInfo* latency) {}
+
+  void OnInputEventAck(const blink::WebInputEvent& event,
+                      ui::LatencyInfo* latency,
+                      InputEventAckState ack_result) {}
+
+  void OnSwapCompositorFrame(std::vector<ui::LatencyInfo>* latencies) {}
+
+  void set_device_scale_factor(float device_scale_factor) {}
+
+  int64_t latency_component_id() const { return 0; }
+
+  void SetDelegate(RenderWidgetHostDelegate*) {}
+  void reset_delegate() { }
+  DISALLOW_COPY_AND_ASSIGN(MockLatencyTracker);
+};
+#endif
+
 }  // namespace content
 
 #endif  // CONTENT_BROWSER_RENDERER_HOST_INPUT_RENDER_WIDGET_HOST_LATENCY_TRACKER_H_

--- a/content/browser/renderer_host/render_process_host_impl.cc
+++ b/content/browser/renderer_host/render_process_host_impl.cc
@@ -2887,6 +2887,9 @@ void RenderProcessHostImpl::PropagateBrowserCommandLineToRenderer(
     switches::kRendererStartupDialog,
     switches::kReportVp9AsAnUnsupportedMimeType,
     switches::kSamplingHeapProfiler,
+#if defined(CASTANETS)
+    switches::kServerAddress,
+#endif
     switches::kShowPaintRects,
     switches::kStatsCollectionController,
     switches::kSkiaFontCacheLimitMb,
@@ -3895,6 +3898,10 @@ RenderProcessHost* RenderProcessHostImpl::GetProcessHostForSiteInstance(
 }
 
 void RenderProcessHostImpl::CreateSharedRendererHistogramAllocator() {
+#if defined(CASTANETS)
+  LOG(INFO) << "SKIP!!!!! RenderProcessHostImpl::CreateSharedRendererHistogramAllocator";
+  return;
+#endif
   // Create a persistent memory segment for renderer histograms only if
   // they're active in the browser.
   if (!base::GlobalHistogramAllocator::Get()) {

--- a/content/browser/renderer_host/render_widget_host_impl.cc
+++ b/content/browser/renderer_host/render_widget_host_impl.cc
@@ -2205,6 +2205,15 @@ void RenderWidgetHostImpl::DidAllocateSharedBitmap(
   owned_bitmaps_.insert(id);
 }
 
+void RenderWidgetHostImpl::DidRasterizeSharedBitmap(
+    int32_t size, const std::vector<uint8_t>& pixels_vec, const viz::SharedBitmapId &id) {
+#if defined(CASTANETS)
+  shared_bitmap_manager_->ChildRasterizedSharedBitmap(size, pixels_vec.data(), id);
+#else
+  NOTIMPLEMENTED();
+#endif
+}
+
 void RenderWidgetHostImpl::DidDeleteSharedBitmap(
     const viz::SharedBitmapId& id) {
   shared_bitmap_manager_->ChildDeletedSharedBitmap(id);

--- a/content/browser/renderer_host/render_widget_host_impl.h
+++ b/content/browser/renderer_host/render_widget_host_impl.h
@@ -643,6 +643,8 @@ class CONTENT_EXPORT RenderWidgetHostImpl
   void DidAllocateSharedBitmap(mojo::ScopedSharedBufferHandle buffer,
                                const viz::SharedBitmapId& id) override;
   void DidDeleteSharedBitmap(const viz::SharedBitmapId& id) override;
+  void DidRasterizeSharedBitmap(int32_t size,
+                                const std::vector<uint8_t>& pixels_vec, const viz::SharedBitmapId &id) override;
 
   // Signals that a frame with token |frame_token| was finished processing. If
   // there are any queued messages belonging to it, they will be processed.
@@ -1068,7 +1070,11 @@ class CONTENT_EXPORT RenderWidgetHostImpl
 
   std::unique_ptr<TimeoutMonitor> new_content_rendering_timeout_;
 
+#if defined(CASTANETS)
+  MockLatencyTracker latency_tracker_;
+#else
   RenderWidgetHostLatencyTracker latency_tracker_;
+#endif
 
   int next_browser_snapshot_id_;
   using PendingSnapshotMap = std::map<int, GetSnapshotFromBrowserCallback>;

--- a/content/browser/service_manager/service_manager_context.cc
+++ b/content/browser/service_manager/service_manager_context.cc
@@ -445,7 +445,11 @@ ServiceManagerContext::ServiceManagerContext(
   if (service_manager::ServiceManagerIsRemote()) {
     auto endpoint = mojo::PlatformChannel::RecoverPassedEndpointFromCommandLine(
         *base::CommandLine::ForCurrentProcess());
+#if defined(CASTANETS)
+    auto invitation = mojo::IncomingInvitation::Accept(std::move(endpoint), "null");
+#else
     auto invitation = mojo::IncomingInvitation::Accept(std::move(endpoint));
+#endif
     packaged_services_request =
         service_manager::GetServiceRequestFromCommandLine(&invitation);
   } else {

--- a/content/common/service_manager/child_connection.cc
+++ b/content/common/service_manager/child_connection.cc
@@ -120,7 +120,14 @@ ChildConnection::ChildConnection(
     : context_(new IOThreadContext),
       child_identity_(child_identity),
       weak_factory_(this) {
+#if defined(CASTANETS)
+if (child_identity.name() == "content_utility")
+    service_token_ = "chromie_service_utility_request";
+  else
+    service_token_ = "chromie_service_request";
+#else
   service_token_ = base::NumberToString(base::RandUint64());
+#endif
   context_->Initialize(child_identity_, connector,
                        invitation->AttachMessagePipe(service_token_),
                        io_task_runner);

--- a/content/public/common/content_features.cc
+++ b/content/public/common/content_features.cc
@@ -392,7 +392,11 @@ const base::Feature kSignedHTTPExchangeOriginTrial{
 // spare renderer process around for the most recently requested BrowserContext.
 // This feature is only consulted in site-per-process mode.
 const base::Feature kSpareRendererForSitePerProcess{
+#if defined(CASTANETS)
+    "SpareRendererForSitePerProcess", base::FEATURE_DISABLED_BY_DEFAULT};
+#else
     "SpareRendererForSitePerProcess", base::FEATURE_ENABLED_BY_DEFAULT};
+#endif
 
 // Stop scheduler task queues in background after allowed grace time.
 const base::Feature kStopInBackground {

--- a/content/public/common/content_switches.cc
+++ b/content/public/common/content_switches.cc
@@ -9,6 +9,10 @@
 
 namespace switches {
 
+#if defined(CASTANETS)
+const char kEnableForking[] = "enable-forking";
+#endif
+
 // The number of MSAA samples for canvas2D. Requires MSAA support by GPU to
 // have an effect. 0 disables MSAA.
 const char kAcceleratedCanvas2dMSAASampleCount[] = "canvas-msaa-sample-count";

--- a/content/public/common/content_switches.h
+++ b/content/public/common/content_switches.h
@@ -13,6 +13,10 @@
 
 namespace switches {
 
+#if defined(CASTANETS)
+CONTENT_EXPORT extern const char kEnableForking[];
+#endif
+
 // All switches in alphabetical order. The switches should be documented
 // alongside the definition of their values in the .cc file.
 CONTENT_EXPORT extern const char kAcceleratedCanvas2dMSAASampleCount[];

--- a/ipc/ipc_message_utils.cc
+++ b/ipc/ipc_message_utils.cc
@@ -695,6 +695,9 @@ void ParamTraits<base::SharedMemoryHandle>::Write(base::Pickle* m,
   DCHECK(!p.GetGUID().is_empty());
   WriteParam(m, p.GetGUID());
   WriteParam(m, static_cast<uint64_t>(p.GetSize()));
+#if defined(CASTANETS)
+  WriteParam(m, static_cast<uint64_t>(p.GetMemoryFileId()));
+#endif
 }
 
 bool ParamTraits<base::SharedMemoryHandle>::Read(const base::Pickle* m,
@@ -738,7 +741,13 @@ bool ParamTraits<base::SharedMemoryHandle>::Read(const base::Pickle* m,
 
   base::UnguessableToken guid;
   uint64_t size;
+#if defined(CASTANETS)
+  uint64_t memory_file_id;
   if (!ReadParam(m, iter, &guid) || !ReadParam(m, iter, &size) ||
+      !ReadParam(m, iter, &memory_file_id) ||
+#else
+  if (!ReadParam(m, iter, &guid) || !ReadParam(m, iter, &size) ||
+#endif
       !base::IsValueInRangeForNumericType<size_t>(size)) {
     return false;
   }
@@ -758,7 +767,11 @@ bool ParamTraits<base::SharedMemoryHandle>::Read(const base::Pickle* m,
           static_cast<internal::PlatformFileAttachment*>(attachment.get())
               ->TakePlatformFile(),
           true),
+#if defined(CASTANETS)
+      static_cast<size_t>(size), guid, memory_file_id);
+#else
       static_cast<size_t>(size), guid);
+#endif
 #endif
 
 #if defined(OS_ANDROID)

--- a/mojo/core/BUILD.gn
+++ b/mojo/core/BUILD.gn
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//build/config/features.gni")
 import("//build/config/nacl/config.gni")
 import("//testing/test.gni")
 
@@ -59,6 +60,7 @@ template("core_impl_source_set") {
       "scoped_process_handle.h",
       "shared_buffer_dispatcher.h",
       "user_message_impl.h",
+
     ]
 
     sources = [
@@ -142,6 +144,9 @@ template("core_impl_source_set") {
     }
 
     deps = []
+    if (enable_castanets) {
+      deps += ["//mojo/public/cpp/platform:platform"]
+    }
     if (is_android) {
       deps += [ "//third_party/ashmem" ]
     }

--- a/mojo/core/broker.h
+++ b/mojo/core/broker.h
@@ -21,7 +21,11 @@ class Broker {
  public:
   // Note: This is blocking, and will wait for the first message over
   // the endpoint handle in |handle|.
+#if defined(CASTANETS)
+  explicit Broker(PlatformHandle handle, int port);
+#else
   explicit Broker(PlatformHandle handle);
+#endif
   ~Broker();
 
   // Returns the platform handle that should be used to establish a NodeChannel

--- a/mojo/core/channel_posix.cc
+++ b/mojo/core/channel_posix.cc
@@ -24,6 +24,11 @@
 #include "mojo/core/core.h"
 #include "mojo/public/cpp/platform/socket_utils_posix.h"
 
+#if defined(CASTANETS)
+#include "mojo/public/cpp/platform/tcp_platform_handle_utils.h"
+#endif
+
+
 #if !defined(OS_NACL)
 #include <sys/uio.h>
 #endif
@@ -270,6 +275,14 @@ class ChannelPosix : public Channel,
     for (size_t i = 0; i < handles->size(); ++i)
       handles->at(i) = handles_in_transit[i].TakeHandle();
 #else
+#if defined(CASTANETS)
+    handles->clear();
+    handles->resize(num_handles);
+    for (size_t i = 0; i < num_handles; ++i) {
+      handles->at(i) = PlatformHandle((base::ScopedFD(kCastanetsHandle)));
+      //(*handles)->at(i).type = PlatformHandle::Type::POSIX_CHROMIE;
+    }
+#else
     if (incoming_fds_.size() < num_handles)
       return true;
 
@@ -279,7 +292,7 @@ class ChannelPosix : public Channel,
       incoming_fds_.pop_front();
     }
 #endif
-
+#endif
     return true;
   }
 
@@ -426,13 +439,19 @@ class ChannelPosix : public Channel,
 #if !defined(OS_NACL)
       read_watcher_.reset();
       base::MessageLoopCurrent::Get()->RemoveDestructionObserver(this);
-
+#if defined(CASTANETS)
+      TCPServerAcceptConnection(server_.platform_handle().GetFD().get(), &socket_);
+#else
       AcceptSocketConnection(server_.platform_handle().GetFD().get(), &socket_);
+#endif
       ignore_result(server_.TakePlatformHandle());
       if (!socket_.is_valid()) {
         OnError(Error::kConnectionFailed);
         return;
       }
+#if defined(CASTANETS)
+      //handle_.reset();
+#endif
       StartOnIOThread();
 #else
       NOTREACHED();

--- a/mojo/core/core.h
+++ b/mojo/core/core.h
@@ -91,7 +91,11 @@ class MOJO_SYSTEM_IMPL_EXPORT Core {
   // Accepts an invitation via |connection_params|. The other end of the
   // connection medium in |connection_params| must have been used by some other
   // process to send an invitation.
+#if defined(CASTANETS)
+  void AcceptBrokerClientInvitation(ConnectionParams connection_params, std::string type);
+#else
   void AcceptBrokerClientInvitation(ConnectionParams connection_params);
+#endif
 
   // Extracts a named message pipe endpoint from the broker client invitation
   // accepted by this process. Must only be called after
@@ -292,6 +296,9 @@ class MOJO_SYSTEM_IMPL_EXPORT Core {
       uint32_t num_platform_handles,
       uint64_t size,
       const MojoSharedBufferGuid* guid,
+#if defined(CASTANETS)
+      int sid,
+#endif
       MojoPlatformSharedMemoryRegionAccessMode access_mode,
       const MojoWrapPlatformSharedMemoryRegionOptions* options,
       MojoHandle* mojo_handle);
@@ -325,11 +332,19 @@ class MOJO_SYSTEM_IMPL_EXPORT Core {
       const MojoInvitationTransportEndpoint* transport_endpoint,
       MojoProcessErrorHandler error_handler,
       uintptr_t error_handler_context,
+#if defined(CASTANETS)
+      const MojoSendInvitationOptions* options, std::string process_type);
+#else
       const MojoSendInvitationOptions* options);
+#endif
   MojoResult AcceptInvitation(
       const MojoInvitationTransportEndpoint* transport_endpoint,
       const MojoAcceptInvitationOptions* options,
+#if defined(CASTANETS)
+      MojoHandle* invitation_handle, std::string type);
+#else
       MojoHandle* invitation_handle);
+#endif
 
   // Quota API.
   MojoResult SetQuota(MojoHandle handle,

--- a/mojo/core/entrypoints.cc
+++ b/mojo/core/entrypoints.cc
@@ -263,11 +263,18 @@ MojoResult MojoWrapPlatformSharedMemoryRegionImpl(
     uint32_t num_platform_handles,
     uint64_t num_bytes,
     const MojoSharedBufferGuid* guid,
+#if defined(CASTANETS)
+    int sid,
+#endif
     MojoPlatformSharedMemoryRegionAccessMode access_mode,
     const MojoWrapPlatformSharedMemoryRegionOptions* options,
     MojoHandle* mojo_handle) {
   return g_core->WrapPlatformSharedMemoryRegion(
+#if defined(CASTANETS)
+      platform_handles, num_platform_handles, num_bytes, guid, sid, access_mode,
+#else
       platform_handles, num_platform_handles, num_bytes, guid, access_mode,
+#endif
       options, mojo_handle);
 }
 
@@ -315,18 +322,34 @@ MojoResult MojoSendInvitationImpl(
     const MojoInvitationTransportEndpoint* transport_endpoint,
     MojoProcessErrorHandler error_handler,
     uintptr_t error_handler_context,
+#if defined(CASTANETS)
+    const MojoSendInvitationOptions* options, std::string process_type) {
+#else
     const MojoSendInvitationOptions* options) {
+#endif
   return g_core->SendInvitation(invitation_handle, process_handle,
                                 transport_endpoint, error_handler,
+#if defined(CASTANETS)
+                                error_handler_context, options, process_type);
+#else
                                 error_handler_context, options);
+#endif
 }
 
 MojoResult MojoAcceptInvitationImpl(
     const MojoInvitationTransportEndpoint* transport_endpoint,
     const MojoAcceptInvitationOptions* options,
+#if defined(CASTANETS)
+    MojoHandle* invitation_handle, std::string type) {
+#else
     MojoHandle* invitation_handle) {
+#endif
   return g_core->AcceptInvitation(transport_endpoint, options,
+#if defined(CASTANETS)
+                                  invitation_handle, type);
+#else
                                   invitation_handle);
+#endif
 }
 
 MojoResult MojoSetQuotaImpl(MojoHandle handle,

--- a/mojo/core/node_controller.h
+++ b/mojo/core/node_controller.h
@@ -81,10 +81,18 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
       base::ProcessHandle target_process,
       ConnectionParams connection_params,
       const std::vector<std::pair<std::string, ports::PortRef>>& attached_ports,
+#if defined(CASTANETS)
+      const ProcessErrorCallback& process_error_callback, std::string="");
+#else
       const ProcessErrorCallback& process_error_callback);
+#endif
 
   // Connects this node to the process which invited it to be a broker client.
+#if defined(CASTANETS)
+  void AcceptBrokerClientInvitation(ConnectionParams connection_params, std::string type);
+#else
   void AcceptBrokerClientInvitation(ConnectionParams connection_params);
+#endif
 
   // Connects this node to a peer node. On success, |port| will be merged with
   // the corresponding port in the peer node.
@@ -160,7 +168,11 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
       ScopedProcessHandle target_process,
       ConnectionParams connection_params,
       ports::NodeName token,
+#if defined(CASTANETS)
+      const ProcessErrorCallback& process_error_callback,std::string="");
+#else
       const ProcessErrorCallback& process_error_callback);
+#endif
   void AcceptBrokerClientInvitationOnIOThread(
       ConnectionParams connection_params);
 

--- a/mojo/public/c/system/invitation.h
+++ b/mojo/public/c/system/invitation.h
@@ -12,6 +12,10 @@
 
 #include <stdint.h>
 
+#if defined(CASTANETS)
+#include <iostream>
+#endif
+
 #include "mojo/public/c/system/macros.h"
 #include "mojo/public/c/system/platform_handle.h"
 #include "mojo/public/c/system/system_export.h"
@@ -410,7 +414,11 @@ MOJO_SYSTEM_EXPORT MojoResult MojoSendInvitation(
     const struct MojoInvitationTransportEndpoint* transport_endpoint,
     MojoProcessErrorHandler error_handler,
     uintptr_t error_handler_context,
+#if defined(CASTANETS)
+    const struct MojoSendInvitationOptions* options, std::string type="");
+#else
     const struct MojoSendInvitationOptions* options);
+#endif
 
 // Accepts an invitation from a transport endpoint to complete IPC bootstrapping
 // between the calling process and whoever sent the invitation from the other
@@ -447,7 +455,11 @@ MOJO_SYSTEM_EXPORT MojoResult MojoSendInvitation(
 MOJO_SYSTEM_EXPORT MojoResult MojoAcceptInvitation(
     const struct MojoInvitationTransportEndpoint* transport_endpoint,
     const struct MojoAcceptInvitationOptions* options,
+#if defined(CASTANETS)
+    MojoHandle* invitation_handle, std::string type);
+#else
     MojoHandle* invitation_handle);
+#endif
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/mojo/public/c/system/platform_handle.h
+++ b/mojo/public/c/system/platform_handle.h
@@ -22,6 +22,10 @@ extern "C" {
 // The type of handle value contained in a |MojoPlatformHandle| structure.
 typedef uint32_t MojoPlatformHandleType;
 
+#if defined(CASTANETS)
+const int kCastanetsHandle = 0;
+#endif
+
 // An invalid handle value. Other contents of the |MojoPlatformHandle| are
 // ignored.
 #define MOJO_PLATFORM_HANDLE_TYPE_INVALID ((MojoPlatformHandleType)0)
@@ -266,6 +270,9 @@ MOJO_SYSTEM_EXPORT MojoResult MojoWrapPlatformSharedMemoryRegion(
     uint32_t num_platform_handles,
     uint64_t num_bytes,
     const struct MojoSharedBufferGuid* guid,
+#if defined(CASTANETS)
+    int sid,
+#endif
     MojoPlatformSharedMemoryRegionAccessMode access_mode,
     const struct MojoWrapPlatformSharedMemoryRegionOptions* options,
     MojoHandle* mojo_handle);

--- a/mojo/public/c/system/thunks.cc
+++ b/mojo/public/c/system/thunks.cc
@@ -387,11 +387,18 @@ MojoResult MojoWrapPlatformSharedMemoryRegion(
     uint32_t num_platform_handles,
     uint64_t num_bytes,
     const MojoSharedBufferGuid* guid,
+#if defined(CASTANETS)
+    int sid,
+#endif
     MojoPlatformSharedMemoryRegionAccessMode access_mode,
     const MojoWrapPlatformSharedMemoryRegionOptions* options,
     MojoHandle* mojo_handle) {
   return INVOKE_THUNK(WrapPlatformSharedMemoryRegion, platform_handles,
+#if defined(CASTANETS)
+                      num_platform_handles, num_bytes, guid, sid, access_mode,
+#else
                       num_platform_handles, num_bytes, guid, access_mode,
+#endif
                       options, mojo_handle);
 }
 
@@ -439,18 +446,34 @@ MojoResult MojoSendInvitation(
     const MojoInvitationTransportEndpoint* transport_endpoint,
     MojoProcessErrorHandler error_handler,
     uintptr_t error_handler_context,
+#if defined(CASTANETS)
+    const MojoSendInvitationOptions* options, std::string process_type) {
+#else
     const MojoSendInvitationOptions* options) {
+#endif
   return INVOKE_THUNK(SendInvitation, invitation_handle, process_handle,
                       transport_endpoint, error_handler, error_handler_context,
+#if defined(CASTANETS)
+                      options, process_type);
+#else
                       options);
+#endif
 }
 
 MojoResult MojoAcceptInvitation(
     const MojoInvitationTransportEndpoint* transport_endpoint,
     const MojoAcceptInvitationOptions* options,
+#if defined(CASTANETS)
+    MojoHandle* invitation_handle, std::string type) {
+#else
     MojoHandle* invitation_handle) {
+#endif
   return INVOKE_THUNK(AcceptInvitation, transport_endpoint, options,
+#if defined(CASTANETS)
+                      invitation_handle, type);
+#else
                       invitation_handle);
+#endif
 }
 
 MojoResult MojoSetQuota(MojoHandle handle,

--- a/mojo/public/c/system/thunks.h
+++ b/mojo/public/c/system/thunks.h
@@ -173,6 +173,9 @@ struct MojoSystemThunks {
       uint32_t num_platform_handles,
       uint64_t num_bytes,
       const struct MojoSharedBufferGuid* guid,
+#if defined(CASTANETS)
+      int sid,
+#endif
       MojoPlatformSharedMemoryRegionAccessMode access_mode,
       const struct MojoWrapPlatformSharedMemoryRegionOptions* options,
       MojoHandle* mojo_handle);
@@ -207,11 +210,19 @@ struct MojoSystemThunks {
       const struct MojoInvitationTransportEndpoint* transport_endpoint,
       MojoProcessErrorHandler error_handler,
       uintptr_t error_handler_context,
+#if defined(CASTANETS)
+      const struct MojoSendInvitationOptions* options, std::string process_type);
+#else
       const struct MojoSendInvitationOptions* options);
+#endif
   MojoResult (*AcceptInvitation)(
       const struct MojoInvitationTransportEndpoint* transport_endpoint,
       const struct MojoAcceptInvitationOptions* options,
+#if defined(CASTANETS)
+      MojoHandle* invitation_handle, std::string type);
+#else
       MojoHandle* invitation_handle);
+#endif
   MojoResult (*SetQuota)(MojoHandle handle,
                          MojoQuotaType type,
                          uint64_t limit,

--- a/mojo/public/cpp/platform/BUILD.gn
+++ b/mojo/public/cpp/platform/BUILD.gn
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//build/config/features.gni")
 import("//build/config/nacl/config.gni")
 
 component("platform") {
@@ -33,6 +34,12 @@ component("platform") {
     "//base",
     "//mojo/public/c/system:headers",
   ]
+
+  if(enable_castanets) {
+    public += [ "tcp_platform_handle_utils.h" ]
+    sources += [ "tcp_platform_handle_utils_posix.cc" ]
+    public_deps += [ "//base:base_static" ]
+  }
 
   if (is_posix && (!is_nacl && !is_fuchsia)) {
     sources += [ "named_platform_channel_posix.cc" ]

--- a/mojo/public/cpp/platform/named_platform_channel.cc
+++ b/mojo/public/cpp/platform/named_platform_channel.cc
@@ -20,6 +20,10 @@ NamedPlatformChannel::NamedPlatformChannel(const Options& options) {
 NamedPlatformChannel::NamedPlatformChannel(NamedPlatformChannel&& other) =
     default;
 
+#if defined(CASTANETS)
+NamedPlatformChannel::NamedPlatformChannel() = default;
+#endif
+
 NamedPlatformChannel::~NamedPlatformChannel() = default;
 
 NamedPlatformChannel& NamedPlatformChannel::operator=(

--- a/mojo/public/cpp/platform/named_platform_channel.h
+++ b/mojo/public/cpp/platform/named_platform_channel.h
@@ -64,6 +64,9 @@ class COMPONENT_EXPORT(MOJO_CPP_PLATFORM) NamedPlatformChannel {
   };
 
   NamedPlatformChannel(const Options& options);
+#if defined(CASTANETS)
+  NamedPlatformChannel();
+#endif
   NamedPlatformChannel(NamedPlatformChannel&& other);
   ~NamedPlatformChannel();
 
@@ -85,6 +88,12 @@ class COMPONENT_EXPORT(MOJO_CPP_PLATFORM) NamedPlatformChannel {
   PlatformChannelServerEndpoint TakeServerEndpoint() WARN_UNUSED_RESULT {
     return std::move(server_endpoint_);
   }
+
+#if defined(CASTANETS)
+  void SetServerEndpoint(PlatformChannelServerEndpoint end_point) {
+    server_endpoint_ = std::move(end_point);
+  }
+#endif
 
   // Returns a name that can be used a remote process to connect to the server
   // endpoint.

--- a/mojo/public/cpp/platform/socket_utils_posix.cc
+++ b/mojo/public/cpp/platform/socket_utils_posix.cc
@@ -109,6 +109,11 @@ ssize_t SendmsgWithHandles(base::PlatformFile socket,
   DCHECK(!descriptors.empty());
   DCHECK_LE(descriptors.size(), kMaxSendmsgHandles);
 
+#if defined(CASTANETS)
+  struct msghdr msg = {};
+  msg.msg_iov = iov;
+  msg.msg_iovlen = num_iov;
+#else
   char cmsg_buf[CMSG_SPACE(kMaxSendmsgHandles * sizeof(int))];
   struct msghdr msg = {};
   msg.msg_iov = iov;
@@ -123,6 +128,7 @@ ssize_t SendmsgWithHandles(base::PlatformFile socket,
     DCHECK_GE(descriptors[i].get(), 0);
     reinterpret_cast<int*>(CMSG_DATA(cmsg))[i] = descriptors[i].get();
   }
+#endif
   return HANDLE_EINTR(sendmsg(socket, &msg, kSendmsgFlags));
 }
 
@@ -131,6 +137,17 @@ ssize_t SocketRecvmsg(base::PlatformFile socket,
                       size_t num_bytes,
                       std::vector<base::ScopedFD>* descriptors,
                       bool block) {
+#if defined(CASTANETS)
+  struct iovec iov = {buf, num_bytes};
+  struct msghdr msg = {};
+  msg.msg_iov = &iov;
+  msg.msg_iovlen = 1;
+
+  ssize_t result =
+      HANDLE_EINTR(recvmsg(socket, &msg, block ? 0 : MSG_DONTWAIT));
+  if (result < 0)
+    return result;
+#else
   struct iovec iov = {buf, num_bytes};
   char cmsg_buf[CMSG_SPACE(kMaxSendmsgHandles * sizeof(int))];
   struct msghdr msg = {};
@@ -163,6 +180,7 @@ ssize_t SocketRecvmsg(base::PlatformFile socket,
       }
     }
   }
+#endif
 
   return result;
 }

--- a/mojo/public/cpp/platform/tcp_platform_handle_utils.h
+++ b/mojo/public/cpp/platform/tcp_platform_handle_utils.h
@@ -1,0 +1,46 @@
+// Copyright 2017 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MOJO_EDK_EMBEDDER_TCP_PLATFORM_HANDLE_UTILS_H_
+#define MOJO_EDK_EMBEDDER_TCP_PLATFORM_HANDLE_UTILS_H_
+
+#include "build/build_config.h"
+#include "mojo/core/system_impl_export.h"
+#include "base/component_export.h"
+
+#include "base/files/platform_file.h"
+#include "base/files/scoped_file.h"
+
+#if defined(OS_WIN)
+#include "base/strings/string16.h"
+#endif
+
+namespace mojo {
+
+const size_t kCastanetsSyncPort = 8008;
+const size_t kCastanetsBrokerPort = 9009;
+const size_t kCastanetsUtilitySyncPort = 7007;
+const size_t kCastanetsUtilityBrokerPort = 6006;
+const size_t kCastanetsNonBrokerPort = 5005;
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+base::ScopedFD
+CreateTCPClientHandle(size_t port);
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+base::ScopedFD
+CreateTCPServerHandle(size_t port);
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+base::ScopedFD
+CreateTCPDummyHandle();
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+bool TCPServerAcceptConnection(
+        base::PlatformFile server_fd,
+        base::ScopedFD* connection_fd);
+
+}  // namespace mojo
+
+#endif  // MOJO_EDK_EMBEDDER_TCP_PLATFORM_HANDLE_UTILS_H_

--- a/mojo/public/cpp/platform/tcp_platform_handle_utils_posix.cc
+++ b/mojo/public/cpp/platform/tcp_platform_handle_utils_posix.cc
@@ -1,0 +1,169 @@
+// Copyright 2017 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tcp_platform_handle_utils.h"
+
+#include <errno.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+
+
+#include "base/base_switches.h"
+#include "base/command_line.h"
+#include "base/files/file_util.h"
+#include "base/logging.h"
+#include "base/posix/eintr_wrapper.h"
+#include "mojo/public/c/system/platform_handle.h"
+
+#include "base/debug/stack_trace.h"
+#include <unistd.h>
+#include <fcntl.h>
+ 
+namespace mojo {
+namespace {
+
+
+base::ScopedFD CreateTCPSocket(bool needs_connection, int protocol) {
+  // Create the inet socket.
+  // FIXME:Do a dummy open to avoid allocating 0 to sock fd
+  int dummy_fd = open("/tmp/tmp", O_WRONLY);
+  if (dummy_fd) {}
+  base::PlatformFile socket_handle(socket(AF_INET, SOCK_STREAM, protocol));
+  base::ScopedFD handle(socket_handle);
+  if (handle.get() < 0) {
+    PLOG(ERROR) << "Failed to create AF_INET socket.";
+    return base::ScopedFD();
+  }
+
+  // Now set it as non-blocking.
+  if (false && !base::SetNonBlocking(handle.get())) {
+    PLOG(ERROR) << "base::SetNonBlocking() failed " << handle.get();
+    return base::ScopedFD();
+  }
+  return handle;
+}
+
+}  // namespace
+
+int
+connect_retry(int sockfd, const struct sockaddr *addr, socklen_t alen)
+{
+    int nsec;
+    for (nsec = 1; nsec <= 128; nsec <<= 1) {
+        if (connect(sockfd, addr, alen) == 0) {
+            return(0);
+        }
+        if (nsec <= 128/2)
+            sleep(nsec);
+    }
+    return(-1);
+}
+
+base::ScopedFD CreateTCPClientHandle(size_t port) {
+  std::string server_address = "127.0.0.1";
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  if (command_line->HasSwitch(switches::kServerAddress))
+    server_address = command_line->GetSwitchValueASCII(switches::kServerAddress);
+  struct sockaddr_in unix_addr;
+  size_t unix_addr_len;
+  memset(&unix_addr, 0, sizeof(struct sockaddr_in));
+  unix_addr.sin_family = AF_INET;
+  unix_addr.sin_port = htons(port);
+#ifdef OS_ANDROID
+  unix_addr.sin_addr.s_addr = inet_addr("192.168.0.118");
+#else
+  unix_addr.sin_addr.s_addr = inet_addr(server_address.c_str());
+#endif
+  if (port == 5005)
+    unix_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+  unix_addr_len = sizeof(struct sockaddr_in);
+
+  base::ScopedFD handle = CreateTCPSocket(false, IPPROTO_TCP);
+  printf("%s %s %d port %d handle %d \n",__FILE__,__func__,__LINE__, (int)port, handle.get());
+  if (handle.get() < 0)
+    return base::ScopedFD();
+  if (HANDLE_EINTR(connect_retry(handle.get(),
+      reinterpret_cast<sockaddr*>(&unix_addr), unix_addr_len)) < 0) {
+    PLOG(ERROR) << "connect " << handle.get();
+    return base::ScopedFD();
+  }
+  return handle;
+}
+
+base::ScopedFD CreateTCPServerHandle(size_t port) {
+  struct sockaddr_in unix_addr;
+  size_t unix_addr_len;
+  memset(&unix_addr, 0, sizeof(struct sockaddr_in));
+  unix_addr.sin_family = AF_INET;
+  unix_addr.sin_port = htons(port);
+  unix_addr.sin_addr.s_addr = INADDR_ANY;
+  unix_addr_len = sizeof(struct sockaddr_in);
+
+  base::ScopedFD handle = CreateTCPSocket(true, 0);
+  if (!handle.get())
+    return base::ScopedFD();
+
+  static const int kOn = 1;
+#ifdef OS_ANDROID
+  setsockopt(handle.get(), SOL_SOCKET, 15, &kOn, sizeof(kOn));
+#else
+  setsockopt(handle.get(), SOL_SOCKET, SO_REUSEPORT, &kOn, sizeof(kOn));
+#endif
+
+  // Bind the socket.
+  if (bind(handle.get(), reinterpret_cast<const sockaddr*>(&unix_addr),
+           unix_addr_len) < 0) {
+    PLOG(ERROR) << "bind " << handle.get();
+    return base::ScopedFD();
+  }
+
+  // Start listening on the socket.
+  if (listen(handle.get(), SOMAXCONN) < 0) {
+    PLOG(ERROR) << "listen" << handle.get();
+    return base::ScopedFD();
+  }
+  printf("%s %s %d port %d handle %d \n",__FILE__,__func__,__LINE__, (int)port, handle.get());
+  return handle;
+}
+
+base::ScopedFD CreateTCPDummyHandle() {
+  base::PlatformFile handle(std::move(kCastanetsHandle));
+  //handle.type = PlatformHandle::Type::POSIX_CHROMIE;
+  return base::ScopedFD(handle);
+}
+
+bool TCPServerAcceptConnection(base::PlatformFile server_handle,
+                               base::ScopedFD* connection_handle) {
+  DCHECK(server_handle);
+  connection_handle->reset();
+#if defined(OS_NACL)
+  NOTREACHED();
+  return false;
+#else
+  // FIXME:Do a dummy open to avoid allocating 0 to sock fd
+  int dummy_fd = open("/tmp/tmp", O_WRONLY);
+  if (dummy_fd) {}
+  int accept_fd = accept(server_handle, NULL, 0);
+  base::ScopedFD accept_handle(
+      base::PlatformFile(HANDLE_EINTR(accept_fd)));
+  if (!accept_handle.is_valid()) {
+    PLOG(ERROR) << "accept" << server_handle;
+    return false;
+  }
+
+  //printf("%s %s %d serverhandle %d accept handle %d \n",__FILE__,__func__,__LINE__, server_handle, accept_handle.get());
+  if (false && !base::SetNonBlocking(accept_handle.get())) {
+    PLOG(ERROR) << "base::SetNonBlocking() failed "
+                << accept_handle.get();
+    // It's safe to keep listening on |server_handle| even if the attempt to set
+    // O_NONBLOCK failed on the client fd.
+    return true;
+  }
+
+  *connection_handle = std::move(accept_handle);
+  return true;
+#endif  // defined(OS_NACL)
+}
+
+}  // namespace mojo

--- a/mojo/public/cpp/system/invitation.cc
+++ b/mojo/public/cpp/system/invitation.cc
@@ -59,7 +59,11 @@ void SendInvitation(ScopedInvitationHandle invitation,
                     MojoInvitationTransportType transport_type,
                     MojoSendInvitationFlags flags,
                     const ProcessErrorCallback& error_callback,
+#if defined(CASTANETS)
+                    base::StringPiece isolated_connection_name, std::string process_type="") {
+#else
                     base::StringPiece isolated_connection_name) {
+#endif
   MojoPlatformProcessHandle process_handle;
   ProcessHandleToMojoProcessHandle(target_process, &process_handle);
 
@@ -91,7 +95,11 @@ void SendInvitation(ScopedInvitationHandle invitation,
   }
   MojoResult result =
       MojoSendInvitation(invitation.get().value(), &process_handle, &endpoint,
+#if defined(CASTANETS)
+                         error_handler, error_handler_context, &options, process_type);
+#else
                          error_handler, error_handler_context, &options);
+#endif
   // If successful, the invitation handle is already closed for us.
   if (result == MOJO_RESULT_OK)
     ignore_result(invitation.release());
@@ -163,11 +171,19 @@ void OutgoingInvitation::Send(OutgoingInvitation invitation,
 void OutgoingInvitation::Send(OutgoingInvitation invitation,
                               base::ProcessHandle target_process,
                               PlatformChannelServerEndpoint server_endpoint,
+#if defined(CASTANETS)
+                              const ProcessErrorCallback& error_callback, std::string type) {
+#else
                               const ProcessErrorCallback& error_callback) {
+#endif
   SendInvitation(std::move(invitation.handle_), target_process,
                  server_endpoint.TakePlatformHandle(),
                  MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER,
+#if defined(CASTANETS)
+                 MOJO_SEND_INVITATION_FLAG_NONE, error_callback, "", type);
+#else
                  MOJO_SEND_INVITATION_FLAG_NONE, error_callback, "");
+#endif
 }
 
 // static
@@ -204,8 +220,15 @@ IncomingInvitation::IncomingInvitation() = default;
 
 IncomingInvitation::IncomingInvitation(IncomingInvitation&& other) = default;
 
+#if defined(CASTANETS)
+IncomingInvitation::IncomingInvitation(ScopedInvitationHandle handle, std::string type)
+    : handle_(std::move(handle)) {
+  type_=type;
+}
+#else
 IncomingInvitation::IncomingInvitation(ScopedInvitationHandle handle)
     : handle_(std::move(handle)) {}
+#endif
 
 IncomingInvitation::~IncomingInvitation() = default;
 
@@ -214,7 +237,11 @@ IncomingInvitation& IncomingInvitation::operator=(IncomingInvitation&& other) =
 
 // static
 IncomingInvitation IncomingInvitation::Accept(
+#if defined(CASTANETS)
+    PlatformChannelEndpoint channel_endpoint, std::string type) {
+#else
     PlatformChannelEndpoint channel_endpoint) {
+#endif
   MojoPlatformHandle endpoint_handle;
   PlatformHandle::ToMojoPlatformHandle(channel_endpoint.TakePlatformHandle(),
                                        &endpoint_handle);
@@ -228,12 +255,20 @@ IncomingInvitation IncomingInvitation::Accept(
 
   MojoHandle invitation_handle;
   MojoResult result =
+#if defined(CASTANETS)
+      MojoAcceptInvitation(&transport_endpoint, nullptr, &invitation_handle, type);
+#else
       MojoAcceptInvitation(&transport_endpoint, nullptr, &invitation_handle);
+#endif
   if (result != MOJO_RESULT_OK)
     return IncomingInvitation();
 
   return IncomingInvitation(
+#if defined(CASTANETS)
+      ScopedInvitationHandle(InvitationHandle(invitation_handle)),type);
+#else
       ScopedInvitationHandle(InvitationHandle(invitation_handle)));
+#endif
 }
 
 // static
@@ -256,12 +291,20 @@ ScopedMessagePipeHandle IncomingInvitation::AcceptIsolated(
 
   MojoHandle invitation_handle;
   MojoResult result =
+#if defined(CASTANETS)
+      MojoAcceptInvitation(&transport_endpoint, &options, &invitation_handle, "null");
+#else
       MojoAcceptInvitation(&transport_endpoint, &options, &invitation_handle);
+#endif
   if (result != MOJO_RESULT_OK)
     return ScopedMessagePipeHandle();
 
   IncomingInvitation invitation{
+#if defined(CASTANETS)
+      ScopedInvitationHandle(InvitationHandle(invitation_handle)),"null"};
+#else
       ScopedInvitationHandle(InvitationHandle(invitation_handle))};
+#endif
   return invitation.ExtractMessagePipe(kIsolatedPipeName);
 }
 

--- a/mojo/public/cpp/system/invitation.h
+++ b/mojo/public/cpp/system/invitation.h
@@ -97,7 +97,11 @@ class MOJO_CPP_SYSTEM_EXPORT OutgoingInvitation {
   static void Send(OutgoingInvitation invitation,
                    base::ProcessHandle target_process,
                    PlatformChannelServerEndpoint server_endpoint,
+#if defined(CASTANETS)
+                   const ProcessErrorCallback& error_callback = {}, std::string="");
+#else
                    const ProcessErrorCallback& error_callback = {});
+#endif
 
   // Sends an isolated invitation over |endpoint|. The process at the other
   // endpoint must use |IncomingInvitation::AcceptIsolated()| to accept the
@@ -150,7 +154,11 @@ class MOJO_CPP_SYSTEM_EXPORT IncomingInvitation {
  public:
   IncomingInvitation();
   IncomingInvitation(IncomingInvitation&& other);
+#if defined(CASTANETS)
+  explicit IncomingInvitation(ScopedInvitationHandle handle, std::string type);
+#else
   explicit IncomingInvitation(ScopedInvitationHandle handle);
+#endif
   ~IncomingInvitation();
 
   IncomingInvitation& operator=(IncomingInvitation&& other);
@@ -160,7 +168,11 @@ class MOJO_CPP_SYSTEM_EXPORT IncomingInvitation {
   // the other end of that channel. If the invitation was sent using a
   // |PlatformChannelServerEndpoint|, then |channel_endpoint| should be created
   // by |NamedPlatformChannel::ConnectToServer|.
+#if defined(CASTANETS)
+  static IncomingInvitation Accept(PlatformChannelEndpoint channel_endpoint, std::string type);
+#else
   static IncomingInvitation Accept(PlatformChannelEndpoint channel_endpoint);
+#endif
 
   // Accepts an incoming isolated invitation from |channel_endpoint|. See
   // notes on |OutgoingInvitation::SendIsolated()|.
@@ -177,6 +189,9 @@ class MOJO_CPP_SYSTEM_EXPORT IncomingInvitation {
 
  private:
   ScopedInvitationHandle handle_;
+#if defined(CASTANETS)
+  std::string type_;
+#endif
 
   DISALLOW_COPY_AND_ASSIGN(IncomingInvitation);
 };

--- a/mojo/public/cpp/system/platform_handle.cc
+++ b/mojo/public/cpp/system/platform_handle.cc
@@ -89,7 +89,11 @@ ScopedSharedBufferHandle WrapPlatformSharedMemoryRegion(
                                     guid.GetLowForSerialization()};
   MojoHandle mojo_handle;
   MojoResult result = MojoWrapPlatformSharedMemoryRegion(
+#if defined(CASTANETS)
+      platform_handles, num_platform_handles, region.GetSize(), &mojo_guid, region.GetMemoryFileId(),
+#else
       platform_handles, num_platform_handles, region.GetSize(), &mojo_guid,
+#endif
       access_mode, nullptr, &mojo_handle);
   if (result != MOJO_RESULT_OK)
     return ScopedSharedBufferHandle();
@@ -274,7 +278,11 @@ ScopedSharedBufferHandle WrapSharedMemoryHandle(
   guid.low = memory_handle.GetGUID().GetLowForSerialization();
   MojoHandle mojo_handle;
   MojoResult result = MojoWrapPlatformSharedMemoryRegion(
+#if defined(CASTANETS)
+      &platform_handle, 1, size, &guid, memory_handle.GetMemoryFileId(), access_mode, nullptr, &mojo_handle);
+#else
       &platform_handle, 1, size, &guid, access_mode, nullptr, &mojo_handle);
+#endif
   CHECK_EQ(result, MOJO_RESULT_OK);
 
   return ScopedSharedBufferHandle(SharedBufferHandle(mojo_handle));

--- a/services/network/public/cpp/features.cc
+++ b/services/network/public/cpp/features.cc
@@ -16,7 +16,11 @@ const base::Feature kNetworkErrorLogging{"NetworkErrorLogging",
                                          base::FEATURE_DISABLED_BY_DEFAULT};
 // Enables the network service.
 const base::Feature kNetworkService{"NetworkService",
+#if defined(CASTANETS)
+                                    base::FEATURE_ENABLED_BY_DEFAULT};
+#else
                                     base::FEATURE_DISABLED_BY_DEFAULT};
+#endif
 
 // Out of Blink CORS
 const base::Feature kOutOfBlinkCORS{"OutOfBlinkCORS",

--- a/services/service_manager/public/cpp/standalone_service/standalone_service.cc
+++ b/services/service_manager/public/cpp/standalone_service/standalone_service.cc
@@ -77,7 +77,11 @@ void RunStandaloneService(const StandaloneServiceCallback& callback) {
 
   auto invitation = mojo::IncomingInvitation::Accept(
       mojo::PlatformChannel::RecoverPassedEndpointFromCommandLine(
+#if defined(CASTANETS)
+          command_line),"null");
+#else
           command_line));
+#endif
   callback.Run(GetServiceRequestFromCommandLine(&invitation));
 }
 

--- a/services/ui/ws/compositor_frame_sink_client_binding.cc
+++ b/services/ui/ws/compositor_frame_sink_client_binding.cc
@@ -55,6 +55,15 @@ void CompositorFrameSinkClientBinding::DidAllocateSharedBitmap(
   compositor_frame_sink_->DidAllocateSharedBitmap(std::move(buffer), id);
 }
 
+void CompositorFrameSinkClientBinding::DidRasterizeSharedBitmap(
+    int32_t size, const std::vector<uint8_t>& pixels_vec, const viz::SharedBitmapId &id) {
+#if defined(CASTANETS)
+  compositor_frame_sink_->DidRasterizeSharedBitmap(size, pixels_vec, id);
+#else
+  NOTIMPLEMENTED();
+#endif
+}
+
 void CompositorFrameSinkClientBinding::DidDeleteSharedBitmap(
     const viz::SharedBitmapId& id) {
   compositor_frame_sink_->DidDeleteSharedBitmap(id);

--- a/services/ui/ws/compositor_frame_sink_client_binding.h
+++ b/services/ui/ws/compositor_frame_sink_client_binding.h
@@ -45,6 +45,8 @@ class CompositorFrameSinkClientBinding
   void DidAllocateSharedBitmap(mojo::ScopedSharedBufferHandle buffer,
                                const viz::SharedBitmapId& id) override;
   void DidDeleteSharedBitmap(const viz::SharedBitmapId& id) override;
+  void DidRasterizeSharedBitmap(int32_t size, const std::vector<uint8_t>& pixels_vec,
+                                const viz::SharedBitmapId &id) override;
 
   mojo::Binding<viz::mojom::CompositorFrameSinkClient> binding_;
   viz::mojom::CompositorFrameSinkAssociatedPtr compositor_frame_sink_;

--- a/services/viz/public/interfaces/compositing/compositor_frame_sink.mojom
+++ b/services/viz/public/interfaces/compositing/compositor_frame_sink.mojom
@@ -66,7 +66,7 @@ interface CompositorFrameSink {
   // SubmitCompositorFrame. The |id| is a Mailbox type which doubles as a
   // SharedBitmapId for this case.
   DidAllocateSharedBitmap(handle<shared_buffer> buffer, gpu.mojom.Mailbox id);
-
+  DidRasterizeSharedBitmap(int32 size, array<uint8> pixels_vec, gpu.mojom.Mailbox id);
   // Informs the display compositor that the client deleted a shared bitmap. This
   // allows the service to free the shared memory that was previously given to it
   // via DidAllocateSharedBitmap(). The |id| is a Mailbox type which doubles as a

--- a/third_party/blink/renderer/platform/fonts/skia/font_cache_skia.cc
+++ b/third_party/blink/renderer/platform/fonts/skia/font_cache_skia.cc
@@ -218,10 +218,14 @@ PaintTypeface FontCache::CreateTypeface(
   // TODO(fuchsia): Revisit this and other font code for Fuchsia.
 
   if (creation_params.CreationType() == kCreateFontByFciIdAndTtcIndex) {
+#if !defined(CASTANETS)
+    // fontconfigInterfaceId() of browser will not be known by renderer in
+    // distributed chromium scenario. So lets go by filename.
     if (Platform::Current()->GetSandboxSupport()) {
       return PaintTypeface::FromFontConfigInterfaceIdAndTtcIndex(
           creation_params.FontconfigInterfaceId(), creation_params.TtcIndex());
     }
+#endif
     return PaintTypeface::FromFilenameAndTtcIndex(
         creation_params.Filename().data(), creation_params.TtcIndex());
   }

--- a/third_party/blink/renderer/platform/graphics/video_frame_submitter.cc
+++ b/third_party/blink/renderer/platform/graphics/video_frame_submitter.cc
@@ -388,6 +388,13 @@ void VideoFrameSubmitter::DidAllocateSharedBitmap(
       std::move(buffer), SharedBitmapIdToGpuMailboxPtr(id));
 }
 
+#if defined(CASTANETS)
+void VideoFrameSubmitter::DidRasterizeSharedBitmap(
+    int32_t size, const std::vector<uint8_t>& pixels_vec, const viz::SharedBitmapId &id) {
+  NOTIMPLEMENTED();
+}
+#endif
+
 void VideoFrameSubmitter::DidDeleteSharedBitmap(const viz::SharedBitmapId& id) {
   DCHECK(compositor_frame_sink_);
   compositor_frame_sink_->DidDeleteSharedBitmap(

--- a/third_party/blink/renderer/platform/graphics/video_frame_submitter.h
+++ b/third_party/blink/renderer/platform/graphics/video_frame_submitter.h
@@ -84,6 +84,11 @@ class PLATFORM_EXPORT VideoFrameSubmitter
   void DidAllocateSharedBitmap(mojo::ScopedSharedBufferHandle,
                                const viz::SharedBitmapId&) override;
   void DidDeleteSharedBitmap(const viz::SharedBitmapId&) override;
+#if defined(CASTANETS)
+  void DidRasterizeSharedBitmap(int32_t size, const std::vector<uint8_t>& pixels_vec,
+                                const viz::SharedBitmapId &id) override;
+#endif
+
 
   void SetCompositorFrameSinkPtrForTesting(
       viz::mojom::blink::CompositorFrameSinkPtr* sink) {

--- a/ui/aura/local/layer_tree_frame_sink_local.cc
+++ b/ui/aura/local/layer_tree_frame_sink_local.cc
@@ -98,6 +98,13 @@ void LayerTreeFrameSinkLocal::DidAllocateSharedBitmap(
   NOTIMPLEMENTED();
 }
 
+#if defined(CASTANETS)
+void LayerTreeFrameSinkLocal::DidRasterizeSharedBitmap(
+    int32_t size, const std::vector<uint8_t>& pixels_vec, const viz::SharedBitmapId &id) {
+  NOTIMPLEMENTED();
+}
+#endif
+
 void LayerTreeFrameSinkLocal::DidDeleteSharedBitmap(
     const viz::SharedBitmapId& id) {
   // No software compositing used with this implementation.

--- a/ui/aura/local/layer_tree_frame_sink_local.h
+++ b/ui/aura/local/layer_tree_frame_sink_local.h
@@ -55,6 +55,11 @@ class LayerTreeFrameSinkLocal : public cc::LayerTreeFrameSink,
   void DidAllocateSharedBitmap(mojo::ScopedSharedBufferHandle buffer,
                                const viz::SharedBitmapId& id) override;
   void DidDeleteSharedBitmap(const viz::SharedBitmapId& id) override;
+#if defined(CASTANETS)
+  void DidRasterizeSharedBitmap(int32_t size, const std::vector<uint8_t>& pixels_vec,
+                                const viz::SharedBitmapId &id) override;
+#endif
+
 
   // viz::mojom::CompositorFrameSinkClient:
   void DidReceiveCompositorFrameAck(


### PR DESCRIPTION
1. Channel, broker connections are adapted as per M69 changes.
2. Changes related to Font Config IPC, fallback fonts are adapted to
font service.
3. Network Service is considered default for castanets 69, it is enabled
alongside renderer process. File based shared memory is used between
network service and renderer in same device.
4. Tile data is shared via bytestream.

Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>