### PR TITLE
Enable logging for linux by default

### DIFF
--- a/content/app/content_main_runner_impl.cc
+++ b/content/app/content_main_runner_impl.cc
@@ -754,6 +754,11 @@ int ContentMainRunnerImpl::Initialize(const ContentMainParams& params) {
       switches::kNumRasterThreads, "4");
   base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
       switches::kRendererClientId, "1");
+
+#if defined(OS_LINUX)
+  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
+      switches::kEnableLogging, "stderr");
+#endif
 #endif  // CASTANETS
 
 #if defined(OS_WIN)


### PR DESCRIPTION
Append "--enable-logging=stderr" option by default for linux