### PR TITLE
Fix compile warnings

### DIFF
--- a/gpu/command_buffer/client/cmd_buffer_helper.cc
+++ b/gpu/command_buffer/client/cmd_buffer_helper.cc
@@ -396,28 +396,28 @@ bool CommandBufferHelper::SyncTransferBuffer(
   return true;
 }
 
-std::vector<uint8_t> CommandBufferHelper::GetBytesInRange(int32_t from,
-                                                          int32_t to) {
+void CommandBufferHelper::GetBytesInRange(int32_t from,
+                                          int32_t to,
+                                          std::vector<uint8_t>& bytes) {
   int32_t offset = from * sizeof(CommandBufferEntry);
   uint8_t* base_ptr = static_cast<uint8_t*>(ring_buffer_->memory());
   uint8_t* start_ptr = base_ptr + offset;
 
   if (from <= to) {
     int32_t size_of_bytes = (to - from + 1) * sizeof(CommandBufferEntry);
-    std::vector<uint8_t> bytes(start_ptr, start_ptr + size_of_bytes);
-    return std::move(bytes);
+    bytes.reserve(size_of_bytes);
+    std::copy(start_ptr, start_ptr + size_of_bytes, std::back_inserter(bytes));
   } else {
     // |from| to end of buffer
     int32_t size_of_bytes = total_entry_count_ * sizeof(CommandBufferEntry);
-    std::vector<uint8_t> bytes(start_ptr, base_ptr + size_of_bytes - 1);
+    bytes.reserve(size_of_bytes);
+    std::copy(start_ptr, base_ptr + size_of_bytes - 1, std::back_inserter(bytes));
     bytes.push_back(start_ptr[size_of_bytes - offset - 1]);
 
     // 0 to |to|
     size_of_bytes = to * sizeof(CommandBufferEntry);
     for(int i = 0; i < size_of_bytes; i++)
       bytes.push_back(base_ptr[i]);
-
-    return std::move(bytes);
   }
 }
 #endif

--- a/gpu/command_buffer/client/cmd_buffer_helper.h
+++ b/gpu/command_buffer/client/cmd_buffer_helper.h
@@ -282,7 +282,9 @@ class GPU_EXPORT CommandBufferHelper
                           uint32_t size,
                           std::vector<uint8_t>* data);
 
-  std::vector<uint8_t> GetBytesInRange(int32_t from, int32_t to) override;
+  void GetBytesInRange(int32_t from,
+                       int32_t to,
+                       std::vector<uint8_t>& bytes) override;
 #endif
 
  private:

--- a/gpu/command_buffer/common/command_buffer.h
+++ b/gpu/command_buffer/common/command_buffer.h
@@ -17,8 +17,9 @@ namespace gpu {
 #if defined(CASTANETS)
 class CommandBufferClient {
 public:
-  virtual std::vector<uint8_t> GetBytesInRange(int32_t from_offset,
-                                               int32_t put_offset) = 0;
+  virtual void GetBytesInRange(int32_t from_offset,
+                               int32_t put_offset,
+                               std::vector<uint8_t>& bytes) = 0;
 };
 #endif
 // Common interface for CommandBuffer implementations.
@@ -125,10 +126,10 @@ class GPU_EXPORT CommandBuffer {
   virtual void DestroyTransferBuffer(int32_t id) = 0;
 
 #if defined(CASTANETS)
-  virtual bool SyncTransferBuffer(int32_t id,
+  virtual void SyncTransferBuffer(int32_t id,
                                   uint32_t offset,
                                   uint32_t size,
-                                  std::vector<uint8_t>* data) { return true; }
+                                  std::vector<uint8_t>* data) {}
 
   virtual void UpdateTransferBuffer(int32_t id,
                                     uint32_t offset,

--- a/gpu/ipc/client/command_buffer_proxy_impl.h
+++ b/gpu/ipc/client/command_buffer_proxy_impl.h
@@ -164,14 +164,14 @@ class GPU_EXPORT CommandBufferProxyImpl : public gpu::CommandBuffer,
   uint32_t CreateStreamTexture(uint32_t texture_id);
 
 #if defined(CASTANETS)
-  bool SyncTransferBuffer(int32_t id,
+  void SyncTransferBuffer(int32_t id,
                           uint32_t offset,
                           uint32_t size, std::vector<uint8_t>* data) override;
 
   void UpdateTransferBuffer(
       int32_t id, uint32_t offset, std::vector<uint8_t> bytes) override;
 
-  void SetClient(CommandBufferClient* client) override { client_ = client; }
+  void SetClient(CommandBufferClient* client) override;
 #endif
 
  private:
@@ -243,6 +243,10 @@ class GPU_EXPORT CommandBufferProxyImpl : public gpu::CommandBuffer,
   // The shared memory area used to update state.
   gpu::CommandBufferSharedState* shared_state() const;
 
+#if defined(CASTANETS)
+  CommandBufferClient* client_ = nullptr;
+#endif
+
   // The shared memory area used to update state.
   std::unique_ptr<base::SharedMemory> shared_state_shm_;
 
@@ -301,10 +305,6 @@ class GPU_EXPORT CommandBufferProxyImpl : public gpu::CommandBuffer,
 
   scoped_refptr<base::SequencedTaskRunner> callback_thread_;
   base::WeakPtrFactory<CommandBufferProxyImpl> weak_ptr_factory_;
-
-#if defined(CASTANETS)
-  CommandBufferClient* client_ = 0;
-#endif
 
   DISALLOW_COPY_AND_ASSIGN(CommandBufferProxyImpl);
 };

--- a/gpu/ipc/client/gpu_channel_host.cc
+++ b/gpu/ipc/client/gpu_channel_host.cc
@@ -127,7 +127,7 @@ uint32_t GpuChannelHost::OrderingBarrier(
     int32_t put_offset,
     std::vector<ui::LatencyInfo> latency_info,
     std::vector<SyncToken> sync_token_fences,
-    std::vector<uint8_t> bytes) {
+    const std::vector<uint8_t>& bytes) {
 #else
 uint32_t GpuChannelHost::OrderingBarrier(
     int32_t route_id,

--- a/gpu/ipc/client/gpu_channel_host.h
+++ b/gpu/ipc/client/gpu_channel_host.h
@@ -112,7 +112,7 @@ class GPU_EXPORT GpuChannelHost
                            int32_t put_offset,
                            std::vector<ui::LatencyInfo> latency_info,
                            std::vector<SyncToken> sync_token_fences,
-                           std::vector<uint8_t> bytes);
+                           const std::vector<uint8_t>& bytes);
 #else
   uint32_t OrderingBarrier(int32_t route_id,
                            int32_t put_offset,


### PR DESCRIPTION
- gpu/command_buffer/common/command_buffer.h:131:63: warning: [chromium-style]
  virtual methods with non-empty bodies shouldn't be declared inline.

- gpu/command_buffer/client/cmd_buffer_helper.cc:422:12: warning:
  moving a local object in a return statement prevents copy elision
  [-Wpessimizing-move]