### PR TITLE
Manage BrokerHost in NodeController.

### DIFF
--- a/base/process/process_posix.cc
+++ b/base/process/process_posix.cc
@@ -182,7 +182,7 @@ bool WaitForExitWithTimeoutImpl(base::ProcessHandle handle,
                                 int* exit_code,
                                 base::TimeDelta timeout) {
 #if defined(CASTANETS)
-  if (handle == base::kCastanetsProcessHandle) {
+  if (handle < base::kCastanetsProcessHandle) {
     *exit_code = -1;
     return true;
   }
@@ -283,7 +283,7 @@ void Process::TerminateCurrentProcessImmediately(int exit_code) {
 
 bool Process::IsValid() const {
 #if defined(CASTANETS)
-  if (process_ == kCastanetsProcessHandle)
+  if (process_ < kCastanetsProcessHandle)
     return true;
 #endif
   return process_ != kNullProcessHandle;
@@ -302,7 +302,7 @@ Process Process::Duplicate() const {
 
 ProcessId Process::Pid() const {
 #if defined(CASTANETS)
-  if (process_ == kCastanetsProcessHandle)
+  if (process_ < kCastanetsProcessHandle)
     return kCastanetsProcessId;
 #endif
   DCHECK(IsValid());
@@ -323,7 +323,7 @@ void Process::Close() {
 #if !defined(OS_NACL_NONSFI)
 bool Process::Terminate(int exit_code, bool wait) const {
 #if defined(CASTANETS)
-  if (process_ == kCastanetsProcessHandle) {
+  if (process_ < kCastanetsProcessHandle) {
     // TODO(hw1008.kim): We have to send exit_code to the remote child process?
     return true;
   }
@@ -390,7 +390,7 @@ bool Process::SetProcessBackgrounded(bool value) {
 
 int Process::GetPriority() const {
 #if defined(CASTANETS)
-  if (process_ == kCastanetsProcessHandle)
+  if (process_ < kCastanetsProcessHandle)
     return  0; // The default priority is 0
 #endif
   DCHECK(IsValid());

--- a/content/browser/child_process_launcher_helper_linux.cc
+++ b/content/browser/child_process_launcher_helper_linux.cc
@@ -164,9 +164,14 @@ ChildProcessLauncherHelper::LaunchProcessOnLauncherThread(
   }
 
 #if defined(CASTANETS)
-  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kEnableForking)) {
+  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kEnableForking)) {
     Process castanets_process;
-    castanets_process.process = base::Process(base::kCastanetsProcessHandle);
+    // Positive: normal process
+    // 0: kNullProcessHandle
+    // Negative: Castanets Process
+    castanets_process.process =
+        base::Process(base::kCastanetsProcessHandle - child_process_id_);
     *launch_result = LAUNCH_RESULT_SUCCESS;
     return castanets_process;
   }

--- a/mojo/core/broker_castanets.cc
+++ b/mojo/core/broker_castanets.cc
@@ -144,17 +144,12 @@ BrokerCastanets::BrokerCastanets(base::ProcessHandle client_process,
   sync_channel_ = PlatformHandle(base::ScopedFD(
       connection_params.server_endpoint().platform_handle().GetFD().get()));
 
-  base::MessageLoopCurrent::Get()->AddDestructionObserver(this);
-
   channel_ = Channel::Create(this, std::move(connection_params),
                              base::ThreadTaskRunnerHandle::Get());
   channel_->Start();
 }
 
 BrokerCastanets::~BrokerCastanets() {
-  // We're always destroyed on the creation thread, which is the IO thread.
-  base::MessageLoopCurrent::Get()->RemoveDestructionObserver(this);
-
   if (channel_)
     channel_->ShutDown();
 }
@@ -531,12 +526,6 @@ void BrokerCastanets::OnChannelError(Channel::Error error) {
       error == Channel::Error::kReceivedMalformedData) {
     process_error_callback_.Run("Broker host received malformed message");
   }
-
-  delete this;
-}
-
-void BrokerCastanets::WillDestroyCurrentMessageLoop() {
-  delete this;
 }
 
 }  // namespace core

--- a/mojo/core/broker_castanets.h
+++ b/mojo/core/broker_castanets.h
@@ -25,8 +25,7 @@ namespace core {
 
 // The Broker is a channel to the broker process, which allows synchronous IPCs
 // to fulfill shared memory allocation requests on some platforms.
-class BrokerCastanets : public Channel::Delegate,
-                        public base::MessageLoopCurrent::DestructionObserver {
+class BrokerCastanets : public Channel::Delegate {
  public:
   // Note: This is blocking, and will wait for the first message over
   // the endpoint handle in |handle|.
@@ -80,9 +79,6 @@ class BrokerCastanets : public Channel::Delegate,
                         size_t payload_size,
                         std::vector<PlatformHandle> handles) override;
   void OnChannelError(Channel::Error error) override;
-
-  // base::MessageLoopCurrent::DestructionObserver:
-  void WillDestroyCurrentMessageLoop() override;
 
   const ProcessErrorCallback process_error_callback_;
 

--- a/mojo/core/node_controller.cc
+++ b/mojo/core/node_controller.cc
@@ -322,7 +322,9 @@ bool NodeController::SyncSharedBuffer(
     size_t sync_size) {
   if (broker_)
     return broker_->SyncSharedBuffer(guid, offset, sync_size);
-  else if (!broker_hosts_.empty()) {
+
+  base::AutoLock lock(broker_hosts_lock_);
+  if (!broker_hosts_.empty()) {
     // TODO(hw1008.kim): Assume there is only one connected node. In multiple
     // nodes scenario, we have to find a proper broker host for the
     // corresponding guid.
@@ -339,7 +341,9 @@ bool NodeController::SyncSharedBuffer(
     size_t sync_size) {
   if (broker_)
     return broker_->SyncSharedBuffer(mapping, offset, sync_size);
-  else if (!broker_hosts_.empty()) {
+
+  base::AutoLock lock(broker_hosts_lock_);
+  if (!broker_hosts_.empty()) {
     // TODO(hw1008.kim): Assume there is only one connected node. In multiple
     // nodes scenario, we have to find a proper broker host for the
     // corresponding guid.

--- a/mojo/core/node_controller.h
+++ b/mojo/core/node_controller.h
@@ -342,6 +342,10 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
   // Broker for sync shared buffer creation on behalf of broker clients.
 #if defined(CASTANETS)
   std::unique_ptr<BrokerCastanets> broker_;
+
+  base::Lock broker_hosts_lock_;
+  std::unordered_map<base::ProcessHandle, std::unique_ptr<BrokerCastanets>>
+      broker_hosts_;
 #else
   std::unique_ptr<Broker> broker_;
 #endif


### PR DESCRIPTION
When launching a child process in Castanets mode, we assigns a
unique negative process handle. This CL is to manage BrokerHosts
by the map with the handle as the key value in NodeController.