### PR TITLE
Fix the scroll performance issue with GPU compositing.

### DIFF
--- a/cc/raster/staging_buffer_pool.cc
+++ b/cc/raster/staging_buffer_pool.cc
@@ -43,6 +43,11 @@ bool CheckForQueryResult(gpu::raster::RasterInterface* ri, unsigned query_id) {
 
 void WaitForQueryResult(gpu::raster::RasterInterface* ri, unsigned query_id) {
   TRACE_EVENT0("cc", "WaitForQueryResult");
+#if defined(CASTANETS)
+  // FIXME: Skip this region because a shared memory of query result is not
+  // being synchronized.
+  return;
+#endif
 
   int attempts_left = kMaxCheckForQueryResultAvailableAttempts;
   while (attempts_left--) {


### PR DESCRIPTION
When playback is in progress, it tries to get the query result in
|WaitForQueryResult| in staging_buffer_pool.cc. It causes delay of the raster
and the query isn't handled on Castanets now, we should skip it.