### PR TITLE
This change fixes the compile error of non-Castanets build

### DIFF
--- a/content/browser/service_manager/service_manager_context.cc
+++ b/content/browser/service_manager/service_manager_context.cc
@@ -673,7 +673,6 @@ ServiceManagerContext::ServiceManagerContext(
         base::BindRepeating(&base::ASCIIToUTF16, "Visuals Service");
   }
 
-#if !defined(CASTANETS)
   for (const auto& service : out_of_process_services) {
     packaged_services_connection_->AddServiceRequestHandlerWithPID(
         service.first,
@@ -681,7 +680,6 @@ ServiceManagerContext::ServiceManagerContext(
                             service.first, service.second.process_name_callback,
                             service.second.process_group));
   }
-#endif
 
 #if BUILDFLAG(ENABLE_MOJO_MEDIA_IN_GPU_PROCESS)
   packaged_services_connection_->AddServiceRequestHandlerWithPID(

--- a/mojo/core/node_controller.cc
+++ b/mojo/core/node_controller.cc
@@ -1162,44 +1162,52 @@ void NodeController::OnIntroduce(const ports::NodeName& from_node,
   DCHECK(io_task_runner_->RunsTasksInCurrentSequence());
 
   if (!channel_handle.is_valid()) {
+#if defined(CASTANETS)
+    NamedPlatformChannel::ServerName shmem_name = ".org.castanets.Castanets.shmem.network";
+    std::string process_type_str =
+        base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type");
+    if (process_type_str == "utility") {
+      NamedPlatformChannel::Options options;
+      options.server_name = shmem_name;
+      mojo::NamedPlatformChannel named_channel(options);
+      scoped_refptr<NodeChannel> channel = NodeChannel::Create(
+        this,
+        ConnectionParams(named_channel.TakeServerEndpoint()),
+        io_task_runner_, ProcessErrorCallback());
+      DVLOG(1) << "Adding new peer " << name << " via broker introduction.";
+      AddPeer(name, channel, true /* start_channel */);
+    }
+    else {
+      PlatformChannelEndpoint channel_endpoint;
+      for (int nsec = 1; nsec <= 128; nsec <<= 1) {
+        channel_endpoint = NamedPlatformChannel::ConnectToServer(shmem_name);
+        if (channel_endpoint.is_valid())
+          break;
+        if (nsec <= 128 / 2)
+          sleep(nsec);
+      }
+      scoped_refptr<NodeChannel> channel =
+          NodeChannel::Create(this, ConnectionParams(std::move(channel_endpoint)),
+                              io_task_runner_, ProcessErrorCallback());
+      DVLOG(1) << "Adding new peer " << name << " via broker introduction.";
+      AddPeer(name, channel, true /* start_channel */);
+    }
+#else
     node_->LostConnectionToNode(name);
 
     DVLOG(1) << "Could not be introduced to peer " << name;
     base::AutoLock lock(peers_lock_);
     pending_peer_messages_.erase(name);
+#endif
     return;
   }
 
-#if defined(CASTANETS)
-  std::string process_type_str =
-      base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type");
-  if (process_type_str == "utility") {
-    scoped_refptr<NodeChannel> channel = NodeChannel::Create(
-        this,
-        ConnectionParams(mojo::PlatformChannelServerEndpoint(
-            mojo::CreateTCPServerHandle(mojo::kCastanetsNonBrokerPort))),
-        io_task_runner_, ProcessErrorCallback());
-    DVLOG(1) << "Adding new peer " << name << " via broker introduction.";
-    AddPeer(name, channel, true /* start_channel */);
-  }
-  else {
-    scoped_refptr<NodeChannel> channel = NodeChannel::Create(
-        this,
-        ConnectionParams(PlatformChannelEndpoint(
-            mojo::CreateTCPClientHandle(mojo::kCastanetsNonBrokerPort))),
-        io_task_runner_, ProcessErrorCallback());
-    DVLOG(1) << "Adding new peer " << name << " via broker introduction.";
-    AddPeer(name, channel, true /* start_channel */);
-  }
-#else
   scoped_refptr<NodeChannel> channel = NodeChannel::Create(
       this,
       ConnectionParams(PlatformChannelEndpoint(std::move(channel_handle))),
       io_task_runner_, ProcessErrorCallback());
       DVLOG(1) << "Adding new peer " << name << " via broker introduction.";
       AddPeer(name, channel, true /* start_channel */);
-#endif
-
 }
 
 void NodeController::OnBroadcast(const ports::NodeName& from_node,

--- a/mojo/public/cpp/platform/tcp_platform_handle_utils.h
+++ b/mojo/public/cpp/platform/tcp_platform_handle_utils.h
@@ -18,7 +18,6 @@ namespace mojo {
 
 const size_t kCastanetsRendererPort = 8008;
 const size_t kCastanetsUtilityPort = 7007;
-const size_t kCastanetsNonBrokerPort = 5005;
 
 COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
 PlatformHandle CreateTCPClientHandle(const uint16_t port,


### PR DESCRIPTION
and Castanest debug build(with the flag, enable_nacl=true).

Below changes are included.

1) Guard Castanets specific functions in mojo entrypoints' g_thunks.
2) Remove debug build compile error messages by guarding the corresponding codes.