### PR TITLE
[SDM] Handle exception for MonitorClient::Start failure

### DIFF
--- a/service_discovery_manager/Component/mmSOCK/pTcpClient.cpp
+++ b/service_discovery_manager/Component/mmSOCK/pTcpClient.cpp
@@ -68,6 +68,7 @@ BOOL CpTcpClient::Open(const CHAR* pAddress, INT32 iPort) {
   }
   if (SOCK_SUCCESS != CbSocket::Connect(pAddress, iPort)) {
     DPRINT(COMM, DEBUG_ERROR, "Connect to [%s] Error!!\n", pAddress);
+    CbSocket::Close();
     return FALSE;
   }
   return TRUE;


### PR DESCRIPTION
This patch deletes MonitorClient related resource in case of
MonitorClient::Start failure.
Plus, closes tcp socket when connection is failed, because it can cause
fd leak.

Signed-off-by: yh106.jung <yh106.jung@samsung.com>