### PR TITLE
[SDM] Fix buffer overflow in strncpy

### DIFF
--- a/service_discovery_manager/Component/mmSH/client_runner.cpp
+++ b/service_discovery_manager/Component/mmSH/client_runner.cpp
@@ -298,7 +298,7 @@ int ClientRunner::Run() {
       Monitor* meta = new Monitor;
       INT32 magic = sequence_id * 100 + i;
       sprintf(meta->id, UUIDS_MDC, magic);
-      strncpy(meta->address, info->address, strlen(info->address));
+      strncpy(meta->address, info->address, sizeof(meta->address));
       meta->service_port = info->service_port;
       meta->monitor_port = info->monitor_port;
 


### PR DESCRIPTION
Currently, the length of source string has been used as third paramter.
It the source string is longer than the destination,
it can cause the buffer overflow.
This patch uses destinations'size as the third parameter of strncpy.

Signed-off-by: yh106.jung <yh106.jung@samsung.com>