### PR TITLE
Add CastanetsMemoryMapping class.

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -1187,7 +1187,7 @@ jumbo_component("base") {
       "timer/hi_res_timer_manager_posix.cc",
     ]
   }
-  
+
   if (enable_castanets) {
     sources += [
       "memory/castanets_memory_mapping.cc",

--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -1187,6 +1187,13 @@ jumbo_component("base") {
       "timer/hi_res_timer_manager_posix.cc",
     ]
   }
+  
+  if (enable_castanets) {
+    sources += [
+      "memory/castanets_memory_mapping.cc",
+      "memory/castanets_memory_mapping.h",
+    ]
+  }
 
   if (!is_nacl) {
     sources += [

--- a/base/memory/castanets_memory_mapping.cc
+++ b/base/memory/castanets_memory_mapping.cc
@@ -9,14 +9,14 @@
 namespace base {
 
 scoped_refptr<CastanetsMemoryMapping> CastanetsMemoryMapping::Create(
-    const UnguessableToken& id, size_t size) {
+    const UnguessableToken& id,
+    size_t size) {
   return new CastanetsMemoryMapping(id, size);
 }
 
-CastanetsMemoryMapping::CastanetsMemoryMapping(
-    const UnguessableToken& id, size_t size)
-  : guid_(id),
-    mapped_size_(size) {}
+CastanetsMemoryMapping::CastanetsMemoryMapping(const UnguessableToken& id,
+                                               size_t size)
+    : guid_(id), mapped_size_(size) {}
 
 CastanetsMemoryMapping::~CastanetsMemoryMapping() {
   CHECK(addresses_.empty());
@@ -43,8 +43,8 @@ void* CastanetsMemoryMapping::GetMemory() {
 
 void* CastanetsMemoryMapping::MapForSync(int fd) {
   CHECK(fd != -1);
-  void* memory = mmap(NULL, mapped_size_, PROT_READ | PROT_WRITE, MAP_SHARED,
-                      fd, 0);
+  void* memory =
+      mmap(NULL, mapped_size_, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   CHECK(memory);
   AddMapping(memory);
   return memory;

--- a/base/memory/castanets_memory_mapping.cc
+++ b/base/memory/castanets_memory_mapping.cc
@@ -1,0 +1,59 @@
+// Copyright 2019 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <sys/mman.h>
+
+#include "base/memory/castanets_memory_mapping.h"
+
+namespace base {
+
+scoped_refptr<CastanetsMemoryMapping> CastanetsMemoryMapping::Create(
+    const UnguessableToken& id, size_t size) {
+  return new CastanetsMemoryMapping(id, size);
+}
+
+CastanetsMemoryMapping::CastanetsMemoryMapping(
+    const UnguessableToken& id, size_t size)
+  : guid_(id),
+    mapped_size_(size) {}
+
+CastanetsMemoryMapping::~CastanetsMemoryMapping() {
+  CHECK(addresses_.empty());
+}
+
+void CastanetsMemoryMapping::AddMapping(void* address) {
+  addresses_.push_back(address);
+}
+
+void CastanetsMemoryMapping::RemoveMapping(void* address) {
+  for (auto it = addresses_.begin(); it < addresses_.end(); ++it) {
+    if (*it == address) {
+      addresses_.erase(it);
+      return;
+    }
+  }
+  NOTREACHED();
+}
+
+void* CastanetsMemoryMapping::GetMemory() {
+  CHECK(HasMapping());
+  return *(addresses_.begin());
+}
+
+void* CastanetsMemoryMapping::MapForSync(int fd) {
+  CHECK(fd != -1);
+  void* memory = mmap(NULL, mapped_size_, PROT_READ | PROT_WRITE, MAP_SHARED,
+                      fd, 0);
+  CHECK(memory);
+  AddMapping(memory);
+  return memory;
+}
+
+void CastanetsMemoryMapping::UnmapForSync(void* memory) {
+  CHECK(memory);
+  munmap(memory, mapped_size_);
+  RemoveMapping(memory);
+}
+
+}  // namespace base

--- a/base/memory/castanets_memory_mapping.h
+++ b/base/memory/castanets_memory_mapping.h
@@ -7,8 +7,8 @@
 
 #include <vector>
 
-#include "base/unguessable_token.h"
 #include "base/memory/ref_counted.h"
+#include "base/unguessable_token.h"
 
 namespace base {
 
@@ -16,7 +16,8 @@ class BASE_EXPORT CastanetsMemoryMapping
     : public RefCountedThreadSafe<CastanetsMemoryMapping> {
  public:
   static scoped_refptr<CastanetsMemoryMapping> Create(
-      const UnguessableToken& id, size_t size);
+      const UnguessableToken& id,
+      size_t size);
 
   void AddMapping(void* address);
   void RemoveMapping(void* address);
@@ -44,4 +45,4 @@ class BASE_EXPORT CastanetsMemoryMapping
 
 }  // namespace base
 
-#endif // BASE_MEMORY_CASTANETS_MEMORY_MAPPING_H_
+#endif  // BASE_MEMORY_CASTANETS_MEMORY_MAPPING_H_

--- a/base/memory/castanets_memory_mapping.h
+++ b/base/memory/castanets_memory_mapping.h
@@ -1,0 +1,47 @@
+// Copyright 2019 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef BASE_MEMORY_CASTANETS_MEMORY_MAPPING_H_
+#define BASE_MEMORY_CASTANETS_MEMORY_MAPPING_H_
+
+#include <vector>
+
+#include "base/unguessable_token.h"
+#include "base/memory/ref_counted.h"
+
+namespace base {
+
+class BASE_EXPORT CastanetsMemoryMapping
+    : public RefCountedThreadSafe<CastanetsMemoryMapping> {
+ public:
+  static scoped_refptr<CastanetsMemoryMapping> Create(
+      const UnguessableToken& id, size_t size);
+
+  void AddMapping(void* address);
+  void RemoveMapping(void* address);
+
+  UnguessableToken guid() const { return guid_; }
+  size_t mapped_size() const { return mapped_size_; }
+  void* GetMemory();
+
+  bool HasMapping() const { return !addresses_.empty(); }
+
+  void* MapForSync(int fd);
+  void UnmapForSync(void* memory);
+
+ private:
+  friend class base::RefCountedThreadSafe<CastanetsMemoryMapping>;
+
+  CastanetsMemoryMapping(const UnguessableToken& id, size_t size);
+  ~CastanetsMemoryMapping();
+
+  UnguessableToken guid_;
+  size_t mapped_size_ = 0;
+
+  std::vector<void*> addresses_;
+};
+
+}  // namespace base
+
+#endif // BASE_MEMORY_CASTANETS_MEMORY_MAPPING_H_

--- a/base/memory/castanets_memory_mapping.h
+++ b/base/memory/castanets_memory_mapping.h
@@ -41,6 +41,8 @@ class BASE_EXPORT CastanetsMemoryMapping
   size_t mapped_size_ = 0;
 
   std::vector<void*> addresses_;
+
+  DISALLOW_COPY_AND_ASSIGN(CastanetsMemoryMapping);
 };
 
 }  // namespace base

--- a/base/memory/shared_memory_tracker.cc
+++ b/base/memory/shared_memory_tracker.cc
@@ -65,8 +65,7 @@ void SharedMemoryTracker::IncrementMemoryUsage(
   usages_.emplace(shared_memory.memory(), UsageInfo(shared_memory.mapped_size(),
                                                     shared_memory.mapped_id()));
 #if defined(CASTANETS)
-  AddMapping(shared_memory.mapped_id(),
-             shared_memory.mapped_size(),
+  AddMapping(shared_memory.mapped_id(), shared_memory.mapped_size(),
              shared_memory.memory());
 #endif
 }
@@ -79,9 +78,7 @@ void SharedMemoryTracker::IncrementMemoryUsage(
                   UsageInfo(mapping.mapped_size(), mapping.guid()));
 
 #if defined(CASTANETS)
-  AddMapping(mapping.guid(),
-             mapping.mapped_size(),
-             mapping.raw_memory_ptr());
+  AddMapping(mapping.guid(), mapping.mapped_size(), mapping.raw_memory_ptr());
 #endif
 }
 
@@ -108,8 +105,9 @@ void SharedMemoryTracker::DecrementMemoryUsage(
 }
 
 #if defined(CASTANETS)
-void SharedMemoryTracker::AddMapping(
-    const UnguessableToken& guid, size_t size, void* ptr) {
+void SharedMemoryTracker::AddMapping(const UnguessableToken& guid,
+                                     size_t size,
+                                     void* ptr) {
   auto it = mappings_.find(guid);
   if (it == mappings_.end()) {
     scoped_refptr<CastanetsMemoryMapping> castanets_mapping =
@@ -120,8 +118,8 @@ void SharedMemoryTracker::AddMapping(
     it->second->AddMapping(ptr);
 }
 
-void SharedMemoryTracker::RemoveMapping(
-    const UnguessableToken& guid, void* ptr) {
+void SharedMemoryTracker::RemoveMapping(const UnguessableToken& guid,
+                                        void* ptr) {
   auto it = mappings_.find(guid);
   CHECK(it != mappings_.end());
   it->second->RemoveMapping(ptr);

--- a/base/memory/shared_memory_tracker.cc
+++ b/base/memory/shared_memory_tracker.cc
@@ -114,8 +114,10 @@ void SharedMemoryTracker::AddMapping(const UnguessableToken& guid,
         CastanetsMemoryMapping::Create(guid, size);
     castanets_mapping->AddMapping(ptr);
     mappings_.emplace(guid, castanets_mapping);
-  } else
+  } else {
+    CHECK_EQ(size, it->second->mapped_size());
     it->second->AddMapping(ptr);
+  }
 }
 
 void SharedMemoryTracker::RemoveMapping(const UnguessableToken& guid,

--- a/mojo/core/broker_castanets.cc
+++ b/mojo/core/broker_castanets.cc
@@ -237,8 +237,8 @@ void BrokerCastanets::OnBufferSync(uint64_t guid_high, uint64_t guid_low,
       base::SharedMemoryTracker::GetInstance()->FindMappedMemory(guid);
   if (mapping) {
     CHECK_GE(mapping->mapped_size(), offset + sync_bytes);
-    memcpy(static_cast<uint8_t*>(mapping->GetMemory()) + offset,
-           data, sync_bytes);
+    memcpy(static_cast<uint8_t*>(mapping->GetMemory()) + offset, data,
+           sync_bytes);
 
     SendSyncAck(guid_high, guid_low);
     return;

--- a/mojo/core/broker_castanets.cc
+++ b/mojo/core/broker_castanets.cc
@@ -9,6 +9,7 @@
 
 #include "base/bind.h"
 #include "base/logging.h"
+#include "base/memory/castanets_memory_mapping.h"
 #include "base/memory/platform_shared_memory_region.h"
 #include "base/memory/shared_memory_helper.h"
 #include "base/memory/shared_memory_tracker.h"
@@ -166,7 +167,7 @@ bool BrokerCastanets::SyncSharedBuffer(
   if (!tcp_connection_)
     return true;
 
-  const base::SharedMemoryTracker::MappingInfo* mapping =
+  scoped_refptr<base::CastanetsMemoryMapping> mapping =
       base::SharedMemoryTracker::GetInstance()->FindMappedMemory(guid);
   if (!mapping) {
     if (base::SharedMemoryTracker::GetInstance()->Find(guid) < 0)
@@ -174,8 +175,8 @@ bool BrokerCastanets::SyncSharedBuffer(
     else
       return MOJO_RESULT_UNIMPLEMENTED;
   }
-  SyncSharedBufferImpl(guid, static_cast<uint8_t*>(mapping->mapped_memory),
-                       offset, sync_size, mapping->mapped_size);
+  SyncSharedBufferImpl(guid, static_cast<uint8_t*>(mapping->GetMemory()),
+                       offset, sync_size, mapping->mapped_size());
   return true;
 }
 
@@ -232,11 +233,11 @@ void BrokerCastanets::OnBufferSync(uint64_t guid_high, uint64_t guid_low,
           << ", sync_size: " << sync_bytes
           << ", buffer_size: " << buffer_bytes;
 
-  const base::SharedMemoryTracker::MappingInfo* mapping =
+  scoped_refptr<base::CastanetsMemoryMapping> mapping =
       base::SharedMemoryTracker::GetInstance()->FindMappedMemory(guid);
   if (mapping) {
-    CHECK_GE(mapping->mapped_size, offset + sync_bytes);
-    memcpy(static_cast<uint8_t*>(mapping->mapped_memory) + offset,
+    CHECK_GE(mapping->mapped_size(), offset + sync_bytes);
+    memcpy(static_cast<uint8_t*>(mapping->GetMemory()) + offset,
            data, sync_bytes);
 
     SendSyncAck(guid_high, guid_low);


### PR DESCRIPTION
- replace the simple struct MappingInfo.
- keep all memory pointers by multiple map().
- has map/unmap methods for sync.