### PR TITLE
Call sync method in data pipe producer.

### DIFF
--- a/content/browser/loader/mojo_async_resource_handler.cc
+++ b/content/browser/loader/mojo_async_resource_handler.cc
@@ -430,9 +430,6 @@ MojoResult MojoAsyncResourceHandler::BeginWrite(void** data,
 
 MojoResult MojoAsyncResourceHandler::EndWrite(uint32_t written) {
   MojoResult result = shared_writer_->writer().EndWriteData(written);
-#if defined(CASTANETS)
-  shared_writer_->writer().SyncData(written);
-#endif
   if (result == MOJO_RESULT_OK) {
     total_written_bytes_ += written;
     handle_watcher_.ArmOrNotify();

--- a/mojo/core/core.cc
+++ b/mojo/core/core.cc
@@ -764,18 +764,6 @@ MojoResult Core::WriteData(MojoHandle data_pipe_producer_handle,
   return dispatcher->WriteData(elements, num_bytes, validated_options);
 }
 
-#if defined(CASTANETS)
-MojoResult Core::SyncData(MojoHandle data_pipe_producer_handle,
-                          uint32_t num_bytes_written) {
-  RequestContext request_context;
-  scoped_refptr<Dispatcher> dispatcher(
-      GetDispatcher(data_pipe_producer_handle));
-  if (!dispatcher)
-    return MOJO_RESULT_INVALID_ARGUMENT;
-  return dispatcher->SyncData(num_bytes_written);
-}
-#endif
-
 MojoResult Core::BeginWriteData(MojoHandle data_pipe_producer_handle,
                                 const MojoBeginWriteDataOptions* options,
                                 void** buffer,

--- a/mojo/core/core.h
+++ b/mojo/core/core.h
@@ -240,10 +240,6 @@ class MOJO_SYSTEM_IMPL_EXPORT Core {
                        const void* elements,
                        uint32_t* num_bytes,
                        const MojoWriteDataOptions* options);
-#if defined(CASTANETS)
-  MojoResult SyncData(MojoHandle data_pipe_producer_handle,
-                      uint32_t num_bytes_written);
-#endif
   MojoResult BeginWriteData(MojoHandle data_pipe_producer_handle,
                             const MojoBeginWriteDataOptions* options,
                             void** buffer,

--- a/mojo/core/data_pipe_producer_dispatcher.cc
+++ b/mojo/core/data_pipe_producer_dispatcher.cc
@@ -238,6 +238,9 @@ MojoResult DataPipeProducerDispatcher::EndWriteData(
     write_offset_ =
         (write_offset_ + num_bytes_written) % options_.capacity_num_bytes;
 
+#if defined(CASTANETS)
+    SyncData(num_bytes_written);
+#endif
     base::AutoUnlock unlock(lock_);
     NotifyWrite(num_bytes_written);
   }

--- a/mojo/core/data_pipe_producer_dispatcher.h
+++ b/mojo/core/data_pipe_producer_dispatcher.h
@@ -44,9 +44,6 @@ class MOJO_SYSTEM_IMPL_EXPORT DataPipeProducerDispatcher final
   MojoResult WriteData(const void* elements,
                        uint32_t* num_bytes,
                        const MojoWriteDataOptions& options) override;
-#if defined(CASTANETS)
-  MojoResult SyncData(uint32_t num_bytes_written) override;
-#endif
   MojoResult BeginWriteData(void** buffer, uint32_t* buffer_num_bytes) override;
   MojoResult EndWriteData(uint32_t num_bytes_written) override;
   HandleSignalsState GetHandleSignalsState() const override;
@@ -89,6 +86,10 @@ class MOJO_SYSTEM_IMPL_EXPORT DataPipeProducerDispatcher final
   void NotifyWrite(uint32_t num_bytes);
   void OnPortStatusChanged();
   void UpdateSignalsStateNoLock();
+
+#if defined(CASTANETS)
+  MojoResult SyncData(uint32_t num_bytes_written);
+#endif
 
   const MojoCreateDataPipeOptions options_;
   NodeController* const node_controller_;

--- a/mojo/core/dispatcher.cc
+++ b/mojo/core/dispatcher.cc
@@ -87,12 +87,6 @@ MojoResult Dispatcher::WriteData(const void* elements,
   return MOJO_RESULT_INVALID_ARGUMENT;
 }
 
-#if defined(CASTANETS)
-MojoResult Dispatcher::SyncData(uint32_t num_bytes_written) {
-  return MOJO_RESULT_INVALID_ARGUMENT;
-}
-#endif
-
 MojoResult Dispatcher::BeginWriteData(void** buffer,
                                       uint32_t* buffer_num_bytes) {
   return MOJO_RESULT_INVALID_ARGUMENT;

--- a/mojo/core/dispatcher.h
+++ b/mojo/core/dispatcher.h
@@ -124,10 +124,6 @@ class MOJO_SYSTEM_IMPL_EXPORT Dispatcher
                                uint32_t* num_bytes,
                                const MojoWriteDataOptions& options);
 
-#if defined(CASTANETS)
-  virtual MojoResult SyncData(uint32_t num_bytes_written);
-#endif
-
   virtual MojoResult BeginWriteData(void** buffer, uint32_t* buffer_num_bytes);
 
   virtual MojoResult EndWriteData(uint32_t num_bytes_written);

--- a/mojo/core/entrypoints.cc
+++ b/mojo/core/entrypoints.cc
@@ -143,13 +143,6 @@ MojoResult MojoWriteDataImpl(MojoHandle data_pipe_producer_handle,
                            options);
 }
 
-#if defined(CASTANETS)
-MojoResult MojoSyncDataImpl(MojoHandle data_pipe_producer_handle,
-                            uint32_t num_bytes_written) {
-  return g_core->SyncData(data_pipe_producer_handle, num_bytes_written);
-}
-#endif
-
 MojoResult MojoBeginWriteDataImpl(MojoHandle data_pipe_producer_handle,
                                   const MojoBeginWriteDataOptions* options,
                                   void** buffer,
@@ -383,7 +376,6 @@ MojoSystemThunks g_thunks = {sizeof(MojoSystemThunks),
                              MojoNotifyBadMessageImpl,
                              MojoCreateDataPipeImpl,
                              MojoWriteDataImpl,
-                             MojoSyncDataImpl,
                              MojoBeginWriteDataImpl,
                              MojoEndWriteDataImpl,
                              MojoReadDataImpl,

--- a/mojo/public/c/system/data_pipe.h
+++ b/mojo/public/c/system/data_pipe.h
@@ -245,12 +245,6 @@ MojoWriteData(MojoHandle data_pipe_producer_handle,
               uint32_t* num_bytes,
               const struct MojoWriteDataOptions* options);
 
-#if defined(CASTANETS)
-MOJO_SYSTEM_EXPORT MojoResult
-MojoSyncData(MojoHandle data_pipe_producer_handle,
-             uint32_t num_bytes_written);
-#endif
-
 // Begins a two-phase write to the data pipe producer given by
 // |data_pipe_producer_handle|. On success |*buffer| will be a pointer to which
 // the caller can write up to |*buffer_num_bytes| bytes of data.

--- a/mojo/public/c/system/thunks.cc
+++ b/mojo/public/c/system/thunks.cc
@@ -207,13 +207,6 @@ MojoResult MojoWriteData(MojoHandle data_pipe_producer_handle,
                       num_elements, options);
 }
 
-#if defined(CASTANETS)
-MojoResult MojoSyncData(MojoHandle data_pipe_producer_handle,
-                        uint32_t num_bytes_written) {
-  return INVOKE_THUNK(SyncData, data_pipe_producer_handle, num_bytes_written);
-}
-#endif
-
 MojoResult MojoBeginWriteData(MojoHandle data_pipe_producer_handle,
                               const MojoBeginWriteDataOptions* options,
                               void** buffer,

--- a/mojo/public/c/system/thunks.h
+++ b/mojo/public/c/system/thunks.h
@@ -103,10 +103,6 @@ struct MojoSystemThunks {
                           const void* elements,
                           uint32_t* num_elements,
                           const struct MojoWriteDataOptions* options);
-#if defined(CASTANETS)
-  MojoResult (*SyncData)(MojoHandle data_pipe_producer_handle,
-                         uint32_t num_bytes_written);
-#endif
   MojoResult (*BeginWriteData)(MojoHandle data_pipe_producer_handle,
                                const struct MojoBeginWriteDataOptions* options,
                                void** buffer,

--- a/mojo/public/cpp/system/data_pipe.h
+++ b/mojo/public/cpp/system/data_pipe.h
@@ -38,12 +38,6 @@ class DataPipeProducerHandle : public Handle {
     return MojoWriteData(value(), elements, num_bytes, &options);
   }
 
-#if defined(CASTANETS)
-  MojoResult SyncData(uint32_t num_bytes_written) const {
-    return MojoSyncData(value(), num_bytes_written);
-  }
-#endif
-
   // Begins a two-phase write to a data pipe. See |MojoBeginWriteData()| for
   // complete documentation.
   MojoResult BeginWriteData(void** buffer,


### PR DESCRIPTION
This CL removes all the functions that make the data pipe's client call sync directly. Data written to the ring buffer of the data pipe will attempt to sync immediately in DataPipeProducerDispatcher::EndWriteData().