### PR TITLE
fixup! Integration Service Discovery Manager (#157)

### DIFF
--- a/content/browser/renderer_host/render_process_host_impl.cc
+++ b/content/browser/renderer_host/render_process_host_impl.cc
@@ -2772,7 +2772,8 @@ void RenderProcessHostImpl::AppendRendererCommandLine(
   // TODO: This guard should be remove after resolving workaround at
   // ChildThreadImpl::Init.
 #if defined(CASTANETS)
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(kEnableForking)) {
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kEnableForking)) {
     command_line->AppendSwitchASCII(switches::kRendererClientId,
                                     std::to_string(GetID()));
   }


### PR DESCRIPTION
This patch fixes below build break.

../../content/browser/renderer_host/render_process_host_impl.cc:2775:57:
error: use of undeclared identifier 'kEnableForking'; did you mean
'switches::kEnableForking'?

Signed-off-by: yh106.jung <yh106.jung@samsung.com>