### PR TITLE
[DCHECK] ChildProcessLauncherHelper::GetFilesToMap()

### DIFF
--- a/content/browser/child_process_launcher_helper.cc
+++ b/content/browser/child_process_launcher_helper.cc
@@ -125,6 +125,12 @@ void ChildProcessLauncherHelper::LaunchOnLauncherThread() {
 void ChildProcessLauncherHelper::PostLaunchOnLauncherThread(
     ChildProcessLauncherHelper::Process process,
     int launch_result) {
+#if defined(CASTANETS)
+  // If mojo_named_channel_ is valid, we are trying to launch process
+  // in Castanets mode, mojo_channel_ is no longer needed.
+  if (mojo_named_channel_)
+    mojo_channel_ = base::nullopt;
+#endif
   if (mojo_channel_)
     mojo_channel_->RemoteProcessLaunchAttempted();
 

--- a/content/browser/child_process_launcher_helper_linux.cc
+++ b/content/browser/child_process_launcher_helper_linux.cc
@@ -44,6 +44,9 @@ ChildProcessLauncherHelper::CreateNamedPlatformChannelOnClientThread() {
   if (GetProcessType() == switches::kUtilityProcess)
     options.port = mojo::kCastanetsUtilityPort;
 
+  // This socket pair is not used, however it is added
+  // to avoid failure of validation check of codes afterwards.
+  mojo_channel_.emplace();
   return mojo::NamedPlatformChannel(options);
 #else
   DCHECK_CURRENTLY_ON(client_thread_id_);


### PR DESCRIPTION
For NamedPlatformChannel, channel is not created
and therefore mojo_channel_ wrapped in optional.h
is not populated and hence DCHECK.
Since the server endpoint is not connected,
PlatformChannelEndPoint is invalid. So there may be no
need to map the shared region for named channel.

Bug: 174 [GitHub.com/samsung/Catsanets]