### PR TITLE
Add BUFFER_SYNC_ACK.

### DIFF
--- a/mojo/core/broker_messages.h
+++ b/mojo/core/broker_messages.h
@@ -18,6 +18,7 @@ enum BrokerMessageType : uint32_t {
   BUFFER_REQUEST,
   BUFFER_RESPONSE,
   BUFFER_SYNC,
+  BUFFER_SYNC_ACK,
 };
 
 struct BrokerMessageHeader {
@@ -44,6 +45,11 @@ struct BufferSyncData {
   uint32_t sync_bytes;
   uint32_t buffer_bytes;
   uint32_t padding;
+};
+
+struct BufferSyncAckData {
+  uint64_t guid_high;
+  uint64_t guid_low;
 };
 
 #if defined(OS_WIN) || defined(CASTANETS)


### PR DESCRIPTION
- Sync caller waits until receiving BUFFER_SYNC_ACK.
- Right after data copy is complete in OnBufferSync(), send BUFFER_SYN_ACK.
- [Workaround] We must not call wait in the IO thread. In case of the browser-side loader, however, Sync() is called in the IO thread. The workaround code using ThreadChecker is to avoid it.
- [Todo] Call WaitSync() when trying to read a shared memory. That's performance could be better than SYNC_ACK approach.