### PR TITLE
Add sync shared memory api for 2-dimensional memory.

### DIFF
--- a/cc/tiles/tile_manager.cc
+++ b/cc/tiles/tile_manager.cc
@@ -143,14 +143,15 @@ class RasterTaskImpl : public TileTask {
         size_t offset_y =
             (invalid_content_rect_.y() - content_rect_.y()) * bytes_per_pixel;
         size_t linear_offset = offset_x + (offset_y * content_rect_.width());
+        size_t sync_bytes =
+            invalid_content_rect_.size().GetArea() * bytes_per_pixel;
+        size_t width = invalid_content_rect_.width() * bytes_per_pixel;
+        size_t stride = content_rect_.width() * bytes_per_pixel;
 
-        // Send bytes the size of invalid_content_rect.
-        for (int i = 0; i < invalid_content_rect_.height(); i++) {
-          mojo::SyncSharedMemoryHandle(
-              sw_backing->SharedMemoryGuid(), linear_offset,
-              invalid_content_rect_.width() * bytes_per_pixel);
-          linear_offset += content_rect_.width() * bytes_per_pixel;
-        }
+        // Send bytes the size of invalid_content_rect (Partial sync).
+        mojo::SyncSharedMemoryHandle2d(sw_backing->SharedMemoryGuid(),
+                                       linear_offset, sync_bytes, width,
+                                       stride);
       } else {
         mojo::SyncSharedMemoryHandle(
             sw_backing->SharedMemoryGuid(), 0,

--- a/mojo/core/broker_castanets.h
+++ b/mojo/core/broker_castanets.h
@@ -74,6 +74,23 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
 
   void AddSyncFence(const base::UnguessableToken& guid, uint32_t fence_id);
 
+  // Sync 2-dimensional memory for partial rasterization,
+  bool SyncSharedBuffer2d(const base::UnguessableToken& guid,
+                          size_t offset,
+                          size_t sync_size,
+                          size_t width,
+                          size_t stride);
+
+  void OnBufferSync2d(uint64_t guid_high,
+                      uint64_t guid_low,
+                      uint32_t fence_id,
+                      uint32_t offset,
+                      uint32_t sync_bytes,
+                      uint32_t buffer_bytes,
+                      uint32_t width,
+                      uint32_t stride,
+                      const void* data);
+
   bool IsHost() const { return host_; }
 
   BrokerCastanets(base::ProcessHandle client_process,
@@ -110,6 +127,14 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
   void SyncSharedBufferImpl(const base::UnguessableToken& guid, uint8_t* memory,
                             size_t offset, size_t sync_size, size_t mapped_size,
                             bool write_lock = true);
+  void SyncSharedBufferImpl2d(const base::UnguessableToken& guid,
+                              uint8_t* memory,
+                              size_t offset,
+                              size_t sync_size,
+                              size_t mapped_size,
+                              size_t width,
+                              size_t stride,
+                              bool write_lock = true);
 
   bool host_;
   bool tcp_connection_ = false;

--- a/mojo/core/broker_messages.h
+++ b/mojo/core/broker_messages.h
@@ -18,6 +18,9 @@ enum BrokerMessageType : uint32_t {
   BUFFER_REQUEST,
   BUFFER_RESPONSE,
   BUFFER_SYNC,
+#if defined(CASTANETS)
+  BUFFER_SYNC_2D,
+#endif
 };
 
 struct BrokerMessageHeader {
@@ -44,6 +47,10 @@ struct BufferSyncData {
   uint32_t offset;
   uint32_t sync_bytes;
   uint32_t buffer_bytes;
+#if defined(CASTANETS)
+  uint32_t width;
+  uint32_t stride;
+#endif
 };
 
 #if defined(OS_WIN) || defined(CASTANETS)

--- a/mojo/core/core.cc
+++ b/mojo/core/core.cc
@@ -1204,6 +1204,22 @@ MojoResult Core::SyncPlatformSharedMemoryRegion(
   return MOJO_RESULT_OK;
 }
 
+MojoResult Core::SyncPlatformSharedMemoryRegion2d(
+    const MojoSharedBufferGuid* guid,
+    size_t offset,
+    size_t sync_size,
+    size_t width,
+    size_t stride) {
+  DCHECK(sync_size);
+  const base::UnguessableToken& token =
+      base::UnguessableToken::Deserialize(guid->high, guid->low);
+  if (!GetNodeController()->SyncSharedBuffer2d(token, offset, sync_size, width,
+                                               stride))
+    return MOJO_RESULT_UNKNOWN;
+
+  return MOJO_RESULT_OK;
+}
+
 MojoResult Core::WaitSyncPlatformSharedMemoryRegion(
     const MojoSharedBufferGuid* guid) {
   const base::UnguessableToken& token =

--- a/mojo/core/core.h
+++ b/mojo/core/core.h
@@ -308,7 +308,11 @@ class MOJO_SYSTEM_IMPL_EXPORT Core {
       const MojoSharedBufferGuid* guid,
       size_t offset,
       size_t sync_size);
-
+  MojoResult SyncPlatformSharedMemoryRegion2d(const MojoSharedBufferGuid* guid,
+                                              size_t offset,
+                                              size_t sync_size,
+                                              size_t width,
+                                              size_t stride);
   MojoResult WaitSyncPlatformSharedMemoryRegion(
       const MojoSharedBufferGuid* guid);
 #endif

--- a/mojo/core/entrypoints.cc
+++ b/mojo/core/entrypoints.cc
@@ -293,6 +293,16 @@ MojoResult MojoSyncPlatformSharedMemoryRegionImpl(
       guid, offset, sync_size);
 }
 
+MojoResult MojoSyncPlatformSharedMemoryRegionImpl2d(
+    const MojoSharedBufferGuid* guid,
+    size_t offset,
+    size_t sync_size,
+    size_t width,
+    size_t stride) {
+  return g_core->SyncPlatformSharedMemoryRegion2d(guid, offset, sync_size,
+                                                  width, stride);
+}
+
 MojoResult MojoWaitSyncPlatformSharedMemoryRegionImpl(
     const MojoSharedBufferGuid* guid) {
   return g_core->WaitSyncPlatformSharedMemoryRegion(guid);
@@ -399,8 +409,11 @@ MojoSystemThunks g_thunks = {sizeof(MojoSystemThunks),
                              MojoUnwrapPlatformHandleImpl,
                              MojoWrapPlatformSharedMemoryRegionImpl,
                              MojoUnwrapPlatformSharedMemoryRegionImpl,
+#if defined(CASTANETS)
                              MojoSyncPlatformSharedMemoryRegionImpl,
+                             MojoSyncPlatformSharedMemoryRegionImpl2d,
                              MojoWaitSyncPlatformSharedMemoryRegionImpl,
+#endif
                              MojoCreateInvitationImpl,
                              MojoAttachMessagePipeToInvitationImpl,
                              MojoExtractMessagePipeFromInvitationImpl,

--- a/mojo/core/node_controller.cc
+++ b/mojo/core/node_controller.cc
@@ -365,6 +365,17 @@ bool NodeController::SyncSharedBuffer(
   return true;
 }
 
+bool NodeController::SyncSharedBuffer2d(const base::UnguessableToken& guid,
+                                        size_t offset,
+                                        size_t sync_size,
+                                        size_t width,
+                                        size_t stride) {
+  // If broker_ is null, it means the current process is a browser process.
+  // The browser process isn't likely to send tile data.
+  CHECK(broker_);
+  return broker_->SyncSharedBuffer2d(guid, offset, sync_size, width, stride);
+}
+
 base::SyncDelegate* NodeController::GetSyncDelegate(
     base::ProcessHandle process) {
   if (broker_)

--- a/mojo/core/node_controller.h
+++ b/mojo/core/node_controller.h
@@ -130,6 +130,11 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
   bool SyncSharedBuffer(base::WritableSharedMemoryMapping& mapping,
                         size_t offset,
                         size_t sync_size);
+  bool SyncSharedBuffer2d(const base::UnguessableToken& guid,
+                          size_t offset,
+                          size_t sync_size,
+                          size_t width,
+                          size_t stride);
 
   void WaitSyncSharedBuffer(const base::UnguessableToken& guid);
 

--- a/mojo/public/c/system/platform_handle.h
+++ b/mojo/public/c/system/platform_handle.h
@@ -325,6 +325,13 @@ MOJO_SYSTEM_EXPORT MojoResult MojoSyncPlatformSharedMemoryRegion(
     size_t offset,
     size_t sync_size);
 
+MOJO_SYSTEM_EXPORT MojoResult
+MojoSyncPlatformSharedMemoryRegion2d(const struct MojoSharedBufferGuid* guid,
+                                     size_t offset,
+                                     size_t sync_size,
+                                     size_t width,
+                                     size_t stride);
+
 MOJO_SYSTEM_EXPORT MojoResult MojoWaitSyncPlatformSharedMemoryRegion(
     const struct MojoSharedBufferGuid* guid);
 #endif

--- a/mojo/public/c/system/thunks.cc
+++ b/mojo/public/c/system/thunks.cc
@@ -417,6 +417,16 @@ MojoResult MojoSyncPlatformSharedMemoryRegion(
                       guid, offset, sync_size);
 }
 
+MojoResult MojoSyncPlatformSharedMemoryRegion2d(
+    const struct MojoSharedBufferGuid* guid,
+    size_t offset,
+    size_t sync_size,
+    size_t width,
+    size_t stride) {
+  return INVOKE_THUNK(SyncPlatformSharedMemoryRegion2d, guid, offset, sync_size,
+                      width, stride);
+}
+
 MojoResult MojoWaitSyncPlatformSharedMemoryRegion(
     const struct MojoSharedBufferGuid* guid) {
   return INVOKE_THUNK(WaitSyncPlatformSharedMemoryRegion, guid);

--- a/mojo/public/c/system/thunks.h
+++ b/mojo/public/c/system/thunks.h
@@ -189,6 +189,12 @@ struct MojoSystemThunks {
       const struct MojoSharedBufferGuid* guid,
       size_t offset,
       size_t sync_size);
+  MojoResult (*SyncPlatformSharedMemoryRegion2d)(
+      const struct MojoSharedBufferGuid* guid,
+      size_t offset,
+      size_t sync_size,
+      size_t width,
+      size_t stride);
   MojoResult (*WaitSyncPlatformSharedMemoryRegion)(
       const struct MojoSharedBufferGuid* guid);
 #endif

--- a/mojo/public/cpp/system/platform_handle.cc
+++ b/mojo/public/cpp/system/platform_handle.cc
@@ -372,6 +372,19 @@ MojoResult SyncSharedMemoryHandle(const base::UnguessableToken& guid,
       &mojo_guid, offset, sync_size);
 }
 
+MojoResult SyncSharedMemoryHandle2d(const base::UnguessableToken& guid,
+                                    size_t offset,
+                                    size_t sync_size,
+                                    size_t width,
+                                    size_t stride) {
+  MojoSharedBufferGuid mojo_guid;
+  mojo_guid.high = guid.GetHighForSerialization();
+  mojo_guid.low = guid.GetLowForSerialization();
+
+  return MojoSyncPlatformSharedMemoryRegion2d(&mojo_guid, offset, sync_size,
+                                              width, stride);
+}
+
 MojoResult WaitSyncSharedMemory(const base::UnguessableToken& guid) {
   MojoSharedBufferGuid mojo_guid;
   mojo_guid.high = guid.GetHighForSerialization();

--- a/mojo/public/cpp/system/platform_handle.h
+++ b/mojo/public/cpp/system/platform_handle.h
@@ -155,6 +155,13 @@ SyncSharedMemoryHandle(const base::UnguessableToken& guid,
                        size_t sync_size);
 
 MOJO_CPP_SYSTEM_EXPORT MojoResult
+SyncSharedMemoryHandle2d(const base::UnguessableToken& guid,
+                         size_t offset,
+                         size_t sync_size,
+                         size_t width,
+                         size_t stride);
+
+MOJO_CPP_SYSTEM_EXPORT MojoResult
 WaitSyncSharedMemory(const base::UnguessableToken& guid);
 #endif
 


### PR DESCRIPTION
Until now, Broker only has the api for linear memory sync. But rasterizing
a tile partially requires synchronization of 2-dimensional memory.
For this, |width| and |stride| are added to sync data to calculate the
rectangular memory.