### PR TITLE
Add kRendererProcessLimit switch to content main runner for Castanets.

### DIFF
--- a/content/app/content_main_runner.cc
+++ b/content/app/content_main_runner.cc
@@ -537,6 +537,7 @@ class ContentMainRunnerImpl : public ContentMainRunner {
     base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kLang,"en-US");
     base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kNumRasterThreads, "4");
     base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kRendererClientId, "1");
+    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kRendererProcessLimit, "1");
 #endif //CASTANETS
 
     int exit_code = 0;


### PR DESCRIPTION
This flag is for multiple tabs and cross origin pages share
one render process.