### PR TITLE
Enable GpuCompositing on android.

### DIFF
--- a/chrome/browser/android/vr/arcore_device/ar_image_transport.cc
+++ b/chrome/browser/android/vr/arcore_device/ar_image_transport.cc
@@ -85,6 +85,7 @@ bool ARImageTransport::Initialize() {
 
 void ARImageTransport::ResizeSharedBuffer(const gfx::Size& size,
                                           SharedFrameBuffer* buffer) {
+#if !defined(CASTANETS)
   DCHECK(IsOnGlThread());
 
   if (buffer->size == size)
@@ -137,6 +138,7 @@ void ARImageTransport::ResizeSharedBuffer(const gfx::Size& size,
   DVLOG(1) << __FUNCTION__ << ": resized to " << size.width() << "x"
            << size.height();
   buffer->size = size;
+#endif
 }
 
 void ARImageTransport::SetupHardwareBuffers() {

--- a/chrome/browser/android/vr/vr_shell_gl.cc
+++ b/chrome/browser/android/vr/vr_shell_gl.cc
@@ -570,6 +570,7 @@ void VrShellGl::CreateOrResizeWebVRSurface(const gfx::Size& size) {
 
 void VrShellGl::WebVrCreateOrResizeSharedBufferImage(WebXrSharedBuffer* buffer,
                                                      const gfx::Size& size) {
+#if !defined(CASTANETS)
   TRACE_EVENT0("gpu", __FUNCTION__);
   // Unbind previous image (if any).
   if (buffer->remote_image) {
@@ -612,6 +613,7 @@ void VrShellGl::WebVrCreateOrResizeSharedBufferImage(WebXrSharedBuffer* buffer,
   glBindTexture(GL_TEXTURE_EXTERNAL_OES, buffer->local_texture);
   img->BindTexImage(GL_TEXTURE_EXTERNAL_OES);
   buffer->local_glimage = std::move(img);
+#endif
 }
 
 void VrShellGl::WebVrPrepareSharedBuffer(const gfx::Size& size) {

--- a/content/app/content_main_runner_impl.cc
+++ b/content/app/content_main_runner_impl.cc
@@ -67,6 +67,7 @@
 #include "ui/gfx/switches.h"
 
 #if defined(CASTANETS)
+#include "gpu/config/gpu_switches.h"
 #include "ui/gl/gl_switches.h"
 #endif
 
@@ -750,6 +751,8 @@ int ContentMainRunnerImpl::Initialize(const ContentMainParams& params) {
                                                             "en-US");
   base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
       switches::kNumRasterThreads, "4");
+  base::CommandLine::ForCurrentProcess()->AppendSwitch(
+      switches::kIgnoreGpuBlacklist);
 
 #if defined(OS_LINUX)
   base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(

--- a/content/browser/android/content_startup_flags.cc
+++ b/content/browser/android/content_startup_flags.cc
@@ -35,12 +35,12 @@ void SetContentCommandLineFlags(bool single_process) {
   base::CommandLine::ForCurrentProcess()->AppendSwitch(
       service_manager::switches::kNoSandbox);
   base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoZygote);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      switches::kDisableGpuCompositing);
   base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
       switches::kNumRasterThreads, "4");
   base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
       switches::kLang, "en-US");
+  base::CommandLine::ForCurrentProcess()->AppendSwitch(
+      switches::kIgnoreGpuBlacklist);
 #endif
 
   if (single_process) {

--- a/gpu/ipc/common/BUILD.gn
+++ b/gpu/ipc/common/BUILD.gn
@@ -102,7 +102,7 @@ source_set("ipc_common_sources") {
       "gpu_memory_buffer_impl_native_pixmap.h",
     ]
   }
-  if (is_android) {
+  if (is_android && !enable_castanets) {
     sources += [
       "gpu_memory_buffer_impl_android_hardware_buffer.cc",
       "gpu_memory_buffer_impl_android_hardware_buffer.h",

--- a/gpu/ipc/common/gpu_memory_buffer_support.cc
+++ b/gpu/ipc/common/gpu_memory_buffer_support.cc
@@ -55,7 +55,7 @@ gfx::GpuMemoryBufferType
 GpuMemoryBufferSupport::GetNativeGpuMemoryBufferType() {
 #if defined(OS_MACOSX)
   return gfx::IO_SURFACE_BUFFER;
-#elif defined(OS_ANDROID)
+#elif defined(OS_ANDROID) && !defined(CASTANETS)
   return gfx::ANDROID_HARDWARE_BUFFER;
 #elif defined(OS_LINUX)
   return gfx::NATIVE_PIXMAP;
@@ -182,7 +182,7 @@ GpuMemoryBufferSupport::CreateGpuMemoryBufferImplFromHandle(
       return GpuMemoryBufferImplDXGI::CreateFromHandle(std::move(handle), size,
                                                        format, usage, callback);
 #endif
-#if defined(OS_ANDROID)
+#if defined(OS_ANDROID) && !defined(CASTANETS)
     case gfx::ANDROID_HARDWARE_BUFFER:
       return GpuMemoryBufferImplAndroidHardwareBuffer::CreateFromHandle(
           std::move(handle), size, format, usage, callback);

--- a/gpu/ipc/common/surface_handle.h
+++ b/gpu/ipc/common/surface_handle.h
@@ -31,8 +31,13 @@ namespace gpu {
 //
 // TODO(fuchsia): Figure out the right approach for Fuchsia.
 #if defined(GPU_SURFACE_HANDLE_IS_ACCELERATED_WINDOW)
+#if defined(CASTANETS)
+using SurfaceHandle = int32_t;
+constexpr SurfaceHandle kNullSurfaceHandle = 0;
+#else
 using SurfaceHandle = gfx::AcceleratedWidget;
 constexpr SurfaceHandle kNullSurfaceHandle = gfx::kNullAcceleratedWidget;
+#endif
 #elif defined(OS_MACOSX) || defined(OS_ANDROID) || defined(OS_NACL) || \
     defined(OS_FUCHSIA)
 using SurfaceHandle = int32_t;

--- a/gpu/ipc/service/BUILD.gn
+++ b/gpu/ipc/service/BUILD.gn
@@ -112,6 +112,12 @@ component("service") {
       "stream_texture_android.cc",
       "stream_texture_android.h",
     ]
+    if (enable_castanets) {
+      sources -= [
+        "gpu_memory_buffer_factory_android_hardware_buffer.cc",
+        "gpu_memory_buffer_factory_android_hardware_buffer.h",
+      ]
+    }
     libs += [ "android" ]
   }
   if (is_linux) {

--- a/gpu/ipc/service/gpu_memory_buffer_factory.cc
+++ b/gpu/ipc/service/gpu_memory_buffer_factory.cc
@@ -31,7 +31,7 @@ std::unique_ptr<GpuMemoryBufferFactory>
 GpuMemoryBufferFactory::CreateNativeType() {
 #if defined(OS_MACOSX)
   return base::WrapUnique(new GpuMemoryBufferFactoryIOSurface);
-#elif defined(OS_ANDROID)
+#elif defined(OS_ANDROID) && !defined(CASTANETS)
   return base::WrapUnique(new GpuMemoryBufferFactoryAndroidHardwareBuffer);
 #elif defined(OS_LINUX)
   return base::WrapUnique(new GpuMemoryBufferFactoryNativePixmap);

--- a/ui/gfx/gpu_memory_buffer.cc
+++ b/ui/gfx/gpu_memory_buffer.cc
@@ -54,12 +54,14 @@ GpuMemoryBufferHandle CloneHandleForIPC(
     }
     case gfx::ANDROID_HARDWARE_BUFFER: {
       gfx::GpuMemoryBufferHandle handle;
+#if !defined(CASTANETS)
       handle.type = gfx::ANDROID_HARDWARE_BUFFER;
       handle.id = source_handle.id;
 #if defined(OS_ANDROID)
       base::AndroidHardwareBufferCompat::GetInstance().Acquire(
           source_handle.android_hardware_buffer);
       handle.android_hardware_buffer = source_handle.android_hardware_buffer;
+#endif
 #endif
       return handle;
     }

--- a/ui/gfx/gpu_memory_buffer.h
+++ b/ui/gfx/gpu_memory_buffer.h
@@ -16,7 +16,7 @@
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/gfx_export.h"
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(CASTANETS)
 #include "ui/gfx/native_pixmap_handle.h"
 #elif defined(OS_MACOSX) && !defined(OS_IOS)
 #include "ui/gfx/mac/io_surface.h"
@@ -57,7 +57,7 @@ struct GFX_EXPORT GpuMemoryBufferHandle {
   base::SharedMemoryHandle handle;
   uint32_t offset;
   int32_t stride;
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(CASTANETS)
   NativePixmapHandle native_pixmap_handle;
 #elif defined(OS_MACOSX) && !defined(OS_IOS)
   ScopedRefCountedIOSurfaceMachPort mach_port;

--- a/ui/gfx/ipc/gfx_param_traits_macros.h
+++ b/ui/gfx/ipc/gfx_param_traits_macros.h
@@ -18,7 +18,7 @@
 #include "ui/gfx/selection_bound.h"
 #include "ui/gfx/swap_result.h"
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(CASTANETS)
 #include "ui/gfx/native_pixmap_handle.h"
 #endif
 
@@ -51,7 +51,7 @@ IPC_STRUCT_TRAITS_BEGIN(gfx::GpuMemoryBufferHandle)
   IPC_STRUCT_TRAITS_MEMBER(handle)
   IPC_STRUCT_TRAITS_MEMBER(offset)
   IPC_STRUCT_TRAITS_MEMBER(stride)
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined (CASTANETS)
   IPC_STRUCT_TRAITS_MEMBER(native_pixmap_handle)
 #elif defined(OS_MACOSX)
   IPC_STRUCT_TRAITS_MEMBER(mach_port)
@@ -66,7 +66,7 @@ IPC_STRUCT_TRAITS_BEGIN(gfx::GpuMemoryBufferId)
   IPC_STRUCT_TRAITS_MEMBER(id)
 IPC_STRUCT_TRAITS_END()
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(CASTANETS)
 IPC_STRUCT_TRAITS_BEGIN(gfx::NativePixmapPlane)
   IPC_STRUCT_TRAITS_MEMBER(stride)
   IPC_STRUCT_TRAITS_MEMBER(offset)

--- a/ui/gfx/mojo/BUILD.gn
+++ b/ui/gfx/mojo/BUILD.gn
@@ -22,6 +22,9 @@ mojom("mojo") {
     "//mojo/public/mojom/base",
     "//ui/gfx/geometry/mojo",
   ]
+  if (is_android && !enable_castanets) {
+    enabled_features += [ "use_android_buffer" ]
+  }
 }
 
 mojom("test_interfaces") {

--- a/ui/gfx/mojo/buffer_types.mojom
+++ b/ui/gfx/mojo/buffer_types.mojom
@@ -109,6 +109,6 @@ struct GpuMemoryBufferHandle {
   [EnableIf=is_win]
   handle? dxgi_handle;
 
-  [EnableIf=is_android]
+  [EnableIf=use_android_buffer]
   AHardwareBufferHandle? android_hardware_buffer_handle;
 };

--- a/ui/gfx/mojo/buffer_types_struct_traits.cc
+++ b/ui/gfx/mojo/buffer_types_struct_traits.cc
@@ -103,7 +103,7 @@ mojo::ScopedHandle StructTraits<gfx::mojom::GpuMemoryBufferHandleDataView,
 }
 #endif
 
-#if defined(OS_ANDROID)
+#if defined(OS_ANDROID) && !defined(CASTANETS)
 // static
 gfx::mojom::AHardwareBufferHandlePtr
 StructTraits<gfx::mojom::GpuMemoryBufferHandleDataView,
@@ -181,7 +181,7 @@ bool StructTraits<gfx::mojom::GpuMemoryBufferHandleDataView,
     out->stride = data.stride();
   }
 #endif
-#if defined(OS_ANDROID)
+#if defined(OS_ANDROID) && !defined(CASTANETS)
   if (out->type == gfx::ANDROID_HARDWARE_BUFFER) {
     gfx::mojom::AHardwareBufferHandlePtr buffer_handle;
     if (!data.ReadAndroidHardwareBufferHandle(&buffer_handle) || !buffer_handle)

--- a/ui/gfx/native_pixmap_handle.h
+++ b/ui/gfx/native_pixmap_handle.h
@@ -13,7 +13,7 @@
 #include "build/build_config.h"
 #include "ui/gfx/gfx_export.h"
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(CASTANETS)
 #include "base/file_descriptor_posix.h"
 #endif
 
@@ -54,7 +54,7 @@ struct GFX_EXPORT NativePixmapHandle {
 
   ~NativePixmapHandle();
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(CASTANETS)
   // File descriptors for the underlying memory objects (usually dmabufs).
   std::vector<base::FileDescriptor> fds;
 #endif


### PR DESCRIPTION
1. GpuMemoryBufferHandle: Do not use AHardwareBufferHandle for castanets.
2. Ignore GpuBlackList, this causes serialization error as the list
   quantity is different between linux, android.
3. Unify datatypes for SurfaceHandle in linux, android.

Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>