### PR TITLE
Use NamedPlatformChannel to connect network and renderer processes.

### DIFF
--- a/content/browser/service_manager/service_manager_context.cc
+++ b/content/browser/service_manager/service_manager_context.cc
@@ -671,7 +671,6 @@ ServiceManagerContext::ServiceManagerContext(
         base::BindRepeating(&base::ASCIIToUTF16, "Visuals Service");
   }
 
-#if !defined(CASTANETS)
   for (const auto& service : out_of_process_services) {
     packaged_services_connection_->AddServiceRequestHandlerWithPID(
         service.first,
@@ -679,7 +678,6 @@ ServiceManagerContext::ServiceManagerContext(
                             service.first, service.second.process_name_callback,
                             service.second.process_group));
   }
-#endif
 
 #if BUILDFLAG(ENABLE_MOJO_MEDIA_IN_GPU_PROCESS)
   packaged_services_connection_->AddServiceRequestHandlerWithPID(

--- a/services/network/public/cpp/features.cc
+++ b/services/network/public/cpp/features.cc
@@ -15,8 +15,14 @@ const base::Feature kExpectCTReporting{"ExpectCTReporting",
 const base::Feature kNetworkErrorLogging{"NetworkErrorLogging",
                                          base::FEATURE_DISABLED_BY_DEFAULT};
 // Enables the network service.
-const base::Feature kNetworkService{"NetworkService",
-                                    base::FEATURE_DISABLED_BY_DEFAULT};
+const base::Feature kNetworkService {
+  "NetworkService",
+#if defined(CASTANETS)
+      base::FEATURE_ENABLED_BY_DEFAULT
+#else
+      base::FEATURE_DISABLED_BY_DEFAULT
+#endif
+};
 
 // Out of Blink CORS
 const base::Feature kOutOfBlinkCORS{"OutOfBlinkCORS",


### PR DESCRIPTION
[WIP] This change uses random file names for connection between network and renderer processes.
Just for reference. Not working yet.