### PR TITLE
Make SharedMemory as writable memory for Castanets

### DIFF
--- a/base/base_switches.cc
+++ b/base/base_switches.cc
@@ -46,11 +46,6 @@ const char kForceFieldTrials[]              = "force-fieldtrials";
 // Suppresses all error dialogs when present.
 const char kNoErrorDialogs[]                = "noerrdialogs";
 
-#if defined(CASTANETS)
-// Specify distributed chrome server address.
-const char kServerAddress[]                 = "server-address";
-#endif
-
 // When running certain tests that spawn child processes, this switch indicates
 // to the test framework that the current process is a child process.
 const char kTestChildProcess[]              = "test-child-process";
@@ -121,6 +116,13 @@ const char kEnableCrashReporterForTesting[] =
 // given in base/android/library_loader/anchor_functions.h, via madvise and
 // changing the library prefetch behavior.
 const char kOrderfileMemoryOptimization[] = "orderfile-memory-optimization";
+#endif
+
+#if defined(CASTANETS)
+const char kEnableForking[] = "enable-forking";
+
+// Specify distributed chrome server address.
+const char kServerAddress[] = "server-address";
 #endif
 
 }  // namespace switches

--- a/base/base_switches.h
+++ b/base/base_switches.h
@@ -22,9 +22,6 @@ extern const char kForceFieldTrials[];
 extern const char kFullMemoryCrashReport[];
 extern const char kNoErrorDialogs[];
 extern const char kProfilingFile[];
-#if defined(CASTANETS)
-extern const char kServerAddress[];
-#endif
 extern const char kTestChildProcess[];
 extern const char kTestDoNotInitializeIcu[];
 extern const char kTraceToFile[];
@@ -47,6 +44,11 @@ extern const char kEnableCrashReporterForTesting[];
 
 #if defined(OS_ANDROID)
 extern const char kOrderfileMemoryOptimization[];
+#endif
+
+#if defined(CASTANETS)
+extern const char kEnableForking[];
+extern const char kServerAddress[];
 #endif
 
 }  // namespace switches

--- a/base/memory/shared_memory_posix.cc
+++ b/base/memory/shared_memory_posix.cc
@@ -36,12 +36,25 @@
 #error "MacOS uses shared_memory_mac.cc"
 #endif
 
+#if defined(CASTANETS)
+#include "base/base_switches.h"
+#include "base/command_line.h"
+#endif
+
 namespace base {
 
 SharedMemory::SharedMemory() = default;
 
 SharedMemory::SharedMemory(const SharedMemoryHandle& handle, bool read_only)
-    : shm_(handle), read_only_(read_only) {}
+    : shm_(handle), read_only_(read_only) {
+#if defined(CASTANETS)
+  // Always make SharedMemory as writable memory to sync memory from remote for
+  // Castanets.
+  if (read_only_ && !base::CommandLine::ForCurrentProcess()->HasSwitch(
+                        switches::kEnableForking))
+    read_only_ = false;
+#endif
+}
 
 SharedMemory::~SharedMemory() {
   Unmap();

--- a/content/browser/child_process_launcher_helper_linux.cc
+++ b/content/browser/child_process_launcher_helper_linux.cc
@@ -22,6 +22,7 @@
 #include "services/service_manager/zygote/host/zygote_host_impl_linux.h"
 
 #if defined(CASTANETS)
+#include "base/base_switches.h"
 #include "dbus/bus.h"
 #include "dbus/message.h"
 #include "dbus/object_path.h"

--- a/content/public/common/content_switches.cc
+++ b/content/public/common/content_switches.cc
@@ -9,10 +9,6 @@
 
 namespace switches {
 
-#if defined(CASTANETS)
-const char kEnableForking[] = "enable-forking";
-#endif
-
 // The number of MSAA samples for canvas2D. Requires MSAA support by GPU to
 // have an effect. 0 disables MSAA.
 const char kAcceleratedCanvas2dMSAASampleCount[] = "canvas-msaa-sample-count";

--- a/content/public/common/content_switches.h
+++ b/content/public/common/content_switches.h
@@ -13,10 +13,6 @@
 
 namespace switches {
 
-#if defined(CASTANETS)
-CONTENT_EXPORT extern const char kEnableForking[];
-#endif
-
 // All switches in alphabetical order. The switches should be documented
 // alongside the definition of their values in the .cc file.
 CONTENT_EXPORT extern const char kAcceleratedCanvas2dMSAASampleCount[];


### PR DESCRIPTION
SharedMemory should be created as writable memory to sync memory even if client makes SharedMemory as read only.
Writing to read-only memory causes SEGV_ACCERR crash.
