### PR TITLE
Refactoring for Sync and WaitSync functions.

### DIFF
--- a/cc/raster/one_copy_raster_buffer_provider.cc
+++ b/cc/raster/one_copy_raster_buffer_provider.cc
@@ -31,7 +31,7 @@
 
 #if defined(CASTANETS)
 #include "base/command_line.h"
-#include "mojo/public/cpp/system/platform_handle.h"
+#include "mojo/public/cpp/system/sync.h"
 #endif
 
 namespace cc {
@@ -362,7 +362,7 @@ void OneCopyRasterBufferProvider::PlaybackToStagingBuffer(
 #if defined(CASTANETS)
     if (std::string("renderer") ==
         base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
-      mojo::SyncSharedMemoryHandle(
+      mojo::SyncSharedMemory(
           buffer->GetHandle().handle.GetGUID(), 0,
           staging_buffer->size.width() * staging_buffer->size.height() * 4);
     }

--- a/cc/tiles/tile_manager.cc
+++ b/cc/tiles/tile_manager.cc
@@ -35,7 +35,7 @@
 
 #if defined(CASTANETS)
 #include "base/command_line.h"
-#include "mojo/public/cpp/system/platform_handle.h"
+#include "mojo/public/cpp/system/sync.h"
 #endif // defined(CASTANETS)
 
 namespace cc {
@@ -146,13 +146,13 @@ class RasterTaskImpl : public TileTask {
 
           // Send bytes the size of invalid_content_rect.
           for (int i = 0; i < invalid_content_rect_.height(); i++) {
-            mojo::SyncSharedMemoryHandle(
+            mojo::SyncSharedMemory(
                 sw_backing->SharedMemoryGuid(), linear_offset,
                 invalid_content_rect_.width() * bytes_per_pixel);
             linear_offset += content_rect_.width() * bytes_per_pixel;
           }
         } else {
-          mojo::SyncSharedMemoryHandle(
+          mojo::SyncSharedMemory(
               sw_backing->SharedMemoryGuid(), 0,
               content_rect_.width() * content_rect_.height() * bytes_per_pixel);
         }

--- a/components/viz/service/display_embedder/server_shared_bitmap_manager.cc
+++ b/components/viz/service/display_embedder/server_shared_bitmap_manager.cc
@@ -18,6 +18,10 @@
 #include "mojo/public/cpp/system/platform_handle.h"
 #include "ui/gfx/geometry/size.h"
 
+#if defined(CASTANETS)
+#include "mojo/public/cpp/system/sync.h"
+#endif
+
 namespace viz {
 
 class BitmapData : public base::RefCounted<BitmapData> {

--- a/gpu/command_buffer/client/cmd_buffer_helper.cc
+++ b/gpu/command_buffer/client/cmd_buffer_helper.cc
@@ -23,7 +23,7 @@
 
 #if defined(CASTANETS)
 #include "base/command_line.h"
-#include "mojo/public/cpp/system/platform_handle.h"
+#include "mojo/public/cpp/system/sync.h"
 #endif
 
 namespace gpu {
@@ -184,14 +184,14 @@ void CommandBufferHelper::SyncSharedMemoryForCommands() {
   if (put_ < last_ordering_barrier_put_) {
     size_t tail_size = ring_buffer_size_ -
                        (last_ordering_barrier_put_ * kCommandBufferEntrySize);
-    mojo::SyncSharedMemoryHandle(
+    mojo::SyncSharedMemory(
         ring_buffer_->backing()->GetGUID(),
         last_ordering_barrier_put_ * kCommandBufferEntrySize, tail_size);
-    mojo::SyncSharedMemoryHandle(ring_buffer_->backing()->GetGUID(), 0,
-                                 put_ * kCommandBufferEntrySize);
+    mojo::SyncSharedMemory(ring_buffer_->backing()->GetGUID(), 0,
+                           put_ * kCommandBufferEntrySize);
   } else {
     size_t size = (put_ - last_ordering_barrier_put_) * kCommandBufferEntrySize;
-    mojo::SyncSharedMemoryHandle(
+    mojo::SyncSharedMemory(
         ring_buffer_->backing()->GetGUID(),
         last_ordering_barrier_put_ * kCommandBufferEntrySize, size);
   }

--- a/gpu/command_buffer/client/mapped_memory.h
+++ b/gpu/command_buffer/client/mapped_memory.h
@@ -19,7 +19,7 @@
 
 #if defined(CASTANETS)
 #include "base/command_line.h"
-#include "mojo/public/cpp/system/platform_handle.h"
+#include "mojo/public/cpp/system/sync.h"
 #endif
 
 namespace gpu {
@@ -96,9 +96,9 @@ class GPU_EXPORT MemoryChunk {
 #if defined(CASTANETS)
     if (std::string("renderer") ==
         base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
-      mojo::SyncSharedMemoryHandle(shm_->backing()->GetGUID(),
-                                   GetOffset(pointer),
-                                   allocator_.GetBlockSize(pointer));
+      mojo::SyncSharedMemory(shm_->backing()->GetGUID(),
+                             GetOffset(pointer),
+                             allocator_.GetBlockSize(pointer));
     }
 #endif
   }

--- a/gpu/command_buffer/client/transfer_buffer.cc
+++ b/gpu/command_buffer/client/transfer_buffer.cc
@@ -16,7 +16,7 @@
 
 #if defined(CASTANETS)
 #include "base/command_line.h"
-#include "mojo/public/cpp/system/platform_handle.h"
+#include "mojo/public/cpp/system/sync.h"
 #endif
 
 namespace gpu {
@@ -93,8 +93,8 @@ void TransferBuffer::FreePendingToken(void* p, unsigned int token) {
 #if defined(CASTANETS)
   if (std::string("renderer") ==
       base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
-    mojo::SyncSharedMemoryHandle(shared_memory_guid(), GetOffset(p),
-                                 ring_buffer_->GetBlockSize(p));
+    mojo::SyncSharedMemory(shared_memory_guid(), GetOffset(p),
+                           ring_buffer_->GetBlockSize(p));
   }
 #endif
 }

--- a/gpu/command_buffer/service/command_buffer_service.cc
+++ b/gpu/command_buffer/service/command_buffer_service.cc
@@ -17,7 +17,7 @@
 #include "gpu/command_buffer/service/transfer_buffer_manager.h"
 
 #if defined(CASTANETS)
-#include "mojo/public/cpp/system/platform_handle.h"
+#include "mojo/public/cpp/system/sync.h"
 #endif
 
 namespace gpu {

--- a/gpu/command_buffer/service/common_decoder.cc
+++ b/gpu/command_buffer/service/common_decoder.cc
@@ -13,7 +13,7 @@
 #include "gpu/command_buffer/service/command_buffer_service.h"
 
 #if defined(CASTANETS)
-#include "mojo/public/cpp/system/platform_handle.h"
+#include "mojo/public/cpp/system/sync.h"
 #endif
 
 namespace gpu {
@@ -342,8 +342,8 @@ error::Error CommonDecoder::HandleGetBucketStart(
 #if defined(CASTANETS)
   scoped_refptr<gpu::Buffer> buffer =
       command_buffer_service_->GetTransferBuffer(data_memory_id);
-  mojo::SyncSharedMemoryHandle(buffer->backing()->GetGUID(), data_memory_offset,
-                               data_memory_size);
+  mojo::SyncSharedMemory(buffer->backing()->GetGUID(), data_memory_offset,
+                         data_memory_size);
 #endif
   return error::kNoError;
 }
@@ -372,7 +372,7 @@ error::Error CommonDecoder::HandleGetBucketData(uint32_t immediate_data_size,
 #if defined(CASTANETS)
   scoped_refptr<gpu::Buffer> buffer =
       command_buffer_service_->GetTransferBuffer(args.shared_memory_id);
-  mojo::SyncSharedMemoryHandle(buffer->backing()->GetGUID(), offset, size);
+  mojo::SyncSharedMemory(buffer->backing()->GetGUID(), offset, size);
 #endif
   return error::kNoError;
 }
@@ -385,8 +385,7 @@ error::Error CommonDecoder::HandleSyncResultData(
       *static_cast<const volatile cmd::SyncResultData*>(cmd_data);
   scoped_refptr<gpu::Buffer> buffer =
       command_buffer_service_->GetTransferBuffer(args.id);
-  mojo::SyncSharedMemoryHandle(buffer->backing()->GetGUID(), args.offset,
-                               args.size);
+  mojo::SyncSharedMemory(buffer->backing()->GetGUID(), args.offset, args.size);
 
   // Set result data to '0' for use in the next command on Castanets.
   // Some apis should set data to non-zero, it can cause an issue.

--- a/media/audio/audio_output_device_thread_callback.cc
+++ b/media/audio/audio_output_device_thread_callback.cc
@@ -10,7 +10,7 @@
 #include "base/trace_event/trace_event.h"
 
 #if defined(CASTANETS)
-#include "mojo/public/cpp/system/platform_handle.h"
+#include "mojo/public/cpp/system/sync.h"
 #endif
 
 namespace media {
@@ -129,8 +129,8 @@ void AudioOutputDeviceThreadCallback::Process(uint32_t control_signal) {
   }
 
 #if defined(CASTANETS)
-  mojo::SyncSharedMemoryHandle(shared_memory_region_.GetGUID(), 0,
-                               shared_memory_region_.GetSize());
+  mojo::SyncSharedMemory(shared_memory_region_.GetGUID(), 0,
+                         shared_memory_region_.GetSize());
 #endif
 
   TRACE_EVENT_END2("audio", "AudioOutputDevice::FireRenderCallback",

--- a/media/audio/audio_sync_reader.cc
+++ b/media/audio/audio_sync_reader.cc
@@ -22,7 +22,7 @@
 #include "media/base/media_switches.h"
 
 #if defined(CASTANETS)
-#include "mojo/public/cpp/system/platform_handle.h"
+#include "mojo/public/cpp/system/sync.h"
 #endif
 
 namespace {
@@ -173,8 +173,8 @@ void AudioSyncReader::RequestMoreData(base::TimeDelta delay,
   output_bus_->Zero();
 
 #if defined(CASTANETS)
-  mojo::SyncSharedMemoryHandle(shared_memory_region_.GetGUID(), 0,
-                               shared_memory_region_.GetSize());
+  mojo::SyncSharedMemory(shared_memory_region_.GetGUID(), 0,
+                         shared_memory_region_.GetSize());
 #endif
 
   uint32_t control_signal = 0;

--- a/media/renderers/video_resource_updater.cc
+++ b/media/renderers/video_resource_updater.cc
@@ -48,7 +48,7 @@
 #include "ui/gl/trace_util.h"
 
 #if defined(CASTANETS)
-#include "mojo/public/cpp/system/platform_handle.h"
+#include "mojo/public/cpp/system/sync.h"
 #endif
 
 namespace media {
@@ -873,8 +873,10 @@ VideoFrameExternalResources VideoResourceUpdater::CreateForSoftwarePlanes(
         video_renderer_->Copy(video_frame, &canvas, Context3D());
 #if defined(CASTANETS)
         // Compute the memory size with a RGBA_8888 format.
-        size_t memory_bytes = software_resource->resource_size().width() * software_resource->resource_size().height() * 4;
-        mojo::SyncSharedMemoryHandle(software_resource->GetSharedMemoryGuid(), 0, memory_bytes);
+        size_t memory_bytes = software_resource->resource_size().width() *
+                              software_resource->resource_size().height() * 4;
+        mojo::SyncSharedMemory(software_resource->GetSharedMemoryGuid(), 0,
+                               memory_bytes);
 #endif
       } else {
         HardwarePlaneResource* hardware_resource = plane_resource->AsHardware();

--- a/media/video/gpu_memory_buffer_video_frame_pool.cc
+++ b/media/video/gpu_memory_buffer_video_frame_pool.cc
@@ -37,7 +37,7 @@
 #include "ui/gl/trace_util.h"
 
 #if defined(CASTANETS)
-#include "mojo/public/cpp/system/platform_handle.h"
+#include "mojo/public/cpp/system/sync.h"
 #endif
 
 namespace media {
@@ -678,8 +678,8 @@ void GpuMemoryBufferVideoFramePool::PoolImpl::OnCopiesDone(
     if (plane_resource.gpu_memory_buffer) {
 #if defined(CASTANETS)
       gfx::GpuMemoryBuffer* buffer = plane_resource.gpu_memory_buffer.get();
-      mojo::SyncSharedMemoryHandle(buffer->GetHandle().handle.GetGUID(), 0,
-                                   buffer->GetHandle().handle.GetSize());
+      mojo::SyncSharedMemory(buffer->GetHandle().handle.GetGUID(), 0,
+                             buffer->GetHandle().handle.GetSize());
 #endif
       plane_resource.gpu_memory_buffer->Unmap();
       plane_resource.gpu_memory_buffer->SetColorSpace(

--- a/mojo/public/c/system/BUILD.gn
+++ b/mojo/public/c/system/BUILD.gn
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//build/config/features.gni")
+
 component("system") {
   output_name = "mojo_public_system"
 
@@ -35,4 +37,10 @@ source_set("headers") {
     "trap.h",
     "types.h",
   ]
+
+  if (enable_castanets) {
+    public += [
+      "sync.h",
+    ]
+  }
 }

--- a/mojo/public/c/system/core.h
+++ b/mojo/public/c/system/core.h
@@ -21,4 +21,8 @@
 #include "mojo/public/c/system/trap.h"
 #include "mojo/public/c/system/types.h"
 
+#if defined(CASTANETS)
+#include "mojo/public/c/system/sync.h"
+#endif
+
 #endif  // MOJO_PUBLIC_C_SYSTEM_CORE_H_

--- a/mojo/public/c/system/platform_handle.h
+++ b/mojo/public/c/system/platform_handle.h
@@ -22,10 +22,6 @@ extern "C" {
 // The type of handle value contained in a |MojoPlatformHandle| structure.
 typedef uint32_t MojoPlatformHandleType;
 
-#if defined(CASTANETS)
-const int kCastanetsHandle = -1;
-#endif
-
 // An invalid handle value. Other contents of the |MojoPlatformHandle| are
 // ignored.
 #define MOJO_PLATFORM_HANDLE_TYPE_INVALID ((MojoPlatformHandleType)0)
@@ -318,23 +314,6 @@ MOJO_SYSTEM_EXPORT MojoResult MojoUnwrapPlatformSharedMemoryRegion(
     uint64_t* num_bytes,
     struct MojoSharedBufferGuid* guid,
     MojoPlatformSharedMemoryRegionAccessMode* access_mode);
-
-#if defined(CASTANETS)
-MOJO_SYSTEM_EXPORT MojoResult MojoSyncPlatformSharedMemoryRegion(
-    const struct MojoSharedBufferGuid* guid,
-    size_t offset,
-    size_t sync_size);
-
-MOJO_SYSTEM_EXPORT MojoResult
-MojoSyncPlatformSharedMemoryRegion2d(const struct MojoSharedBufferGuid* guid,
-                                     size_t offset,
-                                     size_t sync_size,
-                                     size_t width,
-                                     size_t stride);
-
-MOJO_SYSTEM_EXPORT MojoResult MojoWaitSyncPlatformSharedMemoryRegion(
-    const struct MojoSharedBufferGuid* guid);
-#endif
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/mojo/public/c/system/sync.h
+++ b/mojo/public/c/system/sync.h
@@ -1,0 +1,36 @@
+// Copyright 2019 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MOJO_PUBLIC_C_SYSTEM_SYNC_H_
+#define MOJO_PUBLIC_C_SYSTEM_SYNC_H_
+
+#include <stdint.h>
+
+#include "mojo/public/c/system/system_export.h"
+#include "mojo/public/c/system/types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MOJO_SYSTEM_EXPORT MojoResult MojoSyncPlatformSharedMemoryRegion(
+    const struct MojoSharedBufferGuid* guid,
+    size_t offset,
+    size_t sync_size);
+
+MOJO_SYSTEM_EXPORT MojoResult
+MojoSyncPlatformSharedMemoryRegion2d(const struct MojoSharedBufferGuid* guid,
+                                     size_t offset,
+                                     size_t sync_size,
+                                     size_t width,
+                                     size_t stride);
+
+MOJO_SYSTEM_EXPORT MojoResult MojoWaitSyncPlatformSharedMemoryRegion(
+    const struct MojoSharedBufferGuid* guid);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // MOJO_PUBLIC_C_SYSTEM_SYNC_H_

--- a/mojo/public/c/system/types.h
+++ b/mojo/public/c/system/types.h
@@ -30,6 +30,10 @@ const MojoHandle MOJO_HANDLE_INVALID = 0;
 #define MOJO_HANDLE_INVALID ((MojoHandle)0)
 #endif
 
+#if defined(CASTANETS)
+const int kCastanetsHandle = -1;
+#endif
+
 // |MojoResult|: Result codes for Mojo operations. The only success code is zero
 // (|MOJO_RESULT_OK|); all non-zero values should be considered as error/failure
 // codes (even if the value is not recognized).

--- a/mojo/public/cpp/system/BUILD.gn
+++ b/mojo/public/cpp/system/BUILD.gn
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//build/config/features.gni")
+
 # Deletes libsystem.dylib from the build dir, since it shadows
 # /usr/lib/libSystem.dylib on macOS.
 # TODO(thakis): Remove this after a while.
@@ -61,6 +63,13 @@ component("system") {
     "wait_set.cc",
     "wait_set.h",
   ]
+
+  if (enable_castanets) {
+    sources += [
+      "sync.cc",
+      "sync.h",
+    ]
+  }
 
   public_deps = [
     "//base",

--- a/mojo/public/cpp/system/platform_handle.cc
+++ b/mojo/public/cpp/system/platform_handle.cc
@@ -13,10 +13,6 @@
 #include "base/mac/mach_logging.h"
 #endif
 
-#if defined(CASTANETS)
-#include "base/memory/shared_memory_tracker.h"
-#endif
-
 namespace mojo {
 
 namespace {
@@ -359,40 +355,6 @@ MojoResult UnwrapSharedMemoryHandle(
 
   return MOJO_RESULT_OK;
 }
-
-#if defined(CASTANETS)
-MojoResult SyncSharedMemoryHandle(const base::UnguessableToken& guid,
-                                  size_t offset,
-                                  size_t sync_size) {
-  MojoSharedBufferGuid mojo_guid;
-  mojo_guid.high = guid.GetHighForSerialization();
-  mojo_guid.low = guid.GetLowForSerialization();
-
-  return MojoSyncPlatformSharedMemoryRegion(
-      &mojo_guid, offset, sync_size);
-}
-
-MojoResult SyncSharedMemoryHandle2d(const base::UnguessableToken& guid,
-                                    size_t offset,
-                                    size_t sync_size,
-                                    size_t width,
-                                    size_t stride) {
-  MojoSharedBufferGuid mojo_guid;
-  mojo_guid.high = guid.GetHighForSerialization();
-  mojo_guid.low = guid.GetLowForSerialization();
-
-  return MojoSyncPlatformSharedMemoryRegion2d(&mojo_guid, offset, sync_size,
-                                              width, stride);
-}
-
-MojoResult WaitSyncSharedMemory(const base::UnguessableToken& guid) {
-  MojoSharedBufferGuid mojo_guid;
-  mojo_guid.high = guid.GetHighForSerialization();
-  mojo_guid.low = guid.GetLowForSerialization();
-
-  return MojoWaitSyncPlatformSharedMemoryRegion(&mojo_guid);
-}
-#endif
 
 ScopedSharedBufferHandle WrapReadOnlySharedMemoryRegion(
     base::ReadOnlySharedMemoryRegion region) {

--- a/mojo/public/cpp/system/platform_handle.h
+++ b/mojo/public/cpp/system/platform_handle.h
@@ -148,23 +148,6 @@ UnwrapSharedMemoryHandle(ScopedSharedBufferHandle handle,
                          size_t* size,
                          UnwrappedSharedMemoryHandleProtection* protection);
 
-#if defined(CASTANETS)
-MOJO_CPP_SYSTEM_EXPORT MojoResult
-SyncSharedMemoryHandle(const base::UnguessableToken& guid,
-                       size_t offset,
-                       size_t sync_size);
-
-MOJO_CPP_SYSTEM_EXPORT MojoResult
-SyncSharedMemoryHandle2d(const base::UnguessableToken& guid,
-                         size_t offset,
-                         size_t sync_size,
-                         size_t width,
-                         size_t stride);
-
-MOJO_CPP_SYSTEM_EXPORT MojoResult
-WaitSyncSharedMemory(const base::UnguessableToken& guid);
-#endif
-
 // Helpers for wrapping and unwrapping new base shared memory API primitives.
 // If the input |region| is valid for the Wrap* functions, they will always
 // succeed and return a valid Mojo shared buffer handle.

--- a/mojo/public/cpp/system/sync.cc
+++ b/mojo/public/cpp/system/sync.cc
@@ -1,0 +1,44 @@
+// Copyright 2019 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "mojo/public/cpp/system/sync.h"
+
+#include "mojo/public/c/system/platform_handle.h"
+#include "mojo/public/c/system/sync.h"
+
+namespace mojo {
+
+MojoResult SyncSharedMemory(const base::UnguessableToken& guid,
+                            size_t offset,
+                            size_t sync_size) {
+  MojoSharedBufferGuid mojo_guid;
+  mojo_guid.high = guid.GetHighForSerialization();
+  mojo_guid.low = guid.GetLowForSerialization();
+
+  return MojoSyncPlatformSharedMemoryRegion(
+      &mojo_guid, offset, sync_size);
+}
+
+MojoResult SyncSharedMemory2d(const base::UnguessableToken& guid,
+                              size_t offset,
+                              size_t sync_size,
+                              size_t width,
+                              size_t stride) {
+  MojoSharedBufferGuid mojo_guid;
+  mojo_guid.high = guid.GetHighForSerialization();
+  mojo_guid.low = guid.GetLowForSerialization();
+
+  return MojoSyncPlatformSharedMemoryRegion2d(&mojo_guid, offset, sync_size,
+                                              width, stride);
+}
+
+MojoResult WaitSyncSharedMemory(const base::UnguessableToken& guid) {
+  MojoSharedBufferGuid mojo_guid;
+  mojo_guid.high = guid.GetHighForSerialization();
+  mojo_guid.low = guid.GetLowForSerialization();
+
+  return MojoWaitSyncPlatformSharedMemoryRegion(&mojo_guid);
+}
+
+}  // namespace mojo

--- a/mojo/public/cpp/system/sync.h
+++ b/mojo/public/cpp/system/sync.h
@@ -1,0 +1,31 @@
+// Copyright 2019 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MOJO_PUBLIC_CPP_SYSTEM_SYNC_H_
+#define MOJO_PUBLIC_CPP_SYSTEM_SYNC_H_
+
+#include "base/unguessable_token.h"
+#include "mojo/public/c/system/types.h"
+#include "mojo/public/cpp/system/system_export.h"
+
+namespace mojo {
+
+MOJO_CPP_SYSTEM_EXPORT MojoResult
+SyncSharedMemory(const base::UnguessableToken& guid,
+                 size_t offset,
+                 size_t sync_size);
+
+MOJO_CPP_SYSTEM_EXPORT MojoResult
+SyncSharedMemory2d(const base::UnguessableToken& guid,
+                   size_t offset,
+                   size_t sync_size,
+                   size_t width,
+                   size_t stride);
+
+MOJO_CPP_SYSTEM_EXPORT MojoResult
+WaitSyncSharedMemory(const base::UnguessableToken& guid);
+
+}  // namespace mojo
+
+#endif  // MOJO_PUBLIC_CPP_SYSTEM_SYNC_H_


### PR DESCRIPTION
- Add a new file sync.h/cc in mojo public.
- Move Sync and WaitSync functions from platform_handle.h/cc to sync.h/cc.
- Rename SyncSharedMemoryHandle to SyncSharedMemory.