### PR TITLE
Track all mapping information in SharedMemoryTracker.

### DIFF
--- a/base/memory/shared_memory_tracker.h
+++ b/base/memory/shared_memory_tracker.h
@@ -53,14 +53,20 @@ class BASE_EXPORT SharedMemoryTracker : public trace_event::MemoryDumpProvider {
   void DecrementMemoryUsage(const SharedMemoryMapping& mapping);
 
 #if defined(CASTANETS)
-  void OnHandleCreated(const SharedMemoryHandle& handle);
-  void OnHandleClosed(const SharedMemoryHandle& handle);
+  struct MappingInfo {
+    MappingInfo(const UnguessableToken& id, size_t size, void* ptr)
+        : mapped_id(id), mapped_size(size), mapped_memory(ptr) {}
+
+    UnguessableToken mapped_id;
+    size_t mapped_size;
+    void* mapped_memory;
+  };
 
   void AddHolder(subtle::PlatformSharedMemoryRegion handle);
   void RemoveHolder(const UnguessableToken& guid);
 
   int Find(const UnguessableToken& id);
-  const SharedMemory* FindMappedMemory(const UnguessableToken& id);
+  const MappingInfo* FindMappedMemory(const UnguessableToken& id);
 #endif
 
   // Root dump name for all shared memory dumps.
@@ -94,7 +100,7 @@ class BASE_EXPORT SharedMemoryTracker : public trace_event::MemoryDumpProvider {
   std::map<void*, UsageInfo> usages_;
 
 #if defined(CASTANETS)
-  std::map<UnguessableToken, const SharedMemory*> mappings_;
+  std::map<UnguessableToken, MappingInfo> mappings_;
 
   Lock holders_lock_;
   std::map<UnguessableToken, subtle::PlatformSharedMemoryRegion> holders_;


### PR DESCRIPTION
This CL applies a new structure MappingInfo to SharedMemoryTracker::mappings_
in order to work with all overloaded methods in the Tracker class.