### PR TITLE
Fix the issue that broken tiles are shown.

### DIFF
--- a/cc/raster/one_copy_raster_buffer_provider.cc
+++ b/cc/raster/one_copy_raster_buffer_provider.cc
@@ -364,7 +364,7 @@ void OneCopyRasterBufferProvider::PlaybackToStagingBuffer(
         base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
       mojo::SyncSharedMemoryHandle(
           buffer->GetHandle().handle.GetGUID(), 0,
-          raster_full_rect.width() * raster_full_rect.height() * 4);
+          staging_buffer->size.width() * staging_buffer->size.height() * 4);
     }
 #endif
     buffer->Unmap();

--- a/cc/tiles/tile_manager.cc
+++ b/cc/tiles/tile_manager.cc
@@ -137,7 +137,7 @@ class RasterTaskImpl : public TileTask {
       ResourcePool::SoftwareBacking* sw_backing = resource_.software_backing();
       if (sw_backing)
         mojo::SyncSharedMemoryHandle(sw_backing->SharedMemoryGuid(),
-            0, content_rect_.width() * content_rect_.height() * 4);
+            0, resource_.size().width() * resource_.size().height() * 4);
     }
 #endif
   }


### PR DESCRIPTION
This issue occurs when resources are reused for tiles of different sizes.
If a mapped shared memory size is bigger than a tile size,
memory sync should be done with full shared memory size.
Memory sync is not supporting partial sync.