### PR TITLE
Support communication between linux and android

### DIFF
--- a/ipc/ipc_message_macros.h
+++ b/ipc/ipc_message_macros.h
@@ -256,7 +256,7 @@
   struct IPC_MESSAGE_EXPORT msg_name##_Meta {                       \
     using InTuple = in_tuple;                                       \
     using OutTuple = out_tuple;                                     \
-    enum { ID = IPC_MESSAGE_ID() };                                 \
+    enum { ID = IPC_MESSAGE_ID(#msg_name) };                        \
     static const IPC::MessageKind kKind = IPC::MessageKind::kind;   \
     static const char kName[];                                      \
   };                                                                \
@@ -314,9 +314,38 @@
 // Note: we currently use __LINE__ to give unique IDs to messages within
 // a file.  They're globally unique since each file defines its own
 // IPC_MESSAGE_START.
-#define IPC_MESSAGE_ID() ((IPC_MESSAGE_START << 16) + __LINE__)
+#if defined(CASTANETS)
+// Use HASH_MSG_NAME() instead of __LINE__ for unique IDs.
+// The HASH_MSG_NAME() function should ensure unique IDs without collisions.
+// TODO: If hash IDs of messages have collisions, a build error will occur.
+constexpr uint32_t HASH_MSG_NAME(const char* s) {
+  uint32_t hash = 0;
+  const int prime = 2;
+
+  for (; *s; s++) {
+    int ch = *s;
+    if ('a' <= ch && ch <= 'z')
+      ch -= 'a';
+    else if ('A' <= ch && ch <= 'Z')
+      ch -= 'A';
+    else if ('0' <= ch && ch <= '9')
+      ch -= '0' + 26;
+    else
+      continue;
+    hash += hash * prime + ch;
+  }
+
+  return hash;
+}
+#define IPC_MESSAGE_ID(msg_name) \
+  ((IPC_MESSAGE_START << 25) | (HASH_MSG_NAME(msg_name) & 0x1ffffff))
+#define IPC_MESSAGE_ID_CLASS(id) ((id) >> 25)
+#define IPC_MESSAGE_ID_LINE(id) ((id)&0x1ffffff)
+#else
+#define IPC_MESSAGE_ID(msg_name) ((IPC_MESSAGE_START << 16) + __LINE__)
 #define IPC_MESSAGE_ID_CLASS(id) ((id) >> 16)
 #define IPC_MESSAGE_ID_LINE(id) ((id) & 0xffff)
+#endif
 
 // Message crackers and handlers. Usage:
 //

--- a/mojo/core/BUILD.gn
+++ b/mojo/core/BUILD.gn
@@ -168,7 +168,7 @@ template("core_impl_source_set") {
 
     # Use target_os == "chromeos" instead of is_chromeos because we need to
     # build NaCl targets (i.e. IRT) for ChromeOS the same as the rest of ChromeOS.
-    if (is_android || target_os == "chromeos") {
+    if ((is_android && !enable_castanets) || target_os == "chromeos") {
       defines += [ "MOJO_CORE_LEGACY_PROTOCOL" ]
     }
   }

--- a/mojo/public/tools/bindings/mojom.gni
+++ b/mojo/public/tools/bindings/mojom.gni
@@ -14,6 +14,7 @@ import("//build/config/nacl/config.gni")
 import("//components/nacl/features.gni")
 import("//third_party/jinja2/jinja2.gni")
 import("//tools/ipc_fuzzer/ipc_fuzzer.gni")
+import("//build/config/features.gni")
 
 declare_args() {
   # Indicates whether typemapping should be supported in this build
@@ -48,7 +49,7 @@ declare_args() {
 # check |target_os| explicitly, as it's consistent across all toolchains.
 enable_scrambled_message_ids =
     enable_mojom_message_id_scrambling &&
-    (is_mac || is_win || (is_linux && !is_chromeos) ||
+    (is_mac || is_win || (is_linux && !is_chromeos && !enable_castanets) ||
      ((enable_nacl || is_nacl || is_nacl_nonsfi) && target_os != "chromeos"))
 
 mojom_generator_root = "//mojo/public/tools/bindings"


### PR DESCRIPTION
i. Cherry picked c26cc556 from castanets_63.
ii. MOJO_CORE_LEGACY_PROTOCOL changes BrokerMessageHeader, which makes browser process's broker msgs left unidentified in android.
iii. Disable scrambling msg ids for linix as well.