### PR TITLE
Introduce base::Castanets::IsEnabled().

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -1210,6 +1210,14 @@ component("base") {
     sources += [ "power_monitor/power_monitor_device_source_chromeos.cc" ]
   }
 
+  # Distributed chromium
+  if (enable_castanets) {
+    sources += [
+      "distributed_chromium_util.h",
+      "distributed_chromium_util.cc",
+    ]
+  }
+
   if (is_fuchsia) {
     # These files have Fuchsia-specific implementations in the sources += block
     # below, rather than using the generic POSIX or Linux-y ones.

--- a/base/base_switches.cc
+++ b/base/base_switches.cc
@@ -57,8 +57,8 @@ const char kForceFieldTrials[]              = "force-fieldtrials";
 const char kNoErrorDialogs[]                = "noerrdialogs";
 
 #if defined(CASTANETS)
-// Specify distributed chrome server address.
-const char kServerAddress[]                 = "server-address";
+// Enable features for distributed chromium.
+const char kEnableCastanets[]     = "enable-castanets";
 #if defined(NETWORK_SHARED_MEMORY)
 const char kNetworkSharedMemoryPath[]           = "network-shared-memory-path";
 #endif

--- a/base/base_switches.h
+++ b/base/base_switches.h
@@ -24,7 +24,7 @@ extern const char kFullMemoryCrashReport[];
 extern const char kNoErrorDialogs[];
 extern const char kProfilingFile[];
 #if defined(CASTANETS)
-extern const char kServerAddress[];
+extern const char kEnableCastanets[];
 #if defined(NETWORK_SHARED_MEMORY)
 extern const char kNetworkSharedMemoryPath[];
 #endif

--- a/base/distributed_chromium_util.cc
+++ b/base/distributed_chromium_util.cc
@@ -1,0 +1,28 @@
+// Copyright 2018 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/distributed_chromium_util.h"
+
+#include "base/base_switches.h"
+#include "base/command_line.h"
+
+namespace base {
+
+bool Castanets::IsEnabled() {
+  return (CommandLine::ForCurrentProcess()->HasSwitch(
+      switches::kEnableCastanets)) ? true : false;
+}
+
+std::string Castanets::ServerAddress() {
+  std::string server_address = "127.0.0.1";
+  base::CommandLine* command_line = CommandLine::ForCurrentProcess();
+  if (command_line->HasSwitch(switches::kEnableCastanets)) {
+    server_address = command_line->GetSwitchValueASCII(
+        switches::kEnableCastanets);
+  }
+
+  return server_address;
+}
+
+}  // namespace base

--- a/base/distributed_chromium_util.h
+++ b/base/distributed_chromium_util.h
@@ -1,0 +1,23 @@
+// Copyright 2018 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef BASE_DISTRIBUTED_CHROMIUM_H_
+#define BASE_DISTRIBUTED_CHROMIUM_H_
+
+#include <stddef.h>
+#include <string>
+
+#include "base/base_export.h"
+
+namespace base {
+
+class BASE_EXPORT Castanets {
+  public:
+    static bool IsEnabled();
+    static std::string ServerAddress();
+};
+
+}  // namespace base
+
+#endif  // BASE_DISTRIBUTED_CHROMIUM_H_

--- a/base/memory/discardable_shared_memory.cc
+++ b/base/memory/discardable_shared_memory.cc
@@ -31,6 +31,10 @@
 #include "base/win/windows_version.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace base {
 namespace {
 
@@ -271,8 +275,11 @@ DiscardableSharedMemory::LockResult DiscardableSharedMemory::Lock(
 }
 
 void DiscardableSharedMemory::Unlock(size_t offset, size_t length) {
-#if !defined(CASTANETS)
-  DCHECK_EQ(AlignToPageSize(offset), offset);
+#if defined(CASTANETS)
+  if (!base::Castanets::IsEnabled())
+    DCHECK_EQ(AlignToPageSize(offset), offset);
+#else
+    DCHECK_EQ(AlignToPageSize(offset), offset);
 #endif
   DCHECK_EQ(AlignToPageSize(length), length);
 

--- a/base/memory/shared_memory_handle_posix.cc
+++ b/base/memory/shared_memory_handle_posix.cc
@@ -10,6 +10,10 @@
 #include "base/posix/eintr_wrapper.h"
 #include "base/unguessable_token.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace base {
 
 SharedMemoryHandle::SharedMemoryHandle() = default;
@@ -55,7 +59,8 @@ bool SharedMemoryHandle::IsValid() const {
 
 void SharedMemoryHandle::Close() const {
 #if defined(CASTANETS)
-  if (file_descriptor_.fd == 0) {
+  if (base::Castanets::IsEnabled() &&
+          file_descriptor_.fd == 0) {
     return;
   }
 #endif
@@ -75,7 +80,8 @@ SharedMemoryHandle SharedMemoryHandle::Duplicate() const {
     return SharedMemoryHandle();
 
 #if defined(CASTANETS)
-  if (file_descriptor_.fd == 0) {
+  if (base::Castanets::IsEnabled() &&
+          file_descriptor_.fd == 0) {
 #if defined(NETWORK_SHARED_MEMORY)
     return SharedMemoryHandle(FileDescriptor(0, true), GetSize(), GetGUID(), GetMemoryFileId());
 #else

--- a/cc/raster/bitmap_raster_buffer_provider.cc
+++ b/cc/raster/bitmap_raster_buffer_provider.cc
@@ -19,6 +19,10 @@
 #include "cc/resources/resource.h"
 #include "components/viz/common/resources/platform_color.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace cc {
 namespace {
 
@@ -57,7 +61,9 @@ class RasterBufferImpl : public RasterBuffer {
         lock_.color_space_for_raster(), playback_settings);
 
 #if defined(CASTANETS)
-    lock_.NotifyRasterizedTile(resource_->size().height()*lock_.sk_bitmap().rowBytes(), lock_.sk_bitmap().getPixels());
+    if (base::Castanets::IsEnabled())
+      lock_.NotifyRasterizedTile(resource_->size().height()*lock_.sk_bitmap().rowBytes(),
+              lock_.sk_bitmap().getPixels());
 #endif
 
   }

--- a/cc/resources/resource_provider.cc
+++ b/cc/resources/resource_provider.cc
@@ -46,6 +46,10 @@
 #include "ui/gfx/icc_profile.h"
 #include "ui/gl/trace_util.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 using gpu::gles2::GLES2Interface;
 
 namespace cc {
@@ -781,7 +785,9 @@ void ResourceProvider::CopyToResource(viz::ResourceId id,
     SkCanvas dest(lock.sk_bitmap());
     dest.writePixels(source_info, image, image_stride, 0, 0);
 #if defined(CASTANETS)
-    lock.NotifyRasterizedTile(lock.sk_bitmap().height()*lock.sk_bitmap().rowBytes(), lock.sk_bitmap().getPixels());
+    if (base::Castanets::IsEnabled())
+      lock.NotifyRasterizedTile(lock.sk_bitmap().height()*lock.sk_bitmap().rowBytes(),
+              lock.sk_bitmap().getPixels());
 #endif
   } else {
     // No sync token needed because the lock will set synchronization state to
@@ -1074,7 +1080,8 @@ ResourceProvider::ScopedWriteLockSoftware::ScopedWriteLockSoftware(
   resource_provider->PopulateSkBitmapWithResource(&sk_bitmap_, resource);
   color_space_ = resource_provider->GetResourceColorSpaceForRaster(resource);
 #if defined(CASTANETS)
-  shared_bitmap_id_ = resource->shared_bitmap_id;
+  if (base::Castanets::IsEnabled())
+    shared_bitmap_id_ = resource->shared_bitmap_id;
 #endif
   DCHECK(valid());
 }

--- a/components/subresource_filter/content/renderer/unverified_ruleset_dealer.cc
+++ b/components/subresource_filter/content/renderer/unverified_ruleset_dealer.cc
@@ -7,6 +7,10 @@
 #include "components/subresource_filter/content/common/subresource_filter_messages.h"
 #include "ipc/ipc_message_macros.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace subresource_filter {
 
 UnverifiedRulesetDealer::UnverifiedRulesetDealer() = default;
@@ -26,8 +30,10 @@ bool UnverifiedRulesetDealer::OnControlMessageReceived(
 void UnverifiedRulesetDealer::OnSetRulesetForProcess(
     const IPC::PlatformFileForTransit& platform_file) {
 #if defined(CASTANETS)
-  LOG(INFO) << "SKIP!!!!! UnverifiedRulesetDealer::OnSetRulesetForProcess";
-  return;
+  if (base::Castanets::IsEnabled()) {
+    LOG(INFO) << "SKIP!!!!! UnverifiedRulesetDealer::OnSetRulesetForProcess";
+    return;
+  }
 #endif
 
   SetRulesetFile(IPC::PlatformFileForTransitToFile(platform_file));

--- a/components/visitedlink/renderer/visitedlink_slave.cc
+++ b/components/visitedlink/renderer/visitedlink_slave.cc
@@ -10,6 +10,10 @@
 #include "base/logging.h"
 #include "third_party/WebKit/public/web/WebView.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 using blink::WebView;
 
 namespace visitedlink {
@@ -30,8 +34,10 @@ VisitedLinkSlave::GetBindCallback() {
 void VisitedLinkSlave::UpdateVisitedLinks(
     mojo::ScopedSharedBufferHandle table) {
 #if defined(CASTANETS)
-  LOG(INFO) << "SKIP!!!!! VisitedLinkSlave::UpdateVisitedLinks";
-  return;
+  if (base::Castanets::IsEnabled()) {
+    LOG(INFO) << "SKIP!!!!! VisitedLinkSlave::UpdateVisitedLinks";
+    return;
+  }
 #endif
 
   DCHECK(table.is_valid()) << "Bad table handle";
@@ -68,8 +74,10 @@ void VisitedLinkSlave::UpdateVisitedLinks(
 void VisitedLinkSlave::AddVisitedLinks(
     const std::vector<VisitedLinkSlave::Fingerprint>& fingerprints) {
 #if defined(CASTANETS)
-  LOG(INFO) << "SKIP!!!!! VisitedLinkSlave::AddVisitedLinks";
-  return;
+  if (base::Castanets::IsEnabled()) {
+    LOG(INFO) << "SKIP!!!!! VisitedLinkSlave::AddVisitedLinks";
+    return;
+  }
 #endif
 
   for (size_t i = 0; i < fingerprints.size(); ++i)

--- a/components/viz/client/client_shared_bitmap_manager.cc
+++ b/components/viz/client/client_shared_bitmap_manager.cc
@@ -17,6 +17,10 @@
 #include "mojo/public/cpp/system/platform_handle.h"
 #include "ui/gfx/geometry/size.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace viz {
 
 namespace {
@@ -186,10 +190,12 @@ void ClientSharedBitmapManager::NotifyRasterizedSharedBitmap(
     size_t memory_size,
     void* memory,
     SharedBitmapId id) {
-  uint8_t* pixels = static_cast<uint8_t*>(memory);
-  std::vector<uint8_t> pixels_vec(pixels, pixels + memory_size);
-  (*shared_bitmap_allocation_notifier_)
-      ->DidRasterizeSharedBitmap(memory_size, pixels_vec, id);
+  if (base::Castanets::IsEnabled()) {
+    uint8_t* pixels = static_cast<uint8_t*>(memory);
+    std::vector<uint8_t> pixels_vec(pixels, pixels + memory_size);
+    (*shared_bitmap_allocation_notifier_)
+        ->DidRasterizeSharedBitmap(memory_size, pixels_vec, id);
+  }
 }
 #endif
 

--- a/components/viz/service/display_embedder/shared_bitmap_allocation_notifier_impl.cc
+++ b/components/viz/service/display_embedder/shared_bitmap_allocation_notifier_impl.cc
@@ -7,6 +7,10 @@
 #include "components/viz/service/display_embedder/server_shared_bitmap_manager.h"
 #include "mojo/public/cpp/system/platform_handle.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace viz {
 
 SharedBitmapAllocationNotifierImpl::SharedBitmapAllocationNotifierImpl(
@@ -48,7 +52,8 @@ void SharedBitmapAllocationNotifierImpl::DidAllocateSharedBitmap(
 
 void SharedBitmapAllocationNotifierImpl::DidRasterizeSharedBitmap(int32_t size, const std::vector<uint8_t>& pixels_vec, const gpu::Mailbox& id) {
 #if defined(CASTANETS)
-  manager_->ChildRasterizedSharedBitmap(size, pixels_vec.data(), id);
+  if (base::Castanets::IsEnabled())
+    manager_->ChildRasterizedSharedBitmap(size, pixels_vec.data(), id);
 #endif
 }
 

--- a/content/app/content_main_runner.cc
+++ b/content/app/content_main_runner.cc
@@ -113,6 +113,7 @@
 #endif
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "ui/gl/gl_switches.h"
 #endif
 
@@ -529,20 +530,22 @@ class ContentMainRunnerImpl : public ContentMainRunner {
     }
 #endif  // !OS_ANDROID
 #if defined(CASTANETS)
-    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoSandbox);
-    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoZygote);
+    if (base::Castanets::IsEnabled()) {
+      base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoSandbox);
+      base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoZygote);
 
-    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kInProcessGPU);
-    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kDisableGpuVsync);
-    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kDisableAcceleratedVideoDecode);
+      base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kInProcessGPU);
+      base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kDisableGpuVsync);
+      base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kDisableAcceleratedVideoDecode);
 
-    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kProcessPerTab);
+      base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kProcessPerTab);
 
-    base::CommandLine::ForCurrentProcess()->AppendSwitch("no-first-run");
-    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kLang,"en-US");
-    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kNumRasterThreads, "4");
-    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kRendererClientId, "1");
-    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kRendererProcessLimit, "1");
+      base::CommandLine::ForCurrentProcess()->AppendSwitch("no-first-run");
+      base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kLang,"en-US");
+      base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kNumRasterThreads, "4");
+      base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kRendererClientId, "1");
+      base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kRendererProcessLimit, "1");
+    }
 #endif //CASTANETS
 
     int exit_code = 0;

--- a/content/browser/android/content_startup_flags.cc
+++ b/content/browser/android/content_startup_flags.cc
@@ -16,6 +16,7 @@
 #include "ui/base/ui_base_switches.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "ui/gl/gl_switches.h"
 #endif
 
@@ -33,14 +34,16 @@ void SetContentCommandLineFlags(bool single_process,
       base::CommandLine::ForCurrentProcess();
 
 #if defined(CASTANETS)
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoSandbox);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoZygote);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kInProcessGPU);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kDisableGpuVsync);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kEnableUseZoomForDSF);
-  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kNumRasterThreads,"4");
-  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kRendererClientId,"2");
-  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kLang,"en-US");
+  if (base::Castanets::IsEnabled()) {
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoSandbox);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoZygote);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kInProcessGPU);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kDisableGpuVsync);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kEnableUseZoomForDSF);
+    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kNumRasterThreads,"4");
+    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kRendererClientId,"2");
+    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kLang,"en-US");
+  }
 #endif
 
   if (single_process) {

--- a/content/browser/browser_child_process_host_impl.cc
+++ b/content/browser/browser_child_process_host_impl.cc
@@ -55,6 +55,10 @@
 #include "content/browser/mach_broker_mac.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 namespace {
 
@@ -524,8 +528,10 @@ void BrowserChildProcessHostImpl::CreateMetricsAllocator() {
 
 void BrowserChildProcessHostImpl::ShareMetricsAllocatorToProcess() {
 #if defined(CASTANETS)
-  LOG(INFO) << "SKIP!!!!! BrowserChildProcessHostImpl::ShareMetricsAllocatorToProcess";
-  return;
+  if (base::Castanets::IsEnabled()) {
+   LOG(INFO) << "SKIP!!!!! BrowserChildProcessHostImpl::ShareMetricsAllocatorToProcess";
+   return;
+  }
 #endif
   if (metrics_allocator_) {
     HistogramController::GetInstance()->SetHistogramMemory<ChildProcessHost>(

--- a/content/browser/frame_host/render_frame_host_impl.cc
+++ b/content/browser/frame_host/render_frame_host_impl.cc
@@ -165,6 +165,10 @@
 #include "content/browser/frame_host/popup_menu_helper_mac.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 using base::TimeDelta;
 
 namespace content {
@@ -3478,7 +3482,15 @@ void RenderFrameHostImpl::SetUpMojoIfNeeded() {
   remote_interfaces_->Bind(std::move(remote_interfaces));
 
 #if defined(CASTANETS)
+  if (base::Castanets::IsEnabled())
     legacy_frame_input_handler_.reset(new LegacyIPCFrameInputHandler(this));
+  else {
+    if (base::FeatureList::IsEnabled(features::kMojoInputMessages)) {
+      GetRemoteInterfaces()->GetInterface(&frame_input_handler_);
+    } else {
+      legacy_frame_input_handler_.reset(new LegacyIPCFrameInputHandler(this));
+    }
+  }
 #else
   if (base::FeatureList::IsEnabled(features::kMojoInputMessages)) {
     GetRemoteInterfaces()->GetInterface(&frame_input_handler_);

--- a/content/browser/loader/mojo_async_resource_handler.cc
+++ b/content/browser/loader/mojo_async_resource_handler.cc
@@ -31,6 +31,10 @@
 #include "net/base/net_errors.h"
 #include "net/url_request/redirect_info.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 namespace {
 
@@ -320,7 +324,12 @@ void MojoAsyncResourceHandler::OnReadCompleted(
 
   if (response_body_consumer_handle_.is_valid()) {
     // Send the data pipe on the first OnReadCompleted call.
-#if !defined(CASTANETS)
+#if defined(CASTANETS)
+    if (!base::Castanets::IsEnabled()) {
+      url_loader_client_->OnStartLoadingResponseBody(
+          std::move(response_body_consumer_handle_));
+    }
+#else
     url_loader_client_->OnStartLoadingResponseBody(
         std::move(response_body_consumer_handle_));
 #endif

--- a/content/browser/renderer_host/render_message_filter.cc
+++ b/content/browser/renderer_host/render_message_filter.cc
@@ -86,6 +86,10 @@
 #include "base/threading/platform_thread.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 namespace {
 

--- a/content/browser/renderer_host/render_process_host_impl.cc
+++ b/content/browser/renderer_host/render_process_host_impl.cc
@@ -262,6 +262,10 @@
 #define IntToStringType base::IntToString
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 namespace {
 
@@ -2552,6 +2556,9 @@ void RenderProcessHostImpl::PropagateBrowserCommandLineToRenderer(
     switches::kEnableBrowserSideNavigation,
     switches::kEnableDisplayList2dCanvas,
     switches::kEnableDistanceFieldText,
+#if defined(CASTANETS)
+    switches::kEnableCastanets,
+#endif
     switches::kEnableExperimentalCanvasFeatures,
     switches::kEnableExperimentalWebPlatformFeatures,
     switches::kEnableHeapProfiling,
@@ -2617,9 +2624,6 @@ void RenderProcessHostImpl::PropagateBrowserCommandLineToRenderer(
     switches::kRegisterPepperPlugins,
     switches::kRendererStartupDialog,
     switches::kRootLayerScrolls,
-#if defined(CASTANETS)
-    switches::kServerAddress,
-#endif
     switches::kShowPaintRects,
     switches::kSitePerProcess,
     switches::kStatsCollectionController,
@@ -3596,8 +3600,10 @@ RenderProcessHost* RenderProcessHostImpl::GetProcessHostForSiteInstance(
 
 void RenderProcessHostImpl::CreateSharedRendererHistogramAllocator() {
 #if defined(CASTANETS)
-  LOG(INFO) << "SKIP!!!!! RenderProcessHostImpl::CreateSharedRendererHistogramAllocator";
-  return;
+  if (base::Castanets::IsEnabled()) {
+    LOG(INFO) << "SKIP!!!!! RenderProcessHostImpl::CreateSharedRendererHistogramAllocator";
+    return;
+  }
 #endif
   // Create a persistent memory segment for renderer histograms only if
   // they're active in the browser.

--- a/content/child/runtime_features.cc
+++ b/content/child/runtime_features.cc
@@ -22,6 +22,10 @@
 #include "ui/gl/gl_switches.h"
 #include "ui/native_theme/native_theme_features.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 using blink::WebRuntimeFeatures;
 
 namespace content {
@@ -322,7 +326,8 @@ void SetRuntimeFeaturesDefaultsAndUpdateFromArgs(
       base::FeatureList::IsEnabled(features::kNetworkService))
     WebRuntimeFeatures::EnableLoadingWithMojo(true);
 #if defined(CASTANETS)
-  WebRuntimeFeatures::EnableLoadingWithMojo(false);
+  if (base::Castanets::IsEnabled())
+    WebRuntimeFeatures::EnableLoadingWithMojo(false);
 #endif
 
   if (base::FeatureList::IsEnabled(features::kOutOfBlinkCORS))

--- a/content/common/service_manager/child_connection.cc
+++ b/content/common/service_manager/child_connection.cc
@@ -16,6 +16,10 @@
 #include "services/service_manager/public/cpp/identity.h"
 #include "services/service_manager/public/interfaces/service.mojom.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 
 class ChildConnection::IOThreadContext
@@ -122,7 +126,10 @@ ChildConnection::ChildConnection(
   // TODO(rockot): Use a constant name for this pipe attachment rather than a
   // randomly generated token.
 #if defined(CASTANETS)
-  service_token_ = "castanets_service_request";
+  if (base::Castanets::IsEnabled())
+    service_token_ = "castanets_service_request";
+  else
+    service_token_ = mojo::edk::GenerateRandomToken();
 #else
   service_token_ = mojo::edk::GenerateRandomToken();
 #endif

--- a/content/public/common/content_switches.cc
+++ b/content/public/common/content_switches.cc
@@ -9,10 +9,6 @@
 
 namespace switches {
 
-#if defined(CASTANETS)
-const char kEnableForking[] = "enable-forking";
-#endif
-
 // The number of MSAA samples for canvas2D. Requires MSAA support by GPU to
 // have an effect. 0 disables MSAA.
 const char kAcceleratedCanvas2dMSAASampleCount[] = "canvas-msaa-sample-count";

--- a/content/public/common/content_switches.h
+++ b/content/public/common/content_switches.h
@@ -13,10 +13,6 @@
 
 namespace switches {
 
-#if defined(CASTANETS)
-CONTENT_EXPORT extern const char kEnableForking[];
-#endif
-
 // All switches in alphabetical order. The switches should be documented
 // alongside the definition of their values in the .cc file.
 CONTENT_EXPORT extern const char kAcceleratedCanvas2dMSAASampleCount[];

--- a/content/renderer/input/render_widget_input_handler.cc
+++ b/content/renderer/input/render_widget_input_handler.cc
@@ -33,6 +33,7 @@
 #include "ui/latency/latency_info.h"
 
 #if defined (CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "content/common/input_messages.h"
 #endif
 
@@ -274,16 +275,18 @@ void RenderWidgetInputHandler::HandleInputEvent(
   // TODO There is a specific handling for DPAD_CENTER key for Android
   // environment in the above codes. Need a watch if the below change
   // conflicts with the same.
-  if (WebInputEvent::IsKeyboardEventType(input_event.GetType())) {
-    // This message is called for every IME key input.
-    // The current status of processing the input event is used to
-    // properly manage 'CommitQueue' or 'PreeditQueue' on impl side:
-    // If the event is not processed, 'ConfirmComposition' or 'SetComposition'
-    // is called for IME composition, and then pops event queue.
-    // If the event is processed instead, impl side just pops the queue.
-    widget_->Send(new InputHostMsg_DidHandleKeyEvent(
-        widget_->routing_id(), &input_event,
-        processed != WebInputEventResult::kNotHandled));
+  if (base::Castanets::IsEnabled()) {
+    if (WebInputEvent::IsKeyboardEventType(input_event.GetType())) {
+      // This message is called for every IME key input.
+      // The current status of processing the input event is used to
+      // properly manage 'CommitQueue' or 'PreeditQueue' on impl side:
+      // If the event is not processed, 'ConfirmComposition' or 'SetComposition'
+      // is called for IME composition, and then pops event queue.
+      // If the event is processed instead, impl side just pops the queue.
+      widget_->Send(new InputHostMsg_DidHandleKeyEvent(
+          widget_->routing_id(), &input_event,
+          processed != WebInputEventResult::kNotHandled));
+    }
   }
 #endif
 

--- a/content/renderer/renderer_main.cc
+++ b/content/renderer/renderer_main.cc
@@ -68,6 +68,11 @@
 #include "ui/ozone/public/client_native_pixmap_factory_ozone.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#include "ui/gl/gl_switches.h"
+#endif
+
 namespace content {
 namespace {
 // This function provides some ways to test crash and assertion handling
@@ -99,6 +104,12 @@ int RendererMain(const MainFunctionParams& parameters) {
       kTraceEventRendererProcessSortIndex);
 
   const base::CommandLine& parsed_command_line = parameters.command_line;
+
+#if defined(CASTANETS)
+  if (base::Castanets::IsEnabled())
+    const_cast<base::CommandLine&>(parsed_command_line).AppendSwitch(
+        switches::kDisableGpuVsync);
+#endif
 
 #if defined(OS_MACOSX)
   base::mac::ScopedNSAutoreleasePool* pool = parameters.autorelease_pool;

--- a/gpu/command_buffer/client/cmd_buffer_helper.cc
+++ b/gpu/command_buffer/client/cmd_buffer_helper.cc
@@ -21,6 +21,10 @@
 #include "gpu/command_buffer/common/command_buffer.h"
 #include "gpu/command_buffer/common/constants.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace gpu {
 
 CommandBufferHelper::CommandBufferHelper(CommandBuffer* command_buffer)
@@ -399,6 +403,11 @@ bool CommandBufferHelper::SyncTransferBuffer(
 void CommandBufferHelper::GetBytesInRange(int32_t from,
                                           int32_t to,
                                           std::vector<uint8_t>& bytes) {
+  if (!base::Castanets::IsEnabled()) {
+     bytes = std::vector<uint8_t>();
+     return;
+  }
+
   int32_t offset = from * sizeof(CommandBufferEntry);
   uint8_t* base_ptr = static_cast<uint8_t*>(ring_buffer_->memory());
   uint8_t* start_ptr = base_ptr + offset;

--- a/gpu/ipc/client/command_buffer_proxy_impl.cc
+++ b/gpu/ipc/client/command_buffer_proxy_impl.cc
@@ -34,6 +34,10 @@
 #include "gpu/ipc/client/gpu_process_hosted_ca_layer_tree_params.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace gpu {
 
 namespace {
@@ -279,8 +283,10 @@ void CommandBufferProxyImpl::OrderingBarrierHelper(int32_t put_offset) {
     return;
 
 #if defined(CASTANETS)
-  if (last_put_offset_ == -1)
-    last_put_offset_ = 0;
+  if (base::Castanets::IsEnabled()) {
+    if (last_put_offset_ == -1)
+      last_put_offset_ = 0;
+  }
 
   if (channel_) {
     std::vector<uint8_t> bytes;

--- a/gpu/ipc/service/gpu_command_buffer_stub.cc
+++ b/gpu/ipc/service/gpu_command_buffer_stub.cc
@@ -62,6 +62,10 @@
 #include "gpu/ipc/service/stream_texture_android.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 // Macro to reduce code duplication when logging memory in
 // GpuCommandBufferMemoryTracker. This is needed as the UMA_HISTOGRAM_* macros
 // require a unique call-site per histogram (you can't funnel multiple strings
@@ -1013,7 +1017,8 @@ void GpuCommandBufferStub::OnAsyncFlush(
   DCHECK(command_buffer_);
 
 #if defined(CASTANETS)
-  command_buffer_->UpdateCommand(from_offset, put_offset, std::move(bytes));
+  if (base::Castanets::IsEnabled())
+    command_buffer_->UpdateCommand(from_offset, put_offset, std::move(bytes));
 #endif
 
   // We received this message out-of-order. This should not happen but is here

--- a/mojo/edk/embedder/platform_handle.cc
+++ b/mojo/edk/embedder/platform_handle.cc
@@ -19,6 +19,10 @@
 
 #include "base/logging.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace mojo {
 namespace edk {
 
@@ -26,7 +30,7 @@ void PlatformHandle::CloseIfNecessary() {
   if (!is_valid())
     return;
 #if defined(CASTANETS)
-  if (handle == kCastanetsHandle)
+  if (base::Castanets::IsEnabled() && handle == kCastanetsHandle)
     return;
 #endif
 

--- a/mojo/edk/embedder/tcp_platform_handle_utils_posix.cc
+++ b/mojo/edk/embedder/tcp_platform_handle_utils_posix.cc
@@ -11,11 +11,10 @@
 
 #include "base/base_switches.h"
 #include "base/command_line.h"
+#include "base/distributed_chromium_util.h"
 #include "base/files/file_util.h"
 #include "base/logging.h"
 #include "base/posix/eintr_wrapper.h"
-
-#include "base/debug/stack_trace.h"
 
 namespace mojo {
 namespace edk {
@@ -43,20 +42,15 @@ ScopedPlatformHandle CreateTCPSocket(bool needs_connection, int protocol) {
 }  // namespace
 
 ScopedPlatformHandle CreateTCPClientHandle(size_t port) {
-  std::string server_address = "127.0.0.1";
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  if (command_line->HasSwitch(switches::kServerAddress)) {
-    server_address =
-        command_line->GetSwitchValueASCII(switches::kServerAddress);
-    struct addrinfo* result = NULL;
-    int status = getaddrinfo(server_address.c_str(), NULL, NULL, &result);
-    if (status == 0 && result != NULL) {
-      char host[NI_MAXHOST] = "";
-      status = getnameinfo(result->ai_addr, result->ai_addrlen, host,
-                           NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
-      if (status == 0 && *host) {
-        server_address = std::string(host);
-      }
+  std::string server_address = base::Castanets::ServerAddress();
+  struct addrinfo* result = NULL;
+  int status = getaddrinfo(server_address.c_str(), NULL, NULL, &result);
+  if (status == 0 && result != NULL) {
+    char host[NI_MAXHOST] = "";
+    status = getnameinfo(result->ai_addr, result->ai_addrlen, host,
+                         NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
+    if (status == 0 && *host) {
+      server_address = std::string(host);
     }
     freeaddrinfo(result);
   }


### PR DESCRIPTION
Now, we can enable "castanets" dynamically
via command-line flag at runtime.

[Normal mode]
- Disable castanets feature
- Browser : ./out/Default/chrome

[Castanets mode]
- Enable "distributed chromium" feature
- Browser : ./out/Default/chrome --enable-castanets
- Renderer : ./out/Default/chrome --type=renderer --enable-castanets=<server_IP_adress>

Signed-off-by: venu.musham <venu.musham@samsung.com>