### PR TITLE
Handling of shared memory that is not needed to sync.

### DIFF
--- a/base/memory/shared_memory_tracker.cc
+++ b/base/memory/shared_memory_tracker.cc
@@ -153,6 +153,7 @@ void SharedMemoryTracker::RemoveMapping(const UnguessableToken& guid,
 }
 
 void SharedMemoryTracker::MapExternalMemory(int fd, SyncDelegate* delegate) {
+  CHECK(delegate);
   std::unique_ptr<UnknownMemorySyncer> unknown_memory = TakeUnknownMemory(fd);
   if (!unknown_memory)
     return;
@@ -168,8 +169,7 @@ void SharedMemoryTracker::MapExternalMemory(int fd, SyncDelegate* delegate) {
 }
 
 void SharedMemoryTracker::MapInternalMemory(int fd) {
-  std::unique_ptr<UnknownMemorySyncer> unknown_memory = TakeUnknownMemory(fd);
-  CHECK(unknown_memory);
+  IgnoreResult(TakeUnknownMemory(fd));
 }
 
 void SharedMemoryTracker::AddFDInTransit(const UnguessableToken& guid, int fd) {
@@ -207,8 +207,11 @@ CastanetsMemorySyncer* SharedMemoryTracker::GetSyncer(
 
   AutoLock hold(unknown_lock_);
   auto unknown = unknown_memories_.find(guid);
-  CHECK(unknown != unknown_memories_.end());
-  return unknown->second.get();
+  if (unknown != unknown_memories_.end())
+    return unknown->second.get();
+
+  // In case of a internal memory, which does not need to sync.
+  return nullptr;
 }
 
 void SharedMemoryTracker::AddHolder(subtle::PlatformSharedMemoryRegion handle) {

--- a/mojo/core/channel_posix.cc
+++ b/mojo/core/channel_posix.cc
@@ -531,10 +531,15 @@ class ChannelPosix : public Channel,
       std::vector<PlatformHandleInTransit> handles = message_view.TakeHandles();
       if (!handles.empty()) {
 #if defined(CASTANETS)
-        base::SharedMemoryTracker::GetInstance()->MapExternalMemory(
-            handles[0].handle().GetFD().get(),
+        base::SyncDelegate* delegate =
             Core::Get()->GetNodeController()->GetSyncDelegate(
-                remote_process().get()));
+                remote_process().get());
+        if (delegate)
+          base::SharedMemoryTracker::GetInstance()->MapExternalMemory(
+              handles[0].handle().GetFD().get(), delegate);
+        else
+          base::SharedMemoryTracker::GetInstance()->MapInternalMemory(
+              handles[0].handle().GetFD().get());
 #endif
         iovec iov = {const_cast<void*>(message_view.data()),
                      message_view.data_num_bytes()};

--- a/mojo/core/node_controller.cc
+++ b/mojo/core/node_controller.cc
@@ -366,8 +366,11 @@ base::SyncDelegate* NodeController::GetSyncDelegate(
 
   base::AutoLock lock(broker_hosts_lock_);
   auto it = broker_hosts_.find(process);
-  CHECK(it != broker_hosts_.end());
-  return it->second.get();
+  if (it != broker_hosts_.end())
+    return it->second.get();
+
+  CHECK_GE(process, 0);
+  return nullptr;
 }
 #endif
 


### PR DESCRIPTION
The GetSyncer() and GetSyncDelegate() methods may return nullptr.
- If GetSyncer() returns nullptr, the shared memory is being shared
  inside the same node, meaning sync is not needed.
- If GetSyncDelegate() returns nullptr, this means that
  the process is a normal chromium's child process. So there is
  no need for sync as well.