### PR TITLE
Launch renderer process via forking at timeout

### DIFF
--- a/content/browser/child_process_launcher_helper.cc
+++ b/content/browser/child_process_launcher_helper.cc
@@ -22,6 +22,13 @@
 #include "content/browser/android/launcher_thread.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/base_switches.h"
+#include "content/browser/renderer_host/input/timeout_monitor.h"
+
+int kTcpConnectionTimeout = 5;
+#endif
+
 namespace content {
 namespace internal {
 
@@ -76,12 +83,36 @@ ChildProcessLauncherHelper::ChildProcessLauncherHelper(
       command_line_(std::move(command_line)),
       delegate_(std::move(delegate)),
       child_process_launcher_(child_process_launcher),
+#if defined(CASTANETS)
+      tcp_connected_(false),
+#endif
       terminate_on_shutdown_(terminate_on_shutdown),
       mojo_invitation_(std::move(mojo_invitation)),
-      process_error_callback_(process_error_callback) {}
+      process_error_callback_(process_error_callback) {
+#if defined(CASTANETS)
+  tcp_success_callback_ = base::BindRepeating(
+      &ChildProcessLauncherHelper::OnCastanetsRendererLaunchedViaTcp,
+      base::Unretained(this));
+  relaunch_renderer_process_monitor_timeout_.reset(new TimeoutMonitor(
+      base::Bind(&ChildProcessLauncherHelper::OnCastanetsRendererTimeout,
+                 base::Unretained(this))));
+  relaunch_renderer_process_monitor_timeout_->Start(
+      base::TimeDelta::FromSeconds(kTcpConnectionTimeout));
+#endif
+}
 
 ChildProcessLauncherHelper::~ChildProcessLauncherHelper() = default;
+#if defined(CASTANETS)
+void ChildProcessLauncherHelper::OnCastanetsRendererTimeout() {
+  success_or_timeout_event_.Signal();
+}
 
+void ChildProcessLauncherHelper::OnCastanetsRendererLaunchedViaTcp() {
+  tcp_connected_ = true;
+  success_or_timeout_event_.Signal();
+  relaunch_renderer_process_monitor_timeout_->Stop();
+}
+#endif
 void ChildProcessLauncherHelper::StartLaunchOnClientThread() {
   DCHECK_CURRENTLY_ON(client_thread_id_);
 
@@ -121,7 +152,41 @@ void ChildProcessLauncherHelper::LaunchOnLauncherThread() {
     PostLaunchOnLauncherThread(std::move(process), launch_result);
   }
 }
+#if defined(CASTANETS)
+ChildProcessLauncherHelper::Process
+ChildProcessLauncherHelper::RetrySendOutgoingInvitation(
+    base::ProcessHandle old_process,
+    const mojo::ProcessErrorCallback& error_callback) {
+  command_line_->AppendSwitchASCII(switches::kRendererClientId,
+                                   std::to_string(child_process_id_));
 
+  DCHECK(CurrentlyOnProcessLauncherTaskRunner());
+
+  mojo_named_channel_.reset();
+  mojo_channel_.emplace();
+
+  begin_launch_time_ = base::TimeTicks::Now();
+
+  std::unique_ptr<FileMappedForLaunch> files_to_register = GetFilesToMap();
+
+  int launch_result = LAUNCH_RESULT_FAILURE;
+  base::LaunchOptions options;
+
+  Process process;
+  if (BeforeLaunchOnLauncherThread(*files_to_register, &options)) {
+    process.process = base::LaunchProcess(*command_line(), options);
+    launch_result = process.process.IsValid() ? LAUNCH_RESULT_SUCCESS
+                                              : LAUNCH_RESULT_FAILURE;
+
+    AfterLaunchOnLauncherThread(process, options);
+  }
+
+  mojo::OutgoingInvitation::Retry(old_process, process.process.Handle(),
+                                  mojo_channel_->TakeLocalEndpoint());
+
+  return process;
+}
+#endif
 void ChildProcessLauncherHelper::PostLaunchOnLauncherThread(
     ChildProcessLauncherHelper::Process process,
     int launch_result) {
@@ -153,10 +218,24 @@ void ChildProcessLauncherHelper::PostLaunchOnLauncherThread(
       DCHECK(mojo_named_channel_);
       mojo::OutgoingInvitation::Send(
           std::move(invitation), process.process.Handle(),
+#if defined(CASTANETS)
+          mojo_named_channel_->TakeServerEndpoint(), process_error_callback_,
+          tcp_success_callback_);
+#else
           mojo_named_channel_->TakeServerEndpoint(), process_error_callback_);
+#endif
     }
   }
-
+#if defined(CASTANETS)
+  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kEnableForking)) {
+    // If --enable-forking switch exists, we don't have to wait.
+    success_or_timeout_event_.Wait();
+    if (!tcp_connected_)
+      process = RetrySendOutgoingInvitation(process.process.Handle(),
+                                            process_error_callback_);
+  }
+#endif
   BrowserThread::PostTask(
       client_thread_id_, FROM_HERE,
       base::BindOnce(&ChildProcessLauncherHelper::PostLaunchOnClientThread,

--- a/content/browser/child_process_launcher_helper.h
+++ b/content/browser/child_process_launcher_helper.h
@@ -43,6 +43,10 @@
 #include "services/service_manager/zygote/common/zygote_handle.h"  // nogncheck
 #endif
 
+#if defined(CASTANETS)
+#include "base/synchronization/waitable_event.h"
+#endif
+
 namespace base {
 class CommandLine;
 }
@@ -51,6 +55,9 @@ namespace content {
 
 class ChildProcessLauncher;
 class SandboxedProcessLauncherDelegate;
+#if defined(CASTANETS)
+class TimeoutMonitor;
+#endif
 struct ChildProcessLauncherPriority;
 struct ChildProcessTerminationInfo;
 
@@ -170,7 +177,14 @@ class ChildProcessLauncherHelper :
   // Returns immediately and perform the work on the launcher thread.
   static void ForceNormalProcessTerminationAsync(
       ChildProcessLauncherHelper::Process process);
+#if defined(CASTANETS)
+  void OnCastanetsRendererTimeout();
+  void OnCastanetsRendererLaunchedViaTcp();
 
+  ChildProcessLauncherHelper::Process RetrySendOutgoingInvitation(
+      base::ProcessHandle old_process,
+      const mojo::ProcessErrorCallback& error_callback);
+#endif
   void SetProcessPriorityOnLauncherThread(
       base::Process process,
       const ChildProcessLauncherPriority& priority);
@@ -225,11 +239,18 @@ class ChildProcessLauncherHelper :
   // returns a valid server endpoint from
   // |CreateNamedPlatformChannelOnClientThread()|.
   base::Optional<mojo::NamedPlatformChannel> mojo_named_channel_;
+#if defined(CASTANETS)
+  std::unique_ptr<TimeoutMonitor> relaunch_renderer_process_monitor_timeout_;
+  base::WaitableEvent success_or_timeout_event_;
+  bool tcp_connected_;
+#endif
 
   bool terminate_on_shutdown_;
   mojo::OutgoingInvitation mojo_invitation_;
   const mojo::ProcessErrorCallback process_error_callback_;
-
+#if defined(CASTANETS)
+  base::RepeatingCallback<void()> tcp_success_callback_;
+#endif
 #if defined(OS_MACOSX)
   std::unique_ptr<sandbox::SeatbeltExecClient> seatbelt_exec_client_;
 #endif  // defined(OS_MACOSX)

--- a/mojo/core/broker_castanets.cc
+++ b/mojo/core/broker_castanets.cc
@@ -314,6 +314,21 @@ void BrokerCastanets::AddSyncFence(const base::UnguessableToken& guid,
   fence_queue_->AddFence(guid, fence_id);
 }
 
+void BrokerCastanets::ResetNodeChannel(ConnectionParams node_connection_pararms,
+                                       ScopedProcessHandle process_handle) {
+  node_channel_->SetSocket(std::move(node_connection_pararms));
+  node_channel_->Start();
+  node_channel_->SetRemoteProcessHandle(std::move(process_handle));
+}
+
+void BrokerCastanets::ResetBrokerChannel(ConnectionParams connection_params) {
+  sync_channel_ = PlatformHandle(base::ScopedFD(
+      connection_params.endpoint().platform_handle().GetFD().get()));
+  channel_->ClearOutgoingMessages();
+  channel_->SetSocket(std::move(connection_params));
+  channel_->Start();
+}
+
 PlatformChannelEndpoint BrokerCastanets::GetInviterEndpoint() {
   return std::move(inviter_endpoint_);
 }

--- a/mojo/core/broker_castanets.h
+++ b/mojo/core/broker_castanets.h
@@ -44,6 +44,10 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
     CHECK(node_channel);
     node_channel_ = node_channel;
   }
+  void ResetNodeChannel(ConnectionParams connection_params,
+                        ScopedProcessHandle process_handle);
+
+  void ResetBrokerChannel(ConnectionParams connection_params);
 
   // Returns the platform handle that should be used to establish a NodeChannel
   // to the process which is inviting us to join its network. This is the first
@@ -77,9 +81,9 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
   bool IsHost() const { return host_; }
 
   BrokerCastanets(base::ProcessHandle client_process,
-             ConnectionParams connection_params,
-             const ProcessErrorCallback& process_error_callback,
-             CastanetsFenceManager* fence_manager);
+                  ConnectionParams connection_params,
+                  const ProcessErrorCallback& process_error_callback,
+                  CastanetsFenceManager* fence_manager);
 
   // Send |handle| to the client, to be used to establish a NodeChannel to us.
   bool SendChannel(PlatformHandle handle);

--- a/mojo/core/channel.h
+++ b/mojo/core/channel.h
@@ -279,7 +279,10 @@ class MOJO_SYSTEM_IMPL_EXPORT Channel
     remote_process_ = std::move(remote_process);
   }
   const ScopedProcessHandle& remote_process() const { return remote_process_; }
-
+#if defined(CASTANETS)
+  virtual void SetSocket(ConnectionParams connection_params) {}
+  virtual void ClearOutgoingMessages() {}
+#endif
   // Begin processing I/O events. Delegate methods must only be invoked after
   // this call.
   virtual void Start() = 0;

--- a/mojo/core/channel_posix.cc
+++ b/mojo/core/channel_posix.cc
@@ -115,7 +115,19 @@ class ChannelPosix : public Channel,
 
     CHECK(server_.is_valid() || socket_.is_valid());
   }
+#if defined(CASTANETS)
+  void SetSocket(ConnectionParams connection_params) override {
+    read_watcher_.reset();
+    write_watcher_.reset();
 
+    ignore_result(socket_.release());
+    server_.TakePlatformHandle().release();
+
+    socket_ = connection_params.TakeEndpoint().TakePlatformHandle().TakeFD();
+  }
+
+  void ClearOutgoingMessages() override { outgoing_messages_.clear(); }
+#endif
   void Start() override {
 #if defined(OS_MACOSX) && !defined(OS_IOS)
     auto* relay = Core::Get()->GetMachPortRelay();

--- a/mojo/core/core.cc
+++ b/mojo/core/core.cc
@@ -1310,7 +1310,12 @@ MojoResult Core::SendInvitation(
     const MojoInvitationTransportEndpoint* transport_endpoint,
     MojoProcessErrorHandler error_handler,
     uintptr_t error_handler_context,
+#if defined(CASTANETS)
+    const MojoSendInvitationOptions* options,
+    base::RepeatingCallback<void()> tcp_success_callback) {
+#else
     const MojoSendInvitationOptions* options) {
+#endif
   if (options && options->struct_size < sizeof(*options))
     return MOJO_RESULT_INVALID_ARGUMENT;
 
@@ -1414,7 +1419,11 @@ MojoResult Core::SendInvitation(
   } else {
     GetNodeController()->SendBrokerClientInvitation(
         target_process, std::move(connection_params), attached_ports,
+#if defined(CASTANETS)
+        process_error_callback, tcp_success_callback);
+#else
         process_error_callback);
+#endif
   }
 
   return MOJO_RESULT_OK;
@@ -1491,7 +1500,71 @@ MojoResult Core::AcceptInvitation(
 
   return MOJO_RESULT_OK;
 }
+#if defined(CASTANETS)
+MojoResult Core::RetryInvitation(
+    const struct MojoPlatformProcessHandle* old_process_handle,
+    const struct MojoPlatformProcessHandle* process_handle,
+    const struct MojoInvitationTransportEndpoint* transport_endpoint) {
+  base::ProcessHandle old_process, target_process = base::kNullProcessHandle;
+  if (old_process_handle) {
+    if (old_process_handle->struct_size < sizeof(*old_process_handle))
+      return MOJO_RESULT_INVALID_ARGUMENT;
+#if defined(OS_WIN)
+    old_process = reinterpret_cast<base::ProcessHandle>(
+        static_cast<uintptr_t>(old_process_handle->value));
+#else
+    old_process = static_cast<base::ProcessHandle>(old_process_handle->value);
+#endif
+  }
+  if (process_handle) {
+    if (process_handle->struct_size < sizeof(*process_handle))
+      return MOJO_RESULT_INVALID_ARGUMENT;
+#if defined(OS_WIN)
+    target_process = reinterpret_cast<base::ProcessHandle>(
+        static_cast<uintptr_t>(process_handle->value));
+#else
+    target_process = static_cast<base::ProcessHandle>(process_handle->value);
+#endif
+  }
 
+  if (!transport_endpoint)
+    return MOJO_RESULT_INVALID_ARGUMENT;
+  if (transport_endpoint->struct_size < sizeof(*transport_endpoint))
+    return MOJO_RESULT_INVALID_ARGUMENT;
+  if (transport_endpoint->num_platform_handles == 0)
+    return MOJO_RESULT_INVALID_ARGUMENT;
+  if (!transport_endpoint->platform_handles)
+    return MOJO_RESULT_INVALID_ARGUMENT;
+  if (transport_endpoint->type != MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL &&
+      transport_endpoint->type !=
+          MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER) {
+    return MOJO_RESULT_UNIMPLEMENTED;
+  }
+
+  auto endpoint = PlatformHandle::FromMojoPlatformHandle(
+      &transport_endpoint->platform_handles[0]);
+  if (!endpoint.is_valid())
+    return MOJO_RESULT_INVALID_ARGUMENT;
+
+  ConnectionParams connection_params;
+#if defined(OS_WIN) || defined(OS_POSIX)
+  if (transport_endpoint->type ==
+      MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER) {
+    connection_params =
+        ConnectionParams(PlatformChannelServerEndpoint(std::move(endpoint)));
+  }
+#endif
+  if (!connection_params.server_endpoint().is_valid()) {
+    connection_params =
+        ConnectionParams(PlatformChannelEndpoint(std::move(endpoint)));
+  }
+
+  GetNodeController()->RetryInvitation(old_process, target_process,
+                                       std::move(connection_params));
+
+  return MOJO_RESULT_OK;
+}
+#endif
 MojoResult Core::SetQuota(MojoHandle handle,
                           MojoQuotaType type,
                           uint64_t limit,

--- a/mojo/core/core.h
+++ b/mojo/core/core.h
@@ -334,12 +334,22 @@ class MOJO_SYSTEM_IMPL_EXPORT Core {
       const MojoInvitationTransportEndpoint* transport_endpoint,
       MojoProcessErrorHandler error_handler,
       uintptr_t error_handler_context,
+#if defined(CASTANETS)
+      const MojoSendInvitationOptions* options,
+      base::RepeatingCallback<void()> tcp_success_callback = {});
+#else
       const MojoSendInvitationOptions* options);
+#endif
   MojoResult AcceptInvitation(
       const MojoInvitationTransportEndpoint* transport_endpoint,
       const MojoAcceptInvitationOptions* options,
       MojoHandle* invitation_handle);
-
+#if defined(CASTANETS)
+  MojoResult RetryInvitation(
+      const struct MojoPlatformProcessHandle* old_process_handle,
+      const struct MojoPlatformProcessHandle* process_handle,
+      const struct MojoInvitationTransportEndpoint* transport_endpoint);
+#endif
   // Quota API.
   MojoResult SetQuota(MojoHandle handle,
                       MojoQuotaType type,

--- a/mojo/core/entrypoints.cc
+++ b/mojo/core/entrypoints.cc
@@ -330,12 +330,28 @@ MojoResult MojoSendInvitationImpl(
     const MojoInvitationTransportEndpoint* transport_endpoint,
     MojoProcessErrorHandler error_handler,
     uintptr_t error_handler_context,
+#if defined(CASTANETS)
+    const MojoSendInvitationOptions* options,
+    base::RepeatingCallback<void()> tcp_success_callback) {
+  return g_core->SendInvitation(
+      invitation_handle, process_handle, transport_endpoint, error_handler,
+      error_handler_context, options, tcp_success_callback);
+#else
     const MojoSendInvitationOptions* options) {
   return g_core->SendInvitation(invitation_handle, process_handle,
                                 transport_endpoint, error_handler,
                                 error_handler_context, options);
+#endif
 }
-
+#if defined(CASTANETS)
+MojoResult MojoRetryInvitation(
+    const struct MojoPlatformProcessHandle* old_process_handle,
+    const struct MojoPlatformProcessHandle* process_handle,
+    const struct MojoInvitationTransportEndpoint* transport_endpoint) {
+  return g_core->RetryInvitation(old_process_handle, process_handle,
+                                 transport_endpoint);
+}
+#endif
 MojoResult MojoAcceptInvitationImpl(
     const MojoInvitationTransportEndpoint* transport_endpoint,
     const MojoAcceptInvitationOptions* options,
@@ -405,6 +421,9 @@ MojoSystemThunks g_thunks = {sizeof(MojoSystemThunks),
                              MojoAttachMessagePipeToInvitationImpl,
                              MojoExtractMessagePipeFromInvitationImpl,
                              MojoSendInvitationImpl,
+#if defined(CASTANETS)
+                             MojoRetryInvitation,
+#endif
                              MojoAcceptInvitationImpl,
                              MojoSetQuotaImpl,
                              MojoQueryQuotaImpl};

--- a/mojo/core/node_channel.cc
+++ b/mojo/core/node_channel.cc
@@ -466,7 +466,11 @@ NodeChannel::NodeChannel(Delegate* delegate,
 NodeChannel::~NodeChannel() {
   ShutDown();
 }
-
+#if defined(CASTANETS)
+void NodeChannel::SetSocket(ConnectionParams connection_params) {
+  channel_->SetSocket(std::move(connection_params));
+}
+#endif
 void NodeChannel::OnChannelMessage(const void* payload,
                                    size_t payload_size,
                                    std::vector<PlatformHandle> handles) {

--- a/mojo/core/node_channel.h
+++ b/mojo/core/node_channel.h
@@ -99,7 +99,9 @@ class NodeChannel : public base::RefCountedThreadSafe<NodeChannel>,
   static void GetEventMessageData(Channel::Message* message,
                                   void** data,
                                   size_t* num_data_bytes);
-
+#if defined(CASTANETS)
+  void SetSocket(ConnectionParams connection_params);
+#endif
   // Start receiving messages.
   void Start();
 

--- a/mojo/core/node_controller.h
+++ b/mojo/core/node_controller.h
@@ -88,8 +88,17 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
       base::ProcessHandle target_process,
       ConnectionParams connection_params,
       const std::vector<std::pair<std::string, ports::PortRef>>& attached_ports,
+#if defined(CASTANETS)
+      const ProcessErrorCallback& process_error_callback,
+      base::RepeatingCallback<void()> tcp_success_callback = {});
+#else
       const ProcessErrorCallback& process_error_callback);
-
+#endif
+#if defined(CASTANETS)
+  void RetryInvitation(base::ProcessHandle old_process,
+                       base::ProcessHandle target_process,
+                       ConnectionParams connection_params);
+#endif
   // Connects this node to the process which invited it to be a broker client.
   void AcceptBrokerClientInvitation(ConnectionParams connection_params);
 
@@ -181,6 +190,11 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
       ConnectionParams connection_params,
       ports::NodeName token,
       const ProcessErrorCallback& process_error_callback);
+#if defined(CASTANETS)
+  void RetryInvitationOnIOThread(ScopedProcessHandle old_process,
+                                 ScopedProcessHandle target_process,
+                                 ConnectionParams connection_params);
+#endif
   void AcceptBrokerClientInvitationOnIOThread(
       ConnectionParams connection_params);
 
@@ -277,6 +291,9 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
   Core* const core_;
   const ports::NodeName name_;
   const std::unique_ptr<ports::Node> node_;
+#if defined(CASTANETS)
+  base::RepeatingCallback<void()> tcp_success_callback_;
+#endif
   scoped_refptr<base::TaskRunner> io_task_runner_;
 
   // Guards |peers_| and |pending_peer_messages_|.

--- a/mojo/public/c/system/invitation.h
+++ b/mojo/public/c/system/invitation.h
@@ -17,6 +17,10 @@
 #include "mojo/public/c/system/system_export.h"
 #include "mojo/public/c/system/types.h"
 
+#if defined(CASTANETS)
+#include "base/callback.h"
+#endif
+
 // Flags included in |MojoProcessErrorDetails| indicating additional status
 // information.
 typedef uint32_t MojoProcessErrorFlags;
@@ -410,8 +414,18 @@ MOJO_SYSTEM_EXPORT MojoResult MojoSendInvitation(
     const struct MojoInvitationTransportEndpoint* transport_endpoint,
     MojoProcessErrorHandler error_handler,
     uintptr_t error_handler_context,
+#if defined(CASTANETS)
+    const struct MojoSendInvitationOptions* options,
+    base::RepeatingCallback<void()> tcp_success_callback = {});
+#else
     const struct MojoSendInvitationOptions* options);
-
+#endif
+#if defined(CASTANETS)
+MOJO_SYSTEM_EXPORT MojoResult MojoRetryInvitation(
+    const struct MojoPlatformProcessHandle* old_process_handle,
+    const struct MojoPlatformProcessHandle* process_handle,
+    const struct MojoInvitationTransportEndpoint* transport_endpoint);
+#endif
 // Accepts an invitation from a transport endpoint to complete IPC bootstrapping
 // between the calling process and whoever sent the invitation from the other
 // end of the transport.

--- a/mojo/public/c/system/thunks.cc
+++ b/mojo/public/c/system/thunks.cc
@@ -454,10 +454,19 @@ MojoResult MojoSendInvitation(
     const MojoInvitationTransportEndpoint* transport_endpoint,
     MojoProcessErrorHandler error_handler,
     uintptr_t error_handler_context,
-    const MojoSendInvitationOptions* options) {
+    const MojoSendInvitationOptions* options,
+    base::RepeatingCallback<void()> tcp_success_callback) {
   return INVOKE_THUNK(SendInvitation, invitation_handle, process_handle,
                       transport_endpoint, error_handler, error_handler_context,
-                      options);
+                      options, std::move(tcp_success_callback));
+}
+
+MojoResult MojoRetryInvitation(
+    const struct MojoPlatformProcessHandle* old_process_handle,
+    const struct MojoPlatformProcessHandle* process_handle,
+    const struct MojoInvitationTransportEndpoint* transport_endpoint) {
+  return INVOKE_THUNK(RetryInvitation, old_process_handle, process_handle,
+                      transport_endpoint);
 }
 
 MojoResult MojoAcceptInvitation(

--- a/mojo/public/c/system/thunks.h
+++ b/mojo/public/c/system/thunks.h
@@ -215,7 +215,18 @@ struct MojoSystemThunks {
       const struct MojoInvitationTransportEndpoint* transport_endpoint,
       MojoProcessErrorHandler error_handler,
       uintptr_t error_handler_context,
+#if defined(CASTANETS)
+      const struct MojoSendInvitationOptions* options,
+      base::RepeatingCallback<void()> tcp_success_callback);
+#else
       const struct MojoSendInvitationOptions* options);
+#endif
+#if defined(CASTANETS)
+  MojoResult (*RetryInvitation)(
+      const struct MojoPlatformProcessHandle* old_process_handle,
+      const struct MojoPlatformProcessHandle* process_handle,
+      const struct MojoInvitationTransportEndpoint* transport_endpoint);
+#endif
   MojoResult (*AcceptInvitation)(
       const struct MojoInvitationTransportEndpoint* transport_endpoint,
       const struct MojoAcceptInvitationOptions* options,

--- a/mojo/public/cpp/system/invitation.h
+++ b/mojo/public/cpp/system/invitation.h
@@ -97,8 +97,17 @@ class MOJO_CPP_SYSTEM_EXPORT OutgoingInvitation {
   static void Send(OutgoingInvitation invitation,
                    base::ProcessHandle target_process,
                    PlatformChannelServerEndpoint server_endpoint,
+#if defined(CASTANETS)
+                   const ProcessErrorCallback& error_callback = {},
+                   base::RepeatingCallback<void()> tcp_success_callback = {});
+#else
                    const ProcessErrorCallback& error_callback = {});
-
+#endif
+#if defined(CASTANETS)
+  static void Retry(base::ProcessHandle old_process,
+                    base::ProcessHandle process,
+                    PlatformChannelEndpoint channel_endpoint);
+#endif
   // Sends an isolated invitation over |endpoint|. The process at the other
   // endpoint must use |IncomingInvitation::AcceptIsolated()| to accept the
   // invitation.


### PR DESCRIPTION
This CL for Castanets to launch renderer process if launching via tcp connection is not established within timeout.