### PR TITLE
Return valid results in utility methods for IPC messages.

### DIFF
--- a/ipc/ipc_message_utils.cc
+++ b/ipc/ipc_message_utils.cc
@@ -46,6 +46,10 @@
 #include "mojo/public/cpp/system/scope_to_message_pipe.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/memory/shared_memory_helper.h"
+#endif
+
 namespace IPC {
 
 namespace {
@@ -753,6 +757,19 @@ bool ParamTraits<base::SharedMemoryHandle>::Read(const base::Pickle* m,
   *r = base::SharedMemoryHandle(mach_port_mac.get_mach_port(),
                                 static_cast<size_t>(size), guid);
 #elif defined(OS_POSIX)
+#if defined(CASTANETS)
+  if (static_cast<internal::PlatformFileAttachment*>(attachment.get())->file()
+      == -1) {
+    base::SharedMemoryCreateOptions options;
+    options.size = size;
+    base::subtle::PlatformSharedMemoryRegion new_region =
+        base::CreateAnonymousSharedMemoryIfNeeded(guid, options);
+    *r = base::SharedMemoryHandle(
+        base::FileDescriptor(
+            HANDLE_EINTR(dup(new_region.GetPlatformHandle().fd)), true),
+            static_cast<size_t>(size), guid);
+  } else
+#endif
   *r = base::SharedMemoryHandle(
       base::FileDescriptor(
           static_cast<internal::PlatformFileAttachment*>(attachment.get())
@@ -983,6 +1000,17 @@ bool ParamTraits<base::subtle::PlatformSharedMemoryRegion>::Read(
       return false;
     }
   }
+#if defined(CASTANETS)
+  if (static_cast<internal::PlatformFileAttachment*>(attachment.get())->file()
+      == -1) {
+    base::SharedMemoryCreateOptions options;
+    options.size = size;
+    options.share_read_only =
+        (mode == base::subtle::PlatformSharedMemoryRegion::Mode::kWritable) ?
+            true : false;
+    *r = base::CreateAnonymousSharedMemoryIfNeeded(guid, options);
+  } else
+#endif
   *r = base::subtle::PlatformSharedMemoryRegion::Take(
       base::subtle::ScopedFDPair(
           base::ScopedFD(


### PR DESCRIPTION
When invalid handles are received via Mojo connected with TCP/IP sockets, we have to allocate a shared memory directly and return a valid result outside of Mojo.