### PR TITLE
This patch test child process launching behavior

### DIFF
--- a/chrome/browser/ui/startup/startup_browser_creator_impl.cc
+++ b/chrome/browser/ui/startup/startup_browser_creator_impl.cc
@@ -552,7 +552,7 @@ Browser* StartupBrowserCreatorImpl::OpenTabsInBrowser(Browser* browser,
   // to take care of that.
   if (!browser_creator_ || browser_creator_->show_main_browser_window())
     browser->window()->Show();
-
+  LOG(INFO) << __FUNCTION__;
   return browser;
 }
 

--- a/content/browser/browser_child_process_host_impl.cc
+++ b/content/browser/browser_child_process_host_impl.cc
@@ -588,7 +588,6 @@ void BrowserChildProcessHostImpl::OnProcessLaunchFailed(int error_code) {
 
 void BrowserChildProcessHostImpl::OnProcessLaunched() {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
-
   const base::Process& process = child_process_->GetProcess();
   DCHECK(process.IsValid());
 

--- a/content/browser/child_process_launcher_helper_linux.cc
+++ b/content/browser/child_process_launcher_helper_linux.cc
@@ -123,7 +123,7 @@ ChildProcessLauncherHelper::LaunchProcessOnLauncherThread(
     return castanets_process;
   }
 #endif
-
+LOG(INFO) << "forking!!";
   Process process;
   process.process = base::LaunchProcess(*command_line(), options);
   *launch_result = process.process.IsValid() ? LAUNCH_RESULT_SUCCESS

--- a/content/browser/frame_host/navigation_request.cc
+++ b/content/browser/frame_host/navigation_request.cc
@@ -70,7 +70,7 @@
 #include "third_party/blink/public/platform/resource_request_blocked_reason.h"
 #include "third_party/blink/public/platform/web_mixed_content_context_type.h"
 #include "url/url_constants.h"
-
+#include <base/debug/stack_trace.h>
 namespace content {
 
 namespace {
@@ -1646,6 +1646,7 @@ void NavigationRequest::CommitNavigation() {
     }
     associated_site_instance_id_.reset();
   }
+  base::debug::StackTrace().Print();
   render_frame_host->CommitNavigation(
       navigation_handle_->GetNavigationId(), response_.get(),
       std::move(url_loader_client_endpoints_), common_params_, request_params_,

--- a/content/browser/frame_host/render_frame_host_impl.cc
+++ b/content/browser/frame_host/render_frame_host_impl.cc
@@ -176,7 +176,7 @@
 #include "url/gurl.h"
 #include "url/origin.h"
 #include "url/url_constants.h"
-
+#include <base/debug/stack_trace.h>
 #if defined(OS_ANDROID)
 #include "content/browser/android/java_interfaces_impl.h"
 #include "content/browser/frame_host/render_frame_host_android.h"
@@ -4094,6 +4094,8 @@ void RenderFrameHostImpl::CommitNavigation(
           std::move(subresource_overrides), std::move(controller),
           std::move(prefetch_loader_factory), devtools_navigation_token);
     } else {
+      base::debug::StackTrace().Print();
+      LOG(INFO) << "GetNavigationControl()->CommitNavigation";
       GetNavigationControl()->CommitNavigation(
           head, common_params, request_params,
           std::move(url_loader_client_endpoints), CloneSubresourceFactories(),
@@ -5253,8 +5255,10 @@ void RenderFrameHostImpl::SetVisibilityForChildViews(bool visible) {
 }
 
 mojom::FrameNavigationControl* RenderFrameHostImpl::GetNavigationControl() {
-  if (!navigation_control_)
+  if (!navigation_control_) {
+    LOG(INFO) << "GetRemoteAssociatedInterfaces()->GetInterface(&navigation_control_);";
     GetRemoteAssociatedInterfaces()->GetInterface(&navigation_control_);
+  }
   return navigation_control_.get();
 }
 

--- a/content/browser/loader/navigation_url_loader_impl.cc
+++ b/content/browser/loader/navigation_url_loader_impl.cc
@@ -76,7 +76,7 @@
 #include "services/service_manager/public/cpp/connector.h"
 #include "third_party/blink/public/common/mime_util/mime_util.h"
 #include "third_party/blink/public/common/service_worker/service_worker_utils.h"
-
+#include <base/debug/stack_trace.h>
 namespace content {
 
 namespace {
@@ -898,7 +898,7 @@ class NavigationURLLoaderImpl::URLLoaderRequestController
   // network::mojom::URLLoaderClient implementation:
   void OnReceiveResponse(const network::ResourceResponseHead& head) override {
     received_response_ = true;
-
+base::debug::StackTrace().Print();
     // If the default loader (network) was used to handle the URL load request
     // we need to see if the interceptors want to potentially create a new
     // loader for the response. e.g. AppCache.

--- a/content/browser/renderer_host/render_process_host_impl.h
+++ b/content/browser/renderer_host/render_process_host_impl.h
@@ -92,6 +92,7 @@ class SiteInstance;
 class SiteInstanceImpl;
 class StoragePartition;
 class StoragePartitionImpl;
+class TimeoutMonitor;
 struct ChildProcessTerminationInfo;
 
 typedef base::Thread* (*RendererMainThreadFactoryFunction)(
@@ -319,6 +320,8 @@ class CONTENT_EXPORT RenderProcessHostImpl
 
   // This forces a renderer that is running "in process" to shut down.
   static void ShutDownInProcessRenderer();
+
+  void OnCastanetsRendererTimeout();
 
   static void RegisterRendererMainThreadFactory(
       RendererMainThreadFactoryFunction create);
@@ -836,6 +839,8 @@ class CONTENT_EXPORT RenderProcessHostImpl
   FrameSinkProviderImpl frame_sink_provider_;
   std::unique_ptr<mojo::Binding<viz::mojom::CompositingModeReporter>>
       compositing_mode_reporter_;
+
+  std::unique_ptr<TimeoutMonitor> relaunch_renderer_process_monitor_timeout_;
 
   base::WeakPtrFactory<RenderProcessHostImpl> weak_factory_;
 

--- a/content/browser/renderer_host/render_widget_host_impl.cc
+++ b/content/browser/renderer_host/render_widget_host_impl.cc
@@ -127,7 +127,7 @@
 #include "services/service_manager/public/cpp/connector.h"
 #include "ui/accelerated_widget_mac/window_resize_helper_mac.h"
 #endif
-
+#include <base/debug/stack_trace.h>
 using base::TimeDelta;
 using base::TimeTicks;
 using blink::WebDragOperation;
@@ -382,6 +382,7 @@ RenderWidgetHostImpl::RenderWidgetHostImpl(RenderWidgetHostDelegate* delegate,
       frame_sink_id_(base::checked_cast<uint32_t>(process_->GetID()),
                      base::checked_cast<uint32_t>(routing_id_)),
       weak_factory_(this) {
+base::debug::StackTrace().Print();
 #if defined(OS_MACOSX)
   fling_scheduler_ = std::make_unique<FlingSchedulerMac>(this);
 #elif defined(OS_ANDROID)
@@ -436,6 +437,7 @@ RenderWidgetHostImpl::RenderWidgetHostImpl(RenderWidgetHostDelegate* delegate,
 }
 
 RenderWidgetHostImpl::~RenderWidgetHostImpl() {
+  LOG(INFO) << __FUNCTION__;
   render_frame_metadata_provider_.RemoveObserver(this);
   if (!destroyed_)
     Destroy(false);

--- a/content/browser/service_manager/service_manager_context.cc
+++ b/content/browser/service_manager/service_manager_context.cc
@@ -99,7 +99,7 @@
 #include "components/services/font/font_service_app.h"
 #include "components/services/font/public/interfaces/constants.mojom.h"
 #endif
-
+#include <base/debug/stack_trace.h>
 namespace content {
 
 namespace {
@@ -258,6 +258,7 @@ class NullServiceProcessLauncherFactory
  private:
   std::unique_ptr<service_manager::ServiceProcessLauncher> Create(
       const base::FilePath& service_path) override {
+    base::debug::StackTrace().Print();
     // There are innocuous races where browser code may attempt to connect
     // to a specific renderer instance through the Service Manager after that
     // renderer has been terminated. These result in this code path being hit

--- a/content/browser/web_contents/web_contents_impl.cc
+++ b/content/browser/web_contents/web_contents_impl.cc
@@ -6001,14 +6001,14 @@ bool WebContentsImpl::CreateRenderViewForRenderManager(
 
   if (proxy_routing_id == MSG_ROUTING_NONE)
     CreateRenderWidgetHostViewForRenderManager(render_view_host);
-
+LOG(INFO) << __FUNCTION__ << "before CreateRenderView";
   if (!static_cast<RenderViewHostImpl*>(render_view_host)
            ->CreateRenderView(opener_frame_routing_id, proxy_routing_id,
                               devtools_frame_token, replicated_frame_state,
                               created_with_opener_)) {
     return false;
   }
-
+LOG(INFO) << __FUNCTION__ << "after CreateRenderView";
   if (proxy_routing_id == MSG_ROUTING_NONE && node_.outer_web_contents())
     ReattachToOuterWebContentsFrame();
 

--- a/content/common/child_process_host_impl.cc
+++ b/content/common/child_process_host_impl.cc
@@ -53,7 +53,7 @@ ChildProcessHost* ChildProcessHost::Create(ChildProcessHostDelegate* delegate) {
 // static
 base::FilePath ChildProcessHost::GetChildPath(int flags) {
   base::FilePath child_path;
-
+LOG(INFO) << __FUNCTION__ << "1: " << child_path;
   child_path = base::CommandLine::ForCurrentProcess()->GetSwitchValuePath(
       switches::kBrowserSubprocessPath);
 
@@ -63,11 +63,12 @@ base::FilePath ChildProcessHost::GetChildPath(int flags) {
   if (child_path.empty() && flags & CHILD_ALLOW_SELF)
     child_path = base::FilePath(base::kProcSelfExe);
 #endif
-
+LOG(INFO) << __FUNCTION__ << "2: " << child_path;
   // On most platforms, the child executable is the same as the current
   // executable.
   if (child_path.empty())
     base::PathService::Get(CHILD_PROCESS_EXE, &child_path);
+  LOG(INFO) << __FUNCTION__ << "3: " << child_path;
   return child_path;
 }
 

--- a/content/common/service_manager/child_connection.cc
+++ b/content/common/service_manager/child_connection.cc
@@ -28,6 +28,7 @@ class ChildConnection::IOThreadContext
                   service_manager::Connector* connector,
                   mojo::ScopedMessagePipeHandle service_pipe,
                   scoped_refptr<base::SequencedTaskRunner> io_task_runner) {
+    LOG(INFO) << __FUNCTION__;
     DCHECK(!io_task_runner_);
     io_task_runner_ = io_task_runner;
     std::unique_ptr<service_manager::Connector> io_thread_connector;
@@ -78,6 +79,7 @@ class ChildConnection::IOThreadContext
   void InitializeOnIOThread(
       const service_manager::Identity& child_identity,
       mojo::ScopedMessagePipeHandle service_pipe) {
+    LOG(INFO) << __FUNCTION__ << "start";
     service_manager::mojom::ServicePtr service;
     service.Bind(mojo::InterfacePtrInfo<service_manager::mojom::Service>(
         std::move(service_pipe), 0u));
@@ -88,6 +90,7 @@ class ChildConnection::IOThreadContext
                                std::move(pid_receiver_request));
       connector_->BindInterface(child_identity, &child_);
     }
+    LOG(INFO) << __FUNCTION__ << "end";
   }
 
   void ShutDownOnIOThread() {

--- a/content/renderer/appcache/appcache_backend_proxy.cc
+++ b/content/renderer/appcache/appcache_backend_proxy.cc
@@ -7,13 +7,14 @@
 #include "content/public/common/service_names.mojom.h"
 #include "content/public/renderer/render_thread.h"
 #include "services/service_manager/public/cpp/connector.h"
-
+#include <base/debug/stack_trace.h>
 namespace content {
 
 AppCacheBackendProxy::AppCacheBackendProxy() = default;
 AppCacheBackendProxy::~AppCacheBackendProxy() = default;
 
 mojom::AppCacheBackend* AppCacheBackendProxy::GetAppCacheBackendPtr() {
+  base::debug::StackTrace().Print();
   if (!app_cache_backend_ptr_) {
     RenderThread::Get()->GetConnector()->BindInterface(
         mojom::kBrowserServiceName, mojo::MakeRequest(&app_cache_backend_ptr_));

--- a/content/renderer/loader/url_loader_client_impl.cc
+++ b/content/renderer/loader/url_loader_client_impl.cc
@@ -276,7 +276,7 @@ void URLLoaderClientImpl::OnStartLoadingResponseBody(
     mojo::ScopedDataPipeConsumerHandle body) {
   DCHECK(!body_consumer_);
   DCHECK(has_received_response_);
-
+LOG(INFO) << "URLLoaderClientImpl::OnStartLoadingResponseBody";
   if (pass_response_pipe_to_dispatcher_) {
     resource_dispatcher_->OnStartLoadingResponseBody(request_id_,
                                                      std::move(body));

--- a/content/renderer/navigation_client.cc
+++ b/content/renderer/navigation_client.cc
@@ -5,7 +5,7 @@
 #include "content/renderer/navigation_client.h"
 #include "content/renderer/render_frame_impl.h"
 #include "third_party/blink/public/platform/task_type.h"
-
+#include <base/debug/stack_trace.h>
 namespace content {
 
 NavigationClient::NavigationClient(RenderFrameImpl* render_frame)
@@ -24,6 +24,7 @@ void NavigationClient::CommitNavigation(
     mojom::ControllerServiceWorkerInfoPtr controller_service_worker_info,
     network::mojom::URLLoaderFactoryPtr prefetch_loader_factory,
     const base::UnguessableToken& devtools_navigation_token) {
+  base::debug::StackTrace().Print();
   // TODO(ahemery): The reset should be done when the navigation did commit
   // (meaning at a later stage). This is not currently possible because of
   // race conditions leading to the early deletion of NavigationRequest would

--- a/content/renderer/push_messaging/push_messaging_client.cc
+++ b/content/renderer/push_messaging/push_messaging_client.cc
@@ -31,6 +31,7 @@ namespace content {
 
 PushMessagingClient::PushMessagingClient(RenderFrame* render_frame)
     : RenderFrameObserver(render_frame) {
+      LOG(INFO) << __FUNCTION__;
   if (ChildThreadImpl::current()) {
     ChildThreadImpl::current()->GetConnector()->BindInterface(
         mojom::kBrowserServiceName,

--- a/content/renderer/render_frame_impl.cc
+++ b/content/renderer/render_frame_impl.cc
@@ -229,7 +229,7 @@
 #include "url/url_constants.h"
 #include "url/url_util.h"
 #include "v8/include/v8.h"
-
+#include <base/debug/stack_trace.h>
 #if BUILDFLAG(ENABLE_PLUGINS)
 #include "content/renderer/pepper/pepper_browser_connection.h"
 #include "content/renderer/pepper/pepper_plugin_instance_impl.h"
@@ -1553,6 +1553,7 @@ RenderFrameImpl::~RenderFrameImpl() {
 }
 
 void RenderFrameImpl::Initialize() {
+  base::debug::StackTrace().Print();
   is_main_frame_ = !frame_->Parent();
 
   GetRenderWidget()->RegisterRenderFrame(this);
@@ -3068,6 +3069,7 @@ void RenderFrameImpl::CommitNavigation(
     network::mojom::URLLoaderFactoryPtr prefetch_loader_factory,
     const base::UnguessableToken& devtools_navigation_token,
     CommitNavigationCallback callback) {
+  LOG(INFO) << __FUNCTION__;
   DCHECK(!IsRendererDebugURL(common_params.url));
   DCHECK(
       !FrameMsg_Navigate_Type::IsSameDocument(common_params.navigation_type));

--- a/content/renderer/render_thread_impl.cc
+++ b/content/renderer/render_thread_impl.cc
@@ -170,7 +170,7 @@
 #include "ui/base/ui_base_features.h"
 #include "ui/base/ui_base_switches.h"
 #include "ui/display/display_switches.h"
-
+#include <base/debug/stack_trace.h>
 #if defined(OS_ANDROID)
 #include <cpu-features.h>
 #include "content/renderer/android/synchronous_layer_tree_frame_sink.h"
@@ -2187,6 +2187,7 @@ gpu::GpuChannelHost* RenderThreadImpl::GetGpuChannel() {
 
 void RenderThreadImpl::CreateEmbedderRendererService(
     service_manager::mojom::ServiceRequest service_request) {
+  base::debug::StackTrace().Print();
   GetContentClient()->renderer()->CreateRendererService(
       std::move(service_request));
 }

--- a/content/renderer/render_view_impl.cc
+++ b/content/renderer/render_view_impl.cc
@@ -1236,6 +1236,7 @@ WebView* RenderViewImpl::CreateView(WebLocalFrame* creator,
                                     WebNavigationPolicy policy,
                                     bool suppress_opener,
                                     WebSandboxFlags sandbox_flags) {
+  LOG(INFO) << __FUNCTION__;
   RenderFrameImpl* creator_frame = RenderFrameImpl::FromWebFrame(creator);
   mojom::CreateNewWindowParamsPtr params = mojom::CreateNewWindowParams::New();
 

--- a/mojo/core/broker_castanets.cc
+++ b/mojo/core/broker_castanets.cc
@@ -50,7 +50,13 @@ Channel::MessagePtr WaitForBrokerMessage(
     PLOG(ERROR) << "Recvmsg error";
     error = true;
   } else if (static_cast<size_t>(read_result) != message->data_num_bytes()) {
+    LOG(ERROR) << "static_cast<size_t>(read_result): " << static_cast<size_t>(read_result);
+    LOG(ERROR) << "message->data_num_bytes(): " << message->data_num_bytes();
     LOG(ERROR) << "Invalid node channel message";
+    const BrokerMessageHeader* header =
+      reinterpret_cast<const BrokerMessageHeader*>(message->payload());
+      LOG(ERROR) << "Unexpected message - expected_type(" << expected_type
+               << ") != header->type(" << header->type << ")";
     error = true;
   } else if (incoming_fds.size() != expected_num_handles) {
     LOG(ERROR) << "Received unexpected number of handles";


### PR DESCRIPTION
when creating ChildProcessLauncher again and assign it as a member of
RenderProcessHostImpl.

This change is just for reference and test purpose.
I checked that with this patch,
the messages until |RenderFrameHostImpl::CommitNavigation| were queued,
and when RenderProcess was recreated with this patch,
the channel having that messages was destroyed.
So the newly created RenderProcess is connected with RenderProcessHostImpl well,
but the messages related with the navigation stuff was gone,
it leads to the situation where the new Renderer Process does nothing
because it gets no messages from the Browser Process.

We have to think again how to make connection after some timeout
between renderer and browser.