### PR TITLE
[Service Discovery] Separate main function from server/client runner

### DIFF
--- a/service_discovery_manager/Build/Makefile
+++ b/service_discovery_manager/Build/Makefile
@@ -70,13 +70,13 @@ mmclient:
 
 ntserver:
 	@echo "-------------------------------------------"
-	@echo "|  Clean MODULE [ NT SERVER]              |"
+	@echo "|  Build MODULE [ NT SERVER]              |"
 	@echo "-------------------------------------------"
 	$(MAKE) -e TARGET_NOW=$@ -f Makefile.NTSERVER
 
 ntclient:
 	@echo "-------------------------------------------"
-	@echo "|  Clean MODULE [ MT CLIENT]              |"
+	@echo "|  Build MODULE [ MT CLIENT]              |"
 	@echo "-------------------------------------------"
 	$(MAKE) -e TARGET_NOW=$@ -f Makefile.NTCLIENT
 

--- a/service_discovery_manager/Build/Makefile.CLIENT
+++ b/service_discovery_manager/Build/Makefile.CLIENT
@@ -25,7 +25,7 @@ EXEC_NAME      = client_runner
 LIB_NAME       =
 C_NAME         =
 
-CPP_NAME       = client_runner
+CPP_NAME       = client_runner client_main
 
 INI_NAME       = client
 

--- a/service_discovery_manager/Build/Makefile.SERVER
+++ b/service_discovery_manager/Build/Makefile.SERVER
@@ -25,7 +25,7 @@ EXEC_NAME      = server_runner
 LIB_NAME       =
 C_NAME         =
 
-CPP_NAME       = server_runner
+CPP_NAME       = server_runner server_main
 
 INI_NAME       = server
 

--- a/service_discovery_manager/Component/client.ini
+++ b/service_discovery_manager/Component/client.ini
@@ -5,6 +5,4 @@ run-as-damon=false
 address=224.1.1.2
 port=9190
 
-[presence]
-address=1.2.3.4
-port=5000
+

--- a/service_discovery_manager/Component/mmBASE/SubSystem/Debugger.cpp
+++ b/service_discovery_manager/Component/mmBASE/SubSystem/Debugger.cpp
@@ -254,7 +254,7 @@ void SetDebugFormat(DEBUG_FORMAT format) {
   g_fmtDebug = format;
   FILE* fp = fopen(DBG_FORMAT_STREAM, "w");
   if (fp == NULL) {
-    __ASSERT(0);
+    return;
   }
   fprintf(fp, "%d", g_fmtDebug);
   fclose(fp);
@@ -268,7 +268,7 @@ void SetDebugLevel(DEBUG_LEVEL level) {
   g_iDebugLevel = level;
   FILE* fp = fopen(DBG_LEVEL_STREAM, "w");
   if (fp == NULL) {
-    __ASSERT(0);
+    return;
   }
   fprintf(fp, "%d", g_iDebugLevel);
   fclose(fp);
@@ -299,7 +299,7 @@ bool SetModuleDebugFlag(MODULE_ID _id, bool bEnable) {
 
   FILE* fp = fopen(DBG_LEVEL_STREAM, "w");
   if (fp == NULL) {
-    __ASSERT(0);
+    return false;
   }
   fprintf(fp, "%d", g_fDebugModeFlag);
   fclose(fp);

--- a/service_discovery_manager/Component/mmBASE/SubSystem/Debugger.h
+++ b/service_discovery_manager/Component/mmBASE/SubSystem/Debugger.h
@@ -24,6 +24,10 @@
 #include <assert.h>
 #endif
 
+#if defined(ANDROID)
+#include <android/log.h>
+#endif
+
 #include "bDataType.h"
 
 #define DEBUG_STR_MAX 512
@@ -53,7 +57,12 @@ enum MODULE_ID { BLNK = 0, GLOB, COMM, CONN, MODULE_ALL };
 #define DPRINT(prefix, level, str...) \
   dbg_print(__FILE__, __LINE__, prefix, level, ##str)
 #endif
+
+#if defined(ANDROID)
+#define RAW_PRINT(...) __android_log_print(ANDROID_LOG_DEBUG, "NDK_LOG", __VA_ARGS__)
+#else
 #define RAW_PRINT printf
+#endif
 
 
 #ifndef __ASSERT

--- a/service_discovery_manager/Component/mmDiscovery/monitor_server.cpp
+++ b/service_discovery_manager/Component/mmDiscovery/monitor_server.cpp
@@ -39,6 +39,12 @@ using namespace mmProto;
 static unsigned long long last_total_user, last_total_user_low, last_total_sys,
     last_total_idle;
 
+#if defined(ANDROID)
+static inline __u32 ethtool_cmd_speed(const struct ethtool_cmd *ep) {
+  return (ep->speed_hi << 16) | ep->speed;
+}
+#endif
+
 ServerSocket::ServerSocket(MonitorServer* parent)
     : CpTcpServer(), parent_(parent) {}
 

--- a/service_discovery_manager/Component/mmOSAL/daemonAPI.cpp
+++ b/service_discovery_manager/Component/mmOSAL/daemonAPI.cpp
@@ -17,11 +17,7 @@
 #include "daemonAPI.h"
 #include "Debugger.h"
 
-static int running = 0;
-static int pid_fd = -1;
-static char pid_path[256] = { 0 };
-
-#if defined(LINUX)
+#if defined(LINUX) && !defined(ANDROID)
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
@@ -32,6 +28,13 @@ static char pid_path[256] = { 0 };
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#endif
+
+static int running = 0;
+
+#if defined(LINUX) && !defined(ANDROID)
+static int pid_fd = -1;
+static char pid_path[256] = { 0 };
 
 static void handle_signal(int sig) {
   switch (sig) {
@@ -66,8 +69,7 @@ BOOL __OSAL_DaemonAPI_DeInit() {
 }
 
 VOID __OSAL_DaemonAPI_Daemonize(const char* name) {
-
-#if defined(LINUX)
+#if defined(LINUX) && !defined(ANDROID)
   struct rlimit limit;
   unsigned int i;
   sigset_t sigset;

--- a/service_discovery_manager/Component/mmSH/client_main.cpp
+++ b/service_discovery_manager/Component/mmSH/client_main.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Samsung Electronics Co., Ltd
+ *
+ * Licensed under the Flora License, Version 1.1 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bINIParser.h"
+#include "client_runner.h"
+#include "Debugger.h"
+
+#if defined(WIN32)
+#include "spawn_controller.h"
+#endif
+
+#if defined(WIN32)&& defined(RUN_AS_SERVICE)
+int real_main(HANDLE ev_term, int argc, char** argv) {
+#else
+int real_main(int argc, char** argv) {
+#endif
+  ClientRunner::ClientRunnerParams params;
+  mmBase::CbINIParser settings;
+
+  int ret = settings.Parse("server.ini");
+  if (ret == -1)
+    ret = settings.Parse("/usr/bin/server.ini");
+
+  if (ret == 0) {
+    params.multicast_addr = settings.GetAsString("multicast", "address", "");
+    params.multicast_port = settings.GetAsInteger("multicast", "port", -1);
+    params.presence_addr = settings.GetAsString("presence", "address", "");
+    params.presence_port = settings.GetAsInteger("presence", "port", -1);
+    params.with_presence = params.presence_addr.length() > 0 &&
+                           params.presence_port > 0;
+    params.is_daemon = settings.GetAsBoolean("run", "run-as-damon", false);
+  } else {
+    RAW_PRINT("ini parse error(%d)\n", ret);
+    if (argc < 3) {
+      RAW_PRINT("Too Few Argument!!\n");
+      RAW_PRINT("usage : %s mc_addr mc_port <presence> <pr_addr> <pr_port> "
+                "<daemon>\n", argv[0]);
+      RAW_PRINT("comment: mc(multicast),\n");
+      RAW_PRINT("         presence (default is 0. This need to come with "
+                "pr_addr and pr_port once you use it)\n");
+      RAW_PRINT("         daemon (default is 0. You can use it if you want\n");
+      return 0;
+    }
+    params.multicast_addr = std::string(argv[1]);
+    params.multicast_port = atoi(argv[2]);
+    params.is_daemon = (argc == 4 && (strncmp(argv[5], "daemon", 6) == 0)) ||
+                       (argc == 7 && (strncmp(argv[8], "daemon", 6) == 0));
+    params.with_presence = (argc >= 6 && (strncmp(argv[3], "presence", 8) == 0));
+    if (params.with_presence) {
+      params.presence_addr = std::string(argv[4]);
+      params.presence_port = atoi(argv[5]);
+    }
+  }
+
+  auto client_runner = new ClientRunner(params);
+  int exit_code = client_runner->Initialize();
+  if (exit_code > 0)
+    return exit_code;
+
+#if defined(WIN32)&& defined(RUN_AS_SERVICE)
+  exit_code = client_runner->Run(ev_term);
+#else
+  exit_code = client_runner->Run();
+#endif
+
+  return exit_code;
+}
+
+int main(int argc, char** argv) {
+#if defined(WIN32) && defined(RUN_AS_SERVICE)
+  CSpawnController::getInstance().ServiceRegister(real_main);
+  return 0;
+#else
+  return real_main(argc, argv);
+#endif
+}

--- a/service_discovery_manager/Component/mmSH/client_runner.h
+++ b/service_discovery_manager/Component/mmSH/client_runner.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Samsung Electronics Co., Ltd
+ *
+ * Licensed under the Flora License, Version 1.1 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+
+class ClientRunner {
+ public:
+  struct ClientRunnerParams {
+    std::string multicast_addr;
+    int multicast_port;
+    bool with_presence;
+    std::string presence_addr;
+    int presence_port;
+    bool is_daemon;
+  };
+
+  explicit ClientRunner(ClientRunnerParams& params);
+  ~ClientRunner();
+
+  int Initialize();
+#if defined(WIN32)&& defined(RUN_AS_SERVICE)
+  int Run(HANDLE ev_term);
+#else
+  int Run();
+#endif
+
+ private:
+  ClientRunnerParams params_;
+
+  ClientRunner(const ClientRunner&) = delete;
+  ClientRunner& operator=(const ClientRunner&) = delete;
+};

--- a/service_discovery_manager/Component/mmSH/server_main.cpp
+++ b/service_discovery_manager/Component/mmSH/server_main.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 Samsung Electronics Co., Ltd
+ *
+ * Licensed under the Flora License, Version 1.1 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bINIParser.h"
+#include "server_runner.h"
+#include "Debugger.h"
+
+#if defined(WIN32)
+#include "spawn_controller.h"
+#endif
+
+#if defined(WIN32)&& defined(RUN_AS_SERVICE)
+int real_main(HANDLE ev_term, int argc, char** argv) {
+#else
+int real_main(int argc, char** argv) {
+#endif
+  ServerRunner::ServerRunnerParams params;
+  mmBase::CbINIParser settings;
+
+  int ret = settings.Parse("server.ini");
+  if (ret == -1)
+    ret = settings.Parse("/usr/bin/server.ini");
+
+  if (ret == 0) {
+    params.multicast_addr = settings.GetAsString("multicast", "address", "");
+    params.multicast_port = settings.GetAsInteger("multicast", "port", -1);
+    params.service_port = settings.GetAsInteger("service", "port", -1);
+    params.exec_path = settings.GetAsString("exec-path", "address", "");
+    params.monitor_port = settings.GetAsInteger("monitor", "port", -1);
+    params.presence_addr = settings.GetAsString("presence", "address", "");
+    params.presence_port = settings.GetAsInteger("presence", "port", -1);
+    params.with_presence = params.presence_addr.length() > 0 &&
+                           params.presence_port > 0;
+    params.is_daemon = settings.GetAsBoolean("run", "run-as-damon", false);
+  } else {
+    RAW_PRINT("ini parse error(%d)\n", ret);
+    if (argc < 5) {
+      RAW_PRINT("Too Few Argument!!\n");
+      RAW_PRINT("usage : %s mc_addr mc_port svc_port mon_port <presence> "
+                "<pr_addr> <pr_port> <daemon>\n", argv[0]);
+      RAW_PRINT("comment: mc(multicast), svc(service), mon(monitor)\n");
+      RAW_PRINT("         presence (default is 0. You need to come with "
+                "pr_addr and pr_port when you use it)\n");
+      RAW_PRINT("         daemon (default is 0. You can use it if you want\n");
+      return 0;
+    }
+    params.multicast_addr = std::string(argv[1]);
+    params.multicast_port = atoi(argv[2]);
+    params.service_port = atoi(argv[3]);
+    params.monitor_port = atoi(argv[4]);
+    params.is_daemon = (argc == 6 && (strncmp(argv[5], "daemon", 6) == 0)) ||
+                       (argc == 9 && (strncmp(argv[8], "daemon", 6) == 0));
+    params.with_presence = (argc >= 8 && (strncmp(argv[5], "presence", 8) == 0));
+    if (params.with_presence) {
+      params.presence_addr = std::string(argv[6]);
+      params.presence_port = atoi(argv[7]);
+    }
+  }
+
+  auto server_runner = new ServerRunner(params);
+  int exit_code = server_runner->Initialize();
+  if (exit_code > 0)
+    return exit_code;
+
+#if defined(WIN32)&& defined(RUN_AS_SERVICE)
+  exit_code = server_runner->Run(ev_term);
+#else
+  exit_code = server_runner->Run();
+#endif
+
+  return exit_code;
+}
+
+int main(int argc, char** argv) {
+#if defined(WIN32) && defined(RUN_AS_SERVICE)
+  CSpawnController::getInstance().ServiceRegister(real_main);
+  return 0;
+#else
+  return real_main(argc, argv);
+#endif
+}

--- a/service_discovery_manager/Component/mmSH/server_runner.h
+++ b/service_discovery_manager/Component/mmSH/server_runner.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Samsung Electronics Co., Ltd
+ *
+ * Licensed under the Flora License, Version 1.1 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://floralicense.org/license/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+
+class ServerRunner {
+ public:
+  struct ServerRunnerParams {
+    std::string multicast_addr;
+    int multicast_port;
+    int service_port;
+    std::string exec_path;
+    int monitor_port;
+    bool with_presence;
+    std::string presence_addr;
+    int presence_port;
+    bool is_daemon;
+  };
+
+  explicit ServerRunner(ServerRunnerParams& params);
+  ~ServerRunner();
+
+  int Initialize();
+#if defined(WIN32)&& defined(RUN_AS_SERVICE)
+  int Run(HANDLE ev_term);
+#else
+  int Run();
+#endif
+
+ private:
+  ServerRunnerParams params_;
+
+  ServerRunner(const ServerRunner&) = delete;
+  ServerRunner& operator=(const ServerRunner&) = delete;
+};

--- a/service_discovery_manager/Component/server.ini
+++ b/service_discovery_manager/Component/server.ini
@@ -12,6 +12,4 @@ exec-path=/home/yh106.jung/workspace/distributed_chrome/src/out/Default/chrome
 [monitor]
 port=9192
 
-[presence]
-address=1.2.3.4
-port=5000
+


### PR DESCRIPTION
This patch separates main functions from server/client ruuner in order
to develop Android service application.
Android service application only access each runner classes.
Plus, some minor issues have been fixed.

Signed-off-by: yh106.jung <yh106.jung@samsung.com>