### PR TITLE
GPU transfer buffer synchronization control.

### DIFF
--- a/gpu/command_buffer/client/cmd_buffer_helper.cc
+++ b/gpu/command_buffer/client/cmd_buffer_helper.cc
@@ -421,12 +421,4 @@ bool CommandBufferHelper::OnMemoryDump(
   return true;
 }
 
-#if defined(CASTANETS)
-void CommandBufferHelper::RequestSyncTransferBuffer(int32_t id,
-                                                    uint32_t offset,
-                                                    uint32_t size) {
-  command_buffer_->RequestSyncTransferBuffer(id, offset, size);
-}
-#endif
-
 }  // namespace gpu

--- a/gpu/command_buffer/client/cmd_buffer_helper.h
+++ b/gpu/command_buffer/client/cmd_buffer_helper.h
@@ -251,6 +251,15 @@ class GPU_EXPORT CommandBufferHelper
     }
   }
 
+#if defined(CASTANETS)
+  void SyncResultData(int32_t id, uint32_t offset, uint32_t size) {
+    cmd::SyncResultData* cmd = GetCmdSpace<cmd::SyncResultData>();
+    if (cmd) {
+      cmd->Init(id, offset, size);
+    }
+  }
+#endif
+
   CommandBuffer* command_buffer() const { return command_buffer_; }
 
   scoped_refptr<Buffer> get_ring_buffer() const { return ring_buffer_; }
@@ -272,10 +281,6 @@ class GPU_EXPORT CommandBufferHelper
                     base::trace_event::ProcessMemoryDump* pmd) override;
 
   int32_t GetPutOffsetForTest() const { return put_; }
-
-#if defined(CASTANETS)
-  void RequestSyncTransferBuffer(int32_t id, uint32_t offset, uint32_t size);
-#endif
 
  private:
   void CalcImmediateEntries(int waiting_count);

--- a/gpu/command_buffer/client/implementation_base.cc
+++ b/gpu/command_buffer/client/implementation_base.cc
@@ -16,11 +16,6 @@
 #include "gpu/command_buffer/client/shared_memory_limits.h"
 #include "gpu/command_buffer/common/sync_token.h"
 
-#if defined(CASTANETS)
-#include "base/command_line.h"
-#include "mojo/public/cpp/system/platform_handle.h"
-#endif
-
 namespace gpu {
 
 #if !defined(_MSC_VER)
@@ -179,26 +174,12 @@ gpu::ContextResult ImplementationBase::Initialize(
 void ImplementationBase::WaitForCmd() {
   TRACE_EVENT0("gpu", "ImplementationBase::WaitForCmd");
 #if defined(CASTANETS)
-  // Synchronize the result share memory because the result may have been
-  // preset.
-  if (std::string("renderer") ==
-      base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
-    mojo::SyncSharedMemoryHandle(transfer_buffer_->shared_memory_guid(),
-                                 GetResultShmOffset(), kMaxSizeOfSimpleResult);
-  }
+  // Call this api to synchronize the result shared memory.
+  helper_->SyncResultData(GetResultShmId(), GetResultShmOffset(),
+                          kMaxSizeOfSimpleResult);
 #endif
 
   helper_->Finish();
-
-#if defined(CASTANETS)
-  // Request to synchronize shared memory of transfer buffer to get the result
-  // of api.
-  if (std::string("renderer") ==
-      base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
-    helper_->CommandBufferHelper::RequestSyncTransferBuffer(
-        GetResultShmId(), GetResultShmOffset(), kMaxSizeOfSimpleResult);
-  }
-#endif
 }
 
 void* ImplementationBase::GetResultBuffer() {
@@ -232,14 +213,6 @@ bool ImplementationBase::GetBucketContents(uint32_t bucket_id,
                           buffer.size(), buffer.shm_id(), buffer.offset());
   WaitForCmd();
   uint32_t size = *result;
-#if defined(CASTANETS)
-  // Request to synchronize shared memory of transfer buffer to get bucket data.
-  if (std::string("renderer") ==
-      base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
-    helper_->CommandBufferHelper::RequestSyncTransferBuffer(
-        buffer.shm_id(), buffer.offset(), size);
-  }
-#endif
   data->resize(size);
   if (size > 0u) {
     uint32_t offset = 0;
@@ -252,14 +225,6 @@ bool ImplementationBase::GetBucketContents(uint32_t bucket_id,
         helper_->GetBucketData(bucket_id, offset, buffer.size(),
                                buffer.shm_id(), buffer.offset());
         WaitForCmd();
-#if defined(CASTANETS)
-        if (std::string("renderer") ==
-            base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(
-                "type")) {
-          helper_->CommandBufferHelper::RequestSyncTransferBuffer(
-              buffer.shm_id(), buffer.offset(), buffer.size());
-        }
-#endif
       }
       uint32_t size_to_copy = std::min(size, buffer.size());
       memcpy(&(*data)[offset], buffer.address(), size_to_copy);

--- a/gpu/command_buffer/common/command_buffer.h
+++ b/gpu/command_buffer/common/command_buffer.h
@@ -116,12 +116,6 @@ class GPU_EXPORT CommandBuffer {
   // Destroy a transfer buffer. The ID must be positive.
   virtual void DestroyTransferBuffer(int32_t id) = 0;
 
-#if defined(CASTANETS)
-  virtual void RequestSyncTransferBuffer(int32_t id,
-                                         uint32_t offset,
-                                         uint32_t size) {}
-#endif
-
  private:
   DISALLOW_COPY_AND_ASSIGN(CommandBuffer);
 };

--- a/gpu/command_buffer/service/command_buffer_service.cc
+++ b/gpu/command_buffer/service/command_buffer_service.cc
@@ -16,10 +16,6 @@
 #include "gpu/command_buffer/common/command_buffer_shared.h"
 #include "gpu/command_buffer/service/transfer_buffer_manager.h"
 
-#if defined(CASTANETS)
-#include "mojo/public/cpp/system/platform_handle.h"
-#endif
-
 namespace gpu {
 
 namespace {
@@ -180,15 +176,6 @@ scoped_refptr<Buffer> CommandBufferService::CreateTransferBuffer(size_t size,
 void CommandBufferService::DestroyTransferBuffer(int32_t id) {
   transfer_buffer_manager_->DestroyTransferBuffer(id);
 }
-
-#if defined(CASTANETS)
-void CommandBufferService::RequestSyncTransferBuffer(int32_t id,
-                                                     uint32_t offset,
-                                                     uint32_t size) {
-  BufferBacking* backing = GetTransferBuffer(id)->backing();
-  mojo::SyncSharedMemoryHandle(backing->GetGUID(), offset, size);
-}
-#endif
 
 scoped_refptr<Buffer> CommandBufferService::GetTransferBuffer(int32_t id) {
   return transfer_buffer_manager_->GetTransferBuffer(id);

--- a/gpu/command_buffer/service/command_buffer_service.h
+++ b/gpu/command_buffer/service/command_buffer_service.h
@@ -105,10 +105,6 @@ class GPU_EXPORT CommandBufferService : public CommandBufferServiceBase {
   // Unregisters and destroys the transfer buffer associated with the given id.
   void DestroyTransferBuffer(int32_t id);
 
-#if defined(CASTANETS)
-  void RequestSyncTransferBuffer(int32_t id, uint32_t offset, uint32_t size);
-#endif
-
   // Creates an in-process transfer buffer and register it with a newly created
   // id.
   scoped_refptr<Buffer> CreateTransferBuffer(size_t size, int32_t* id);

--- a/gpu/command_buffer/service/common_decoder.cc
+++ b/gpu/command_buffer/service/common_decoder.cc
@@ -12,6 +12,10 @@
 #include "base/numerics/safe_math.h"
 #include "gpu/command_buffer/service/command_buffer_service.h"
 
+#if defined(CASTANETS)
+#include "mojo/public/cpp/system/platform_handle.h"
+#endif
+
 namespace gpu {
 namespace {
 static const size_t kDefaultMaxBucketSize = 1u << 30;  // 1 GB
@@ -335,6 +339,12 @@ error::Error CommonDecoder::HandleGetBucketStart(
     uint32_t size = std::min(data_memory_size, bucket_size);
     memcpy(data, bucket->GetData(0, size), size);
   }
+#if defined(CASTANETS)
+  scoped_refptr<gpu::Buffer> buffer =
+      command_buffer_service_->GetTransferBuffer(data_memory_id);
+  mojo::SyncSharedMemoryHandle(buffer->backing()->GetGUID(), data_memory_offset,
+                               data_memory_size);
+#endif
   return error::kNoError;
 }
 
@@ -359,7 +369,30 @@ error::Error CommonDecoder::HandleGetBucketData(uint32_t immediate_data_size,
       return error::kInvalidArguments;
   }
   memcpy(data, src, size);
+#if defined(CASTANETS)
+  scoped_refptr<gpu::Buffer> buffer =
+      command_buffer_service_->GetTransferBuffer(args.shared_memory_id);
+  mojo::SyncSharedMemoryHandle(buffer->backing()->GetGUID(), offset, size);
+#endif
   return error::kNoError;
 }
+
+#if defined(CASTANETS)
+error::Error CommonDecoder::HandleSyncResultData(
+    uint32_t immediate_data_size,
+    const volatile void* cmd_data) {
+  const volatile cmd::SyncResultData& args =
+      *static_cast<const volatile cmd::SyncResultData*>(cmd_data);
+  scoped_refptr<gpu::Buffer> buffer =
+      command_buffer_service_->GetTransferBuffer(args.id);
+  mojo::SyncSharedMemoryHandle(buffer->backing()->GetGUID(), args.offset,
+                               args.size);
+
+  // Set result data to '0' for use in the next command on Castanets.
+  // Some apis should set data to non-zero, it can cause an issue.
+  memset(buffer->memory(), 0, args.size);
+  return error::kNoError;
+}
+#endif
 
 }  // namespace gpu

--- a/gpu/ipc/client/command_buffer_proxy_impl.cc
+++ b/gpu/ipc/client/command_buffer_proxy_impl.cc
@@ -669,18 +669,6 @@ void CommandBufferProxyImpl::ReturnFrontBuffer(const gpu::Mailbox& mailbox,
   Send(new GpuCommandBufferMsg_ReturnFrontBuffer(route_id_, mailbox, is_lost));
 }
 
-#if defined(CASTANETS)
-void CommandBufferProxyImpl::RequestSyncTransferBuffer(int32_t id,
-                                                       uint32_t offset,
-                                                       uint32_t size) {
-  CheckLock();
-  base::AutoLock lock(last_state_lock_);
-
-  Send(
-      new GpuChannelMsg_RequestSyncTransferBuffer(route_id_, id, offset, size));
-}
-#endif
-
 bool CommandBufferProxyImpl::Send(IPC::Message* msg) {
   DCHECK(channel_);
   last_state_lock_.AssertAcquired();

--- a/gpu/ipc/client/command_buffer_proxy_impl.h
+++ b/gpu/ipc/client/command_buffer_proxy_impl.h
@@ -155,12 +155,6 @@ class GPU_EXPORT CommandBufferProxyImpl : public gpu::CommandBuffer,
   }
   uint32_t CreateStreamTexture(uint32_t texture_id);
 
-#if defined(CASTANETS)
-  void RequestSyncTransferBuffer(int32_t id,
-                                 uint32_t offset,
-                                 uint32_t size) override;
-#endif
-
  private:
   typedef std::map<int32_t, scoped_refptr<gpu::Buffer>> TransferBufferMap;
   typedef base::hash_map<uint32_t, base::OnceClosure> SignalTaskMap;

--- a/gpu/ipc/common/gpu_messages.h
+++ b/gpu/ipc/common/gpu_messages.h
@@ -101,13 +101,6 @@ IPC_MESSAGE_CONTROL1(GpuChannelMsg_FlushCommandBuffers,
 // messages have been received.
 IPC_SYNC_MESSAGE_CONTROL0_0(GpuChannelMsg_Nop)
 
-#if defined(CASTANETS)
-IPC_SYNC_MESSAGE_ROUTED3_0(GpuChannelMsg_RequestSyncTransferBuffer,
-                           int32_t /* id */,
-                           uint32_t /* offset */,
-                           uint32_t /* size */)
-#endif
-
 #if defined(OS_ANDROID)
 //------------------------------------------------------------------------------
 // Tells the StreamTexture to send its SurfaceTexture to the browser process,

--- a/gpu/ipc/service/command_buffer_stub.cc
+++ b/gpu/ipc/service/command_buffer_stub.cc
@@ -257,9 +257,6 @@ bool CommandBufferStub::OnMessageReceived(const IPC::Message& message) {
       message.type() != GpuCommandBufferMsg_WaitForGetOffsetInRange::ID &&
       message.type() != GpuCommandBufferMsg_RegisterTransferBuffer::ID &&
       message.type() != GpuCommandBufferMsg_DestroyTransferBuffer::ID &&
-#if defined(CASTANETS)
-      message.type() != GpuCommandBufferMsg_DestroyTransferBuffer::ID &&
-#endif
       message.type() != GpuCommandBufferMsg_WaitSyncToken::ID &&
       message.type() != GpuCommandBufferMsg_SignalSyncToken::ID &&
       message.type() != GpuCommandBufferMsg_SignalQuery::ID) {
@@ -285,10 +282,6 @@ bool CommandBufferStub::OnMessageReceived(const IPC::Message& message) {
                         OnRegisterTransferBuffer);
     IPC_MESSAGE_HANDLER(GpuCommandBufferMsg_DestroyTransferBuffer,
                         OnDestroyTransferBuffer);
-#if defined(CASTANETS)
-    IPC_MESSAGE_HANDLER(GpuChannelMsg_RequestSyncTransferBuffer,
-                        OnRequestSyncTransferBuffer);
-#endif
     IPC_MESSAGE_HANDLER(GpuCommandBufferMsg_WaitSyncToken, OnWaitSyncToken)
     IPC_MESSAGE_HANDLER(GpuCommandBufferMsg_SignalSyncToken, OnSignalSyncToken)
     IPC_MESSAGE_HANDLER(GpuCommandBufferMsg_SignalQuery, OnSignalQuery)
@@ -654,14 +647,6 @@ void CommandBufferStub::OnDestroyTransferBuffer(int32_t id) {
   if (command_buffer_)
     command_buffer_->DestroyTransferBuffer(id);
 }
-
-#if defined(CASTANETS)
-void CommandBufferStub::OnRequestSyncTransferBuffer(int32_t id,
-                                                    uint32_t offset,
-                                                    uint32_t size) {
-  command_buffer_->RequestSyncTransferBuffer(id, offset, size);
-}
-#endif
 
 void CommandBufferStub::ReportState() {
   command_buffer_->UpdateState();

--- a/gpu/ipc/service/command_buffer_stub.h
+++ b/gpu/ipc/service/command_buffer_stub.h
@@ -193,9 +193,6 @@ class GPU_IPC_SERVICE_EXPORT CommandBufferStub
   void OnRegisterTransferBuffer(int32_t id,
                                 base::UnsafeSharedMemoryRegion transfer_buffer);
   void OnDestroyTransferBuffer(int32_t id);
-#if defined(CASTANETS)
-  void OnRequestSyncTransferBuffer(int32_t id, uint32_t offset, uint32_t size);
-#endif
   void OnGetTransferBuffer(int32_t id, IPC::Message* reply_message);
 
   void OnEnsureBackbuffer();


### PR DESCRIPTION
1. Remove GpuChannelMsg_RequestSyncTransferBuffer and
   GPU determines data sync timing.
2. Add the command to control synchronization for result data.