### PR TITLE
Enable to play video with MediaElement

### DIFF
--- a/cc/layers/video_frame_provider_client_impl.cc
+++ b/cc/layers/video_frame_provider_client_impl.cc
@@ -155,9 +155,19 @@ void VideoFrameProviderClientImpl::OnBeginFrame(
 
     // We use frame_time + interval here because that is the estimated time at
     // which a frame returned during this phase will end up being displayed.
+#if defined(CASTANETS)
+    // FIXME: |BeginFrameArgs| comes from browser process, but the system time
+    // is not synchronized. As a temporary measure, sets frame_time to
+    // the system time of renderer process.
+    base::TimeTicks frame_time = base::subtle::TimeTicksNowIgnoringOverride();
+    if (!provider_ ||
+        !provider_->UpdateCurrentFrame(frame_time + args.interval,
+                                       frame_time + 2 * args.interval)) {
+#else
     if (!provider_ ||
         !provider_->UpdateCurrentFrame(args.frame_time + args.interval,
                                        args.frame_time + 2 * args.interval)) {
+#endif
       return;
     }
   }

--- a/media/renderers/video_resource_updater.cc
+++ b/media/renderers/video_resource_updater.cc
@@ -47,6 +47,10 @@
 #include "ui/gl/gl_enums.h"
 #include "ui/gl/trace_util.h"
 
+#if defined(CASTANETS)
+#include "mojo/public/cpp/system/platform_handle.h"
+#endif
+
 namespace media {
 namespace {
 
@@ -867,6 +871,11 @@ VideoFrameExternalResources VideoResourceUpdater::CreateForSoftwarePlanes(
         // This is software path, so canvas and video_frame are always backed
         // by software.
         video_renderer_->Copy(video_frame, &canvas, Context3D());
+#if defined(CASTANETS)
+        // Compute the memory size with a RGBA_8888 format.
+        size_t memory_bytes = software_resource->resource_size().width() * software_resource->resource_size().height() * 4;
+        mojo::SyncSharedMemoryHandle(software_resource->GetSharedMemoryGuid(), 0, memory_bytes);
+#endif
       } else {
         HardwarePlaneResource* hardware_resource = plane_resource->AsHardware();
         size_t bytes_per_row = viz::ResourceSizes::CheckedWidthInBytes<size_t>(

--- a/media/video/gpu_memory_buffer_video_frame_pool.cc
+++ b/media/video/gpu_memory_buffer_video_frame_pool.cc
@@ -36,6 +36,10 @@
 #include "ui/gfx/color_space.h"
 #include "ui/gl/trace_util.h"
 
+#if defined(CASTANETS)
+#include "mojo/public/cpp/system/platform_handle.h"
+#endif
+
 namespace media {
 
 // Implementation of a pool of GpuMemoryBuffers used to back VideoFrames.
@@ -672,6 +676,11 @@ void GpuMemoryBufferVideoFramePool::PoolImpl::OnCopiesDone(
     FrameResources* frame_resources) {
   for (const auto& plane_resource : frame_resources->plane_resources) {
     if (plane_resource.gpu_memory_buffer) {
+#if defined(CASTANETS)
+      gfx::GpuMemoryBuffer* buffer = plane_resource.gpu_memory_buffer.get();
+      mojo::SyncSharedMemoryHandle(buffer->GetHandle().handle.GetGUID(), 0,
+                                   buffer->GetHandle().handle.GetSize());
+#endif
       plane_resource.gpu_memory_buffer->Unmap();
       plane_resource.gpu_memory_buffer->SetColorSpace(
           video_frame->ColorSpace());


### PR DESCRIPTION
Synchronize the gpu memory buffer in the video frame resource.
In case of a SW compositor, synchronize the SW resource.
Set the frame time to the system time of renderer process.