### PR TITLE
Remove workaround code for Castanets specific process.

### DIFF
--- a/base/process/kill_posix.cc
+++ b/base/process/kill_posix.cc
@@ -28,11 +28,11 @@ TerminationStatus GetTerminationStatusImpl(ProcessHandle handle,
                                            bool can_block,
                                            int* exit_code) {
   DCHECK(exit_code);
-
 #if defined(CASTANETS)
-  if (exit_code)
+  if (handle == kCastanetsProcessHandle) {
     *exit_code = 0;
-  return TERMINATION_STATUS_STILL_RUNNING;
+    return TERMINATION_STATUS_NORMAL_TERMINATION;
+  }
 #endif
   int status = 0;
 
@@ -92,16 +92,14 @@ bool KillProcessGroup(ProcessHandle process_group_id) {
 #endif  // !defined(OS_NACL_NONSFI)
 
 TerminationStatus GetTerminationStatus(ProcessHandle handle, int* exit_code) {
-#if defined(CASTANETS)
-  return TERMINATION_STATUS_NORMAL_TERMINATION;
-#endif
   return GetTerminationStatusImpl(handle, false /* can_block */, exit_code);
 }
 
 TerminationStatus GetKnownDeadTerminationStatus(ProcessHandle handle,
                                                 int* exit_code) {
 #if defined(CASTANETS)
-  return GetTerminationStatusImpl(handle, true /* can_block */, exit_code);
+  if (handle == kCastanetsProcessHandle)
+    return GetTerminationStatusImpl(handle, true /* can_block */, exit_code);
 #endif
 
   bool result = kill(handle, SIGKILL) == 0;

--- a/base/process/process_handle.h
+++ b/base/process/process_handle.h
@@ -42,6 +42,8 @@ typedef pid_t ProcessHandle;
 typedef pid_t ProcessId;
 const ProcessHandle kNullProcessHandle = 0;
 const ProcessId kNullProcessId = 0;
+const ProcessHandle kCastanetsProcessHandle = -1;
+const ProcessId kCastanetsProcessId = -1;
 #endif  // defined(OS_WIN)
 
 // To print ProcessIds portably use CrPRIdPid (based on PRIuS and friends from

--- a/base/process/process_posix.cc
+++ b/base/process/process_posix.cc
@@ -181,6 +181,13 @@ bool WaitForSingleNonChildProcess(base::ProcessHandle handle,
 bool WaitForExitWithTimeoutImpl(base::ProcessHandle handle,
                                 int* exit_code,
                                 base::TimeDelta timeout) {
+#if defined(CASTANETS)
+  if (handle == base::kCastanetsProcessHandle) {
+    *exit_code = -1;
+    return true;
+  }
+#endif
+
   const base::ProcessHandle our_pid = base::GetCurrentProcessHandle();
   if (handle == our_pid) {
     // We won't be able to wait for ourselves to exit.
@@ -275,6 +282,10 @@ void Process::TerminateCurrentProcessImmediately(int exit_code) {
 }
 
 bool Process::IsValid() const {
+#if defined(CASTANETS)
+  if (process_ == kCastanetsProcessHandle)
+    return true;
+#endif
   return process_ != kNullProcessHandle;
 }
 
@@ -290,6 +301,10 @@ Process Process::Duplicate() const {
 }
 
 ProcessId Process::Pid() const {
+#if defined(CASTANETS)
+  if (process_ == kCastanetsProcessHandle)
+    return kCastanetsProcessId;
+#endif
   DCHECK(IsValid());
   return GetProcId(process_);
 }
@@ -307,6 +322,12 @@ void Process::Close() {
 
 #if !defined(OS_NACL_NONSFI)
 bool Process::Terminate(int exit_code, bool wait) const {
+#if defined(CASTANETS)
+  if (process_ == kCastanetsProcessHandle) {
+    // TODO(hw1008.kim): We have to send exit_code to the remote child process?
+    return true;
+  }
+#endif
   // exit_code isn't supportable.
   DCHECK(IsValid());
   CHECK_GT(process_, 0);
@@ -368,6 +389,10 @@ bool Process::SetProcessBackgrounded(bool value) {
 #endif  // !defined(OS_LINUX) && !defined(OS_MACOSX) && !defined(OS_AIX)
 
 int Process::GetPriority() const {
+#if defined(CASTANETS)
+  if (process_ == kCastanetsProcessHandle)
+    return  0; // The default priority is 0
+#endif
   DCHECK(IsValid());
   return getpriority(PRIO_PROCESS, process_);
 }


### PR DESCRIPTION
- Use kCastanetsProcessHandle instead of the hard-coded process handle.
- Add process_castanets.cc to handle IsValid() checks and
  to avoid system API calls.
- Remove some code branches by defined(CASTANETS).