### PR TITLE
Enable WebGL and Canvas2D on Castanets.

### DIFF
--- a/gpu/command_buffer/client/cmd_buffer_helper.cc
+++ b/gpu/command_buffer/client/cmd_buffer_helper.cc
@@ -421,4 +421,12 @@ bool CommandBufferHelper::OnMemoryDump(
   return true;
 }
 
+#if defined(CASTANETS)
+void CommandBufferHelper::RequestSyncTransferBuffer(int32_t id,
+                                                    uint32_t offset,
+                                                    uint32_t size) {
+  command_buffer_->RequestSyncTransferBuffer(id, offset, size);
+}
+#endif
+
 }  // namespace gpu

--- a/gpu/command_buffer/client/cmd_buffer_helper.h
+++ b/gpu/command_buffer/client/cmd_buffer_helper.h
@@ -273,6 +273,10 @@ class GPU_EXPORT CommandBufferHelper
 
   int32_t GetPutOffsetForTest() const { return put_; }
 
+#if defined(CASTANETS)
+  void RequestSyncTransferBuffer(int32_t id, uint32_t offset, uint32_t size);
+#endif
+
  private:
   void CalcImmediateEntries(int waiting_count);
   bool AllocateRingBuffer();

--- a/gpu/command_buffer/client/fenced_allocator.cc
+++ b/gpu/command_buffer/client/fenced_allocator.cc
@@ -146,6 +146,15 @@ unsigned int FencedAllocator::GetFreeSize() {
   return size;
 }
 
+#if defined(CASTANETS)
+unsigned int FencedAllocator::GetBlockSize(Offset offset) {
+  BlockIndex index = GetBlockByOffset(offset);
+  Block& block = blocks_[index];
+  DCHECK_EQ(block.offset, offset);
+  return block.size;
+}
+#endif
+
 // Makes sure that:
 // - there is at least one block.
 // - there are no contiguous FREE blocks (they should have been collapsed).

--- a/gpu/command_buffer/client/fenced_allocator.h
+++ b/gpu/command_buffer/client/fenced_allocator.h
@@ -88,6 +88,10 @@ class GPU_EXPORT FencedAllocator {
   // Gets the total size of all free blocks that are available without waiting.
   unsigned int GetFreeSize();
 
+#if defined(CASTANETS)
+  unsigned int GetBlockSize(Offset offset);
+#endif
+
   // Checks for consistency inside the book-keeping structures. Used for
   // testing.
   bool CheckConsistency();
@@ -244,6 +248,12 @@ class FencedAllocatorWrapper {
 
   // Gets the total size of all free blocks.
   unsigned int GetFreeSize() { return allocator_.GetFreeSize(); }
+
+#if defined(CASTANETS)
+  unsigned int GetBlockSize(void* pointer) {
+    return allocator_.GetBlockSize(GetOffset(pointer));
+  }
+#endif
 
   // Checks for consistency inside the book-keeping structures. Used for
   // testing.

--- a/gpu/command_buffer/client/implementation_base.cc
+++ b/gpu/command_buffer/client/implementation_base.cc
@@ -16,6 +16,11 @@
 #include "gpu/command_buffer/client/shared_memory_limits.h"
 #include "gpu/command_buffer/common/sync_token.h"
 
+#if defined(CASTANETS)
+#include "base/command_line.h"
+#include "mojo/public/cpp/system/platform_handle.h"
+#endif
+
 namespace gpu {
 
 #if !defined(_MSC_VER)
@@ -173,7 +178,27 @@ gpu::ContextResult ImplementationBase::Initialize(
 
 void ImplementationBase::WaitForCmd() {
   TRACE_EVENT0("gpu", "ImplementationBase::WaitForCmd");
+#if defined(CASTANETS)
+  // Synchronize the result share memory because the result may have been
+  // preset.
+  if (std::string("renderer") ==
+      base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
+    mojo::SyncSharedMemoryHandle(transfer_buffer_->shared_memory_guid(),
+                                 GetResultShmOffset(), kMaxSizeOfSimpleResult);
+  }
+#endif
+
   helper_->Finish();
+
+#if defined(CASTANETS)
+  // Request to synchronize shared memory of transfer buffer to get the result
+  // of api.
+  if (std::string("renderer") ==
+      base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
+    helper_->CommandBufferHelper::RequestSyncTransferBuffer(
+        GetResultShmId(), GetResultShmOffset(), kMaxSizeOfSimpleResult);
+  }
+#endif
 }
 
 void* ImplementationBase::GetResultBuffer() {
@@ -207,6 +232,14 @@ bool ImplementationBase::GetBucketContents(uint32_t bucket_id,
                           buffer.size(), buffer.shm_id(), buffer.offset());
   WaitForCmd();
   uint32_t size = *result;
+#if defined(CASTANETS)
+  // Request to synchronize shared memory of transfer buffer to get bucket data.
+  if (std::string("renderer") ==
+      base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
+    helper_->CommandBufferHelper::RequestSyncTransferBuffer(
+        buffer.shm_id(), buffer.offset(), size);
+  }
+#endif
   data->resize(size);
   if (size > 0u) {
     uint32_t offset = 0;
@@ -219,6 +252,14 @@ bool ImplementationBase::GetBucketContents(uint32_t bucket_id,
         helper_->GetBucketData(bucket_id, offset, buffer.size(),
                                buffer.shm_id(), buffer.offset());
         WaitForCmd();
+#if defined(CASTANETS)
+        if (std::string("renderer") ==
+            base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(
+                "type")) {
+          helper_->CommandBufferHelper::RequestSyncTransferBuffer(
+              buffer.shm_id(), buffer.offset(), buffer.size());
+        }
+#endif
       }
       uint32_t size_to_copy = std::min(size, buffer.size());
       memcpy(&(*data)[offset], buffer.address(), size_to_copy);

--- a/gpu/command_buffer/client/mapped_memory.h
+++ b/gpu/command_buffer/client/mapped_memory.h
@@ -17,6 +17,11 @@
 #include "gpu/command_buffer/common/buffer.h"
 #include "gpu/gpu_export.h"
 
+#if defined(CASTANETS)
+#include "base/command_line.h"
+#include "mojo/public/cpp/system/platform_handle.h"
+#endif
+
 namespace gpu {
 
 class CommandBufferHelper;
@@ -88,6 +93,14 @@ class GPU_EXPORT MemoryChunk {
   //   token: the token value to wait for before re-using the memory.
   void FreePendingToken(void* pointer, unsigned int token) {
     allocator_.FreePendingToken(pointer, token);
+#if defined(CASTANETS)
+    if (std::string("renderer") ==
+        base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
+      mojo::SyncSharedMemoryHandle(shm_->backing()->GetGUID(),
+                                   GetOffset(pointer),
+                                   allocator_.GetBlockSize(pointer));
+    }
+#endif
   }
 
   // Frees any blocks whose tokens have passed.

--- a/gpu/command_buffer/client/ring_buffer.cc
+++ b/gpu/command_buffer/client/ring_buffer.cc
@@ -186,6 +186,20 @@ unsigned int RingBuffer::GetTotalFreeSizeNoWaiting() {
   }
 }
 
+#if defined(CASTANETS)
+unsigned int RingBuffer::GetBlockSize(void* pointer) {
+  Offset offset = GetOffset(pointer);
+  offset -= base_offset_;
+  for (Container::reverse_iterator it = blocks_.rbegin(); it != blocks_.rend();
+       ++it) {
+    Block& block = *it;
+    if (block.offset == offset)
+      return block.size;
+  }
+  return 0;
+}
+#endif
+
 void RingBuffer::ShrinkLastBlock(unsigned int new_size) {
   if (blocks_.empty())
     return;

--- a/gpu/command_buffer/client/ring_buffer.h
+++ b/gpu/command_buffer/client/ring_buffer.h
@@ -88,6 +88,10 @@ class GPU_EXPORT RingBuffer {
     return static_cast<int8_t*>(base_) + offset;
   }
 
+#if defined(CASTANETS)
+  unsigned int GetBlockSize(void* pointer);
+#endif
+
   // Gets the offset to a memory block given the base memory and the address.
   RingBuffer::Offset GetOffset(void* pointer) const {
     return static_cast<int8_t*>(pointer) - static_cast<int8_t*>(base_);

--- a/gpu/command_buffer/client/transfer_buffer.cc
+++ b/gpu/command_buffer/client/transfer_buffer.cc
@@ -14,6 +14,11 @@
 #include "base/trace_event/trace_event.h"
 #include "gpu/command_buffer/client/cmd_buffer_helper.h"
 
+#if defined(CASTANETS)
+#include "base/command_line.h"
+#include "mojo/public/cpp/system/platform_handle.h"
+#endif
+
 namespace gpu {
 
 TransferBuffer::TransferBuffer(CommandBufferHelper* helper)
@@ -85,6 +90,13 @@ void TransferBuffer::DiscardBlock(void* p) {
 
 void TransferBuffer::FreePendingToken(void* p, unsigned int token) {
   ring_buffer_->FreePendingToken(p, token);
+#if defined(CASTANETS)
+  if (std::string("renderer") ==
+      base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
+    mojo::SyncSharedMemoryHandle(shared_memory_guid(), GetOffset(p),
+                                 ring_buffer_->GetBlockSize(p));
+  }
+#endif
 }
 
 unsigned int TransferBuffer::GetSize() const {

--- a/gpu/command_buffer/common/command_buffer.h
+++ b/gpu/command_buffer/common/command_buffer.h
@@ -116,6 +116,12 @@ class GPU_EXPORT CommandBuffer {
   // Destroy a transfer buffer. The ID must be positive.
   virtual void DestroyTransferBuffer(int32_t id) = 0;
 
+#if defined(CASTANETS)
+  virtual void RequestSyncTransferBuffer(int32_t id,
+                                         uint32_t offset,
+                                         uint32_t size) {}
+#endif
+
  private:
   DISALLOW_COPY_AND_ASSIGN(CommandBuffer);
 };

--- a/gpu/command_buffer/service/command_buffer_service.cc
+++ b/gpu/command_buffer/service/command_buffer_service.cc
@@ -16,6 +16,10 @@
 #include "gpu/command_buffer/common/command_buffer_shared.h"
 #include "gpu/command_buffer/service/transfer_buffer_manager.h"
 
+#if defined(CASTANETS)
+#include "mojo/public/cpp/system/platform_handle.h"
+#endif
+
 namespace gpu {
 
 namespace {
@@ -176,6 +180,15 @@ scoped_refptr<Buffer> CommandBufferService::CreateTransferBuffer(size_t size,
 void CommandBufferService::DestroyTransferBuffer(int32_t id) {
   transfer_buffer_manager_->DestroyTransferBuffer(id);
 }
+
+#if defined(CASTANETS)
+void CommandBufferService::RequestSyncTransferBuffer(int32_t id,
+                                                     uint32_t offset,
+                                                     uint32_t size) {
+  BufferBacking* backing = GetTransferBuffer(id)->backing();
+  mojo::SyncSharedMemoryHandle(backing->GetGUID(), offset, size);
+}
+#endif
 
 scoped_refptr<Buffer> CommandBufferService::GetTransferBuffer(int32_t id) {
   return transfer_buffer_manager_->GetTransferBuffer(id);

--- a/gpu/command_buffer/service/command_buffer_service.h
+++ b/gpu/command_buffer/service/command_buffer_service.h
@@ -105,6 +105,10 @@ class GPU_EXPORT CommandBufferService : public CommandBufferServiceBase {
   // Unregisters and destroys the transfer buffer associated with the given id.
   void DestroyTransferBuffer(int32_t id);
 
+#if defined(CASTANETS)
+  void RequestSyncTransferBuffer(int32_t id, uint32_t offset, uint32_t size);
+#endif
+
   // Creates an in-process transfer buffer and register it with a newly created
   // id.
   scoped_refptr<Buffer> CreateTransferBuffer(size_t size, int32_t* id);

--- a/gpu/ipc/client/command_buffer_proxy_impl.cc
+++ b/gpu/ipc/client/command_buffer_proxy_impl.cc
@@ -669,6 +669,18 @@ void CommandBufferProxyImpl::ReturnFrontBuffer(const gpu::Mailbox& mailbox,
   Send(new GpuCommandBufferMsg_ReturnFrontBuffer(route_id_, mailbox, is_lost));
 }
 
+#if defined(CASTANETS)
+void CommandBufferProxyImpl::RequestSyncTransferBuffer(int32_t id,
+                                                       uint32_t offset,
+                                                       uint32_t size) {
+  CheckLock();
+  base::AutoLock lock(last_state_lock_);
+
+  Send(
+      new GpuChannelMsg_RequestSyncTransferBuffer(route_id_, id, offset, size));
+}
+#endif
+
 bool CommandBufferProxyImpl::Send(IPC::Message* msg) {
   DCHECK(channel_);
   last_state_lock_.AssertAcquired();

--- a/gpu/ipc/client/command_buffer_proxy_impl.h
+++ b/gpu/ipc/client/command_buffer_proxy_impl.h
@@ -155,6 +155,12 @@ class GPU_EXPORT CommandBufferProxyImpl : public gpu::CommandBuffer,
   }
   uint32_t CreateStreamTexture(uint32_t texture_id);
 
+#if defined(CASTANETS)
+  void RequestSyncTransferBuffer(int32_t id,
+                                 uint32_t offset,
+                                 uint32_t size) override;
+#endif
+
  private:
   typedef std::map<int32_t, scoped_refptr<gpu::Buffer>> TransferBufferMap;
   typedef base::hash_map<uint32_t, base::OnceClosure> SignalTaskMap;

--- a/gpu/ipc/common/gpu_messages.h
+++ b/gpu/ipc/common/gpu_messages.h
@@ -101,6 +101,13 @@ IPC_MESSAGE_CONTROL1(GpuChannelMsg_FlushCommandBuffers,
 // messages have been received.
 IPC_SYNC_MESSAGE_CONTROL0_0(GpuChannelMsg_Nop)
 
+#if defined(CASTANETS)
+IPC_SYNC_MESSAGE_ROUTED3_0(GpuChannelMsg_RequestSyncTransferBuffer,
+                           int32_t /* id */,
+                           uint32_t /* offset */,
+                           uint32_t /* size */)
+#endif
+
 #if defined(OS_ANDROID)
 //------------------------------------------------------------------------------
 // Tells the StreamTexture to send its SurfaceTexture to the browser process,

--- a/gpu/ipc/service/command_buffer_stub.cc
+++ b/gpu/ipc/service/command_buffer_stub.cc
@@ -257,6 +257,9 @@ bool CommandBufferStub::OnMessageReceived(const IPC::Message& message) {
       message.type() != GpuCommandBufferMsg_WaitForGetOffsetInRange::ID &&
       message.type() != GpuCommandBufferMsg_RegisterTransferBuffer::ID &&
       message.type() != GpuCommandBufferMsg_DestroyTransferBuffer::ID &&
+#if defined(CASTANETS)
+      message.type() != GpuCommandBufferMsg_DestroyTransferBuffer::ID &&
+#endif
       message.type() != GpuCommandBufferMsg_WaitSyncToken::ID &&
       message.type() != GpuCommandBufferMsg_SignalSyncToken::ID &&
       message.type() != GpuCommandBufferMsg_SignalQuery::ID) {
@@ -282,6 +285,10 @@ bool CommandBufferStub::OnMessageReceived(const IPC::Message& message) {
                         OnRegisterTransferBuffer);
     IPC_MESSAGE_HANDLER(GpuCommandBufferMsg_DestroyTransferBuffer,
                         OnDestroyTransferBuffer);
+#if defined(CASTANETS)
+    IPC_MESSAGE_HANDLER(GpuChannelMsg_RequestSyncTransferBuffer,
+                        OnRequestSyncTransferBuffer);
+#endif
     IPC_MESSAGE_HANDLER(GpuCommandBufferMsg_WaitSyncToken, OnWaitSyncToken)
     IPC_MESSAGE_HANDLER(GpuCommandBufferMsg_SignalSyncToken, OnSignalSyncToken)
     IPC_MESSAGE_HANDLER(GpuCommandBufferMsg_SignalQuery, OnSignalQuery)
@@ -647,6 +654,14 @@ void CommandBufferStub::OnDestroyTransferBuffer(int32_t id) {
   if (command_buffer_)
     command_buffer_->DestroyTransferBuffer(id);
 }
+
+#if defined(CASTANETS)
+void CommandBufferStub::OnRequestSyncTransferBuffer(int32_t id,
+                                                    uint32_t offset,
+                                                    uint32_t size) {
+  command_buffer_->RequestSyncTransferBuffer(id, offset, size);
+}
+#endif
 
 void CommandBufferStub::ReportState() {
   command_buffer_->UpdateState();

--- a/gpu/ipc/service/command_buffer_stub.h
+++ b/gpu/ipc/service/command_buffer_stub.h
@@ -193,6 +193,9 @@ class GPU_IPC_SERVICE_EXPORT CommandBufferStub
   void OnRegisterTransferBuffer(int32_t id,
                                 base::UnsafeSharedMemoryRegion transfer_buffer);
   void OnDestroyTransferBuffer(int32_t id);
+#if defined(CASTANETS)
+  void OnRequestSyncTransferBuffer(int32_t id, uint32_t offset, uint32_t size);
+#endif
   void OnGetTransferBuffer(int32_t id, IPC::Message* reply_message);
 
   void OnEnsureBackbuffer();


### PR DESCRIPTION
To enable WebGL, shared memories of the result, bucket and some data
need to be synchronized between GPU process and remote renderer process.
FYI, I tried to run some webgl sites (Aquarium, Toonshading) for test and
the performance was up to 30fps.