### PR TITLE
Pass the TCP server address to create TCP client.

### DIFF
--- a/mojo/public/cpp/platform/tcp_platform_handle_utils.h
+++ b/mojo/public/cpp/platform/tcp_platform_handle_utils.h
@@ -21,16 +21,16 @@ const size_t kCastanetsUtilityPort = 7007;
 const size_t kCastanetsNonBrokerPort = 5005;
 
 COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
-PlatformHandle CreateTCPClientHandle(uint16_t port);
+PlatformHandle CreateTCPClientHandle(const uint16_t port,
+                                     std::string server_address = "");
 
 COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
 PlatformHandle CreateTCPServerHandle(uint16_t port,
                                      uint16_t* out_port = nullptr);
 
 COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
-bool TCPServerAcceptConnection(
-        base::PlatformFile server_fd,
-        base::ScopedFD* connection_fd);
+bool TCPServerAcceptConnection(const base::PlatformFile server_socket,
+                               base::ScopedFD* accept_socket);
 
 }  // namespace mojo
 


### PR DESCRIPTION
In some cases browser process needs to create TCP client
for TCP server placed in Renderer Process. In this case, renderer process
should transfer own address because browser process doesn't know it.

In addition, match parameter names of |TCPServerAcceptConnection|.