### PR TITLE
Disable Gpu compositing temporarilly.

### DIFF
--- a/content/app/content_main_runner_impl.cc
+++ b/content/app/content_main_runner_impl.cc
@@ -741,6 +741,8 @@ int ContentMainRunnerImpl::Initialize(const ContentMainParams& params) {
   base::CommandLine::ForCurrentProcess()->AppendSwitch(
       switches::kInProcessGPU);
   base::CommandLine::ForCurrentProcess()->AppendSwitch(
+      switches::kDisableGpuCompositing);
+  base::CommandLine::ForCurrentProcess()->AppendSwitch(
       switches::kDisableAcceleratedVideoDecode);
 
   base::CommandLine::ForCurrentProcess()->AppendSwitch(

--- a/gpu/command_buffer/client/gles2_implementation.cc
+++ b/gpu/command_buffer/client/gles2_implementation.cc
@@ -1167,7 +1167,11 @@ bool GLES2Implementation::GetQueryObjectValueHelper(
         helper_->WaitForToken(query->token());
         if (!query->CheckResultsAvailable(helper_)) {
           FinishHelper();
+#if !defined(CASTANETS)
+          // FIXME: This validation occurs crash on Castanets
+          // because the shared memory of query result is not synchronized.
           CHECK(query->CheckResultsAvailable(helper_));
+#endif
         }
       }
       *params = query->GetResult();


### PR DESCRIPTION
Gpu compositing has crash issues related to shared memory sync.
So gpu compositing is disabled urgently while fixing the issue.

In addition, skip CHECK() on |GetQueryObjectValueHelper|.
It causes a crash issue while using Gpu compositing
because the shared memory for query is not synchronized.