### PR TITLE
Add trace logs to profile the shared memory synchronization.

### DIFF
--- a/base/trace_event/trace_log.cc
+++ b/base/trace_event/trace_log.cc
@@ -1201,7 +1201,13 @@ TraceEventHandle TraceLog::AddTraceEventWithThreadIdAndTimestamp(
     id = MangleEventId(id);
   }
 
+#if defined(CASTANETS)
+  // Some timestamps bring the timeticks of the other process,
+  // it causes a problem.
+  TimeTicks offset_event_timestamp = OffsetNow();
+#else
   TimeTicks offset_event_timestamp = OffsetTimestamp(timestamp);
+#endif
   ThreadTicks thread_now = ThreadNow();
 
   ThreadLocalEventBuffer* thread_local_event_buffer = nullptr;

--- a/mojo/core/broker_castanets.cc
+++ b/mojo/core/broker_castanets.cc
@@ -14,6 +14,8 @@
 #include "base/memory/shared_memory_helper.h"
 #include "base/memory/shared_memory_tracker.h"
 #include "base/threading/thread_task_runner_handle.h"
+#include "base/trace_event/trace_event.h"
+#include "base/trace_event/trace_event_argument.h"
 #include "build/build_config.h"
 #include "mojo/core/broker_messages.h"
 #include "mojo/core/channel.h"
@@ -205,6 +207,9 @@ void BrokerCastanets::SyncSharedBufferImpl(const base::UnguessableToken& guid,
     BeginSync(guid);
 
   CHECK_GE(mapped_size, offset + sync_size);
+
+  TRACE_EVENT2("SyncSharedMemory", "BrokerCastanets::SyncSharedBufferImpl",
+               "GUID", guid.ToString(), "sync_bytes", sync_size);
   BufferSyncData* buffer_sync = nullptr;
   void* extra_data = nullptr;
   Channel::MessagePtr out_message =
@@ -234,6 +239,8 @@ void BrokerCastanets::OnBufferSync(uint64_t guid_high, uint64_t guid_low,
   base::UnguessableToken guid =
       base::UnguessableToken::Deserialize(guid_high, guid_low);
 
+  TRACE_EVENT2("SyncSharedMemory", "BrokerCastanets::OnBufferSync", "GUID",
+               guid.ToString(), "sync_bytes", sync_bytes);
   VLOG(2) << "Recv sync" << guid << " offset: " << offset
           << ", sync_size: " << sync_bytes
           << ", buffer_size: " << buffer_bytes;

--- a/services/tracing/public/cpp/trace_event_agent.cc
+++ b/services/tracing/public/cpp/trace_event_agent.cc
@@ -22,6 +22,10 @@
 #include "services/tracing/public/cpp/tracing_features.h"
 #include "services/tracing/public/mojom/constants.mojom.h"
 
+#if defined(CASTANETS)
+#include "base/command_line.h"
+#endif
+
 #if defined(OS_ANDROID) || defined(OS_LINUX) || defined(OS_MACOSX) || \
     defined(OS_WIN)
 #define PERFETTO_AVAILABLE
@@ -146,6 +150,13 @@ void LegacyTraceEventAgent::StartTracing(const std::string& config,
   // latency.
   base::TimeDelta time_offset = TRACE_TIME_TICKS_NOW() - coordinator_time;
   TraceLog::GetInstance()->SetTimeOffset(time_offset);
+#endif
+#if defined(CASTANETS)
+  if (std::string("renderer") ==
+      base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
+    base::TimeDelta time_offset = TRACE_TIME_TICKS_NOW() - coordinator_time;
+    base::trace_event::TraceLog::GetInstance()->SetTimeOffset(time_offset);
+  }
 #endif
   enabled_tracing_modes_ = base::trace_event::TraceLog::RECORDING_MODE;
   const base::trace_event::TraceConfig trace_config(config);


### PR DESCRIPTION
The progress of the shared memory synchronization is very important
on Castanets. We want to use Chrome trace to do that and time ticks
between processes need to be synchronized.

This CL still has a problem because the network delay affects timestamps.
We better check only total memories transferred without a duration.