### PR TITLE
Remove the map for tracking SharedMemoryHandles and its methods.

### DIFF
--- a/base/memory/shared_memory_handle_posix.cc
+++ b/base/memory/shared_memory_handle_posix.cc
@@ -10,10 +10,6 @@
 #include "base/posix/eintr_wrapper.h"
 #include "base/unguessable_token.h"
 
-#if defined(CASTANETS)
-#include "base/memory/shared_memory_tracker.h"
-#endif
-
 namespace base {
 
 SharedMemoryHandle::SharedMemoryHandle() = default;
@@ -31,9 +27,6 @@ SharedMemoryHandle SharedMemoryHandle::ImportHandle(int fd, size_t size) {
   handle.file_descriptor_.auto_close = false;
   handle.guid_ = UnguessableToken::Create();
   handle.size_ = size;
-#if defined(CASTANETS)
-  base::SharedMemoryTracker::GetInstance()->OnHandleCreated(handle);
-#endif
   return handle;
 }
 
@@ -46,9 +39,6 @@ bool SharedMemoryHandle::IsValid() const {
 }
 
 void SharedMemoryHandle::Close() const {
-#if defined(CASTANETS)
-  base::SharedMemoryTracker::GetInstance()->OnHandleClosed(*this);
-#endif
   if (IGNORE_EINTR(close(file_descriptor_.fd)) < 0)
     PLOG(ERROR) << "close";
 }

--- a/base/memory/shared_memory_tracker.h
+++ b/base/memory/shared_memory_tracker.h
@@ -96,9 +96,6 @@ class BASE_EXPORT SharedMemoryTracker : public trace_event::MemoryDumpProvider {
 #if defined(CASTANETS)
   std::map<UnguessableToken, const SharedMemory*> mappings_;
 
-  Lock handles_lock_;
-  std::map<UnguessableToken, std::set<int>> handles_;
-
   Lock holders_lock_;
   std::map<UnguessableToken, subtle::PlatformSharedMemoryRegion> holders_;
 #endif


### PR DESCRIPTION
We can find a proper fd with mappings_ and holders_
in SharedMemoryTracker in case of default loading and sw compositing.
Thus we don't need to be tracking SharedMemoryHandles.