### PR TITLE
Set |TCP_NODELAY| option to remove delay while sending message.

### DIFF
--- a/mojo/public/cpp/platform/tcp_platform_handle_utils_posix.cc
+++ b/mojo/public/cpp/platform/tcp_platform_handle_utils_posix.cc
@@ -5,6 +5,7 @@
 #include "tcp_platform_handle_utils.h"
 
 #include <arpa/inet.h>
+#include <netinet/tcp.h>
 #include <sys/socket.h>
 
 #include "base/base_switches.h"
@@ -68,6 +69,9 @@ PlatformHandle CreateTCPClientHandle(uint16_t port) {
   PlatformHandle handle = CreateTCPSocket(false, IPPROTO_TCP);
   if (!handle.is_valid())
     return PlatformHandle();
+
+  static const int kOn = 1;
+  setsockopt(handle.GetFD().get(), IPPROTO_TCP, TCP_NODELAY, &kOn, sizeof(kOn));
 
   if (HANDLE_EINTR(connect_retry(handle.GetFD().get(),
                                  reinterpret_cast<sockaddr*>(&unix_addr),
@@ -150,6 +154,9 @@ bool TCPServerAcceptConnection(base::PlatformFile server_handle,
     // O_NONBLOCK failed on the client fd.
     return true;
   }
+
+  static const int kOn = 1;
+  setsockopt(accept_handle.get(), IPPROTO_TCP, TCP_NODELAY, &kOn, sizeof(kOn));
 
   *connection_handle = std::move(accept_handle);
   return true;


### PR DESCRIPTION
Sometimes message delivery between browser process and renderer process takes
over 30ms and this makes performance degradation. The reason of this symptom is
"Nagle's algorithm" which is a means of improving the efficiency of TCP/IP.
Turn off "Nagle's algorithm" by giving |TCP_NODELAY| option.

Cherry-picked yg's commit from Tizen branch.