### PR TITLE
Partial synchronization of memory for partial rasterization.

### DIFF
--- a/content/app/content_main_runner_impl.cc
+++ b/content/app/content_main_runner_impl.cc
@@ -756,6 +756,9 @@ int ContentMainRunnerImpl::Initialize(const ContentMainParams& params) {
   base::CommandLine::ForCurrentProcess()->AppendSwitch(
       switches::kIgnoreGpuBlacklist);
 
+  base::CommandLine::ForCurrentProcess()->AppendSwitch(
+      switches::kDisallowNonExactResourceReuse);
+
 #if defined(OS_LINUX)
   base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
       switches::kEnableLogging, "stderr");


### PR DESCRIPTION
On SW compositing mode, tiles are rasterized the size of the dirty area
partially. The memory, therefore, needs to be sent the partial size.
Also, enable kDisallowNonExactResourceReuse because reusing resources
should only be done if they're the same size as requested.
These will reduce memory sync usage.