### PR TITLE
Do not delete the allocated memory when SharedMemory::Close is called.

### DIFF
--- a/base/memory/shared_memory_posix.cc
+++ b/base/memory/shared_memory_posix.cc
@@ -357,13 +357,6 @@ SharedMemoryHandle SharedMemory::TakeHandle() {
 }
 
 void SharedMemory::Close() {
-#if defined(CASTANETS)
-  if (memory_) {
-    delete [] memory_;
-    memory_ = nullptr;
-  }
-#endif
-
   if (shm_.IsValid()) {
     shm_.Close();
     shm_ = SharedMemoryHandle();


### PR DESCRIPTION
SharedMemory::Close() doesn't mean that the mapped memory would be deleted.
It should only close the fd.