### PR TITLE
Make tcp socket port number to be in sync with tizen environment.

### DIFF
--- a/mojo/edk/embedder/tcp_platform_handle_utils.h
+++ b/mojo/edk/embedder/tcp_platform_handle_utils.h
@@ -17,9 +17,9 @@ namespace mojo {
 namespace edk {
 
 const size_t kCastanetsAudioSyncPort = 7000;
-const size_t kCastanetsSyncPort = 8000;
+const size_t kCastanetsSyncPort = 8880;
 const size_t kCastanetsUtilitySyncPort = 6000;
-const size_t kCastanetsBrokerPort = 9000;
+const size_t kCastanetsBrokerPort = 9990;
 
 MOJO_SYSTEM_IMPL_EXPORT ScopedPlatformHandle
 CreateTCPClientHandle(size_t port);


### PR DESCRIPTION
This CL modifies the default port number as it conflicts with
tct-manager in order to support webtct for distributed chrome.

Signed-off-by: Soorya R <soorya.r@samsung.com>