### PR TITLE
Allow the node channel to connect using SSL.

### DIFF
--- a/base/base_switches.cc
+++ b/base/base_switches.cc
@@ -125,6 +125,8 @@ const char kEnableForking[] = "enable-forking";
 const char kServerAddress[] = "server-address";
 
 const char kTcpLaunchTimeout[] = "tcp-launch-timeout";
+
+const char kSecureConnection[] = "secure-connection";
 #endif
 
 }  // namespace switches

--- a/base/base_switches.h
+++ b/base/base_switches.h
@@ -50,6 +50,7 @@ extern const char kOrderfileMemoryOptimization[];
 extern const char kEnableForking[];
 extern const char kServerAddress[];
 extern const char kTcpLaunchTimeout[];
+extern const char kSecureConnection[];
 #endif
 
 }  // namespace switches

--- a/mojo/core/BUILD.gn
+++ b/mojo/core/BUILD.gn
@@ -154,7 +154,10 @@ template("core_impl_source_set") {
 
     deps = []
     if (enable_castanets) {
-      deps += ["//mojo/public/cpp/platform:platform"]
+      deps += [
+        "//base:base_static",
+        "//mojo/public/cpp/platform:platform",
+      ]
     }
     if (is_android) {
       deps += [ "//third_party/ashmem" ]

--- a/mojo/core/broker_castanets.h
+++ b/mojo/core/broker_castanets.h
@@ -97,8 +97,8 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
   // Send |handle| to the client, to be used to establish a NodeChannel to us.
   bool SendChannel(PlatformHandle handle);
 
-  // Send a port number to the client for TCP socket.
-  bool SendPortNumber(int port);
+  // Send InitData to the client for node channel connection.
+  bool SendBrokerInit(int port, bool secure_connection);
 
 #if defined(OS_WIN)
   // Sends a named channel to the client. Like above, but for named pipes.
@@ -112,6 +112,8 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
                         size_t payload_size,
                         std::vector<PlatformHandle> handles) override;
   void OnChannelError(Channel::Error error) override;
+
+  bool IsSecureConnection() const { return secure_connection_; }
 
   const ProcessErrorCallback process_error_callback_;
 
@@ -150,6 +152,7 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
                               bool write_lock = true);
 
   bool tcp_connection_ = false;
+  bool secure_connection_ = false;
 
   // Handle to the broker process, used for synchronous IPCs.
   PlatformHandle sync_channel_;

--- a/mojo/core/broker_messages.h
+++ b/mojo/core/broker_messages.h
@@ -64,6 +64,8 @@ struct InitData {
 #endif
 #if defined(CASTANETS)
   uint16_t port;
+  uint16_t secure_connection; // bool
+  uint32_t padding;
 #endif
 };
 #endif

--- a/mojo/core/connection_params.h
+++ b/mojo/core/connection_params.h
@@ -36,6 +36,14 @@ class MOJO_SYSTEM_IMPL_EXPORT ConnectionParams {
     return std::move(server_endpoint_);
   }
 
+#if defined(CASTANETS)
+  bool is_secure() const { return secure_connection_; }
+  void SetSecure() { secure_connection_ = true; }
+
+ private:
+  bool secure_connection_ = false;
+#endif
+
  private:
   PlatformChannelEndpoint endpoint_;
   PlatformChannelServerEndpoint server_endpoint_;

--- a/mojo/core/node_controller.cc
+++ b/mojo/core/node_controller.cc
@@ -29,6 +29,7 @@
 #include "mojo/public/cpp/platform/platform_channel.h"
 
 #if defined(CASTANETS)
+#include "base/base_switches.h"
 #include "base/memory/castanets_memory_mapping.h"
 #include "base/memory/castanets_memory_syncer.h"
 #include "base/memory/shared_memory_tracker.h"
@@ -468,13 +469,17 @@ void NodeController::SendBrokerClientInvitationOnIOThread(
     node_connection_params =
         ConnectionParams(mojo::PlatformChannelServerEndpoint(
             mojo::PlatformHandle(CreateTCPServerHandle(port, &port))));
+    if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+        switches::kSecureConnection))
+      node_connection_params.SetSecure();
 
     scoped_refptr<BrokerCastanets> broker_host =
         BrokerCastanets::CreateInBrowserProcess(target_process.get(),
                                                 std::move(connection_params),
                                                 process_error_callback,
                                                 fence_manager_.get());
-    channel_ok = broker_host->SendPortNumber(port);
+    channel_ok = broker_host->SendBrokerInit(
+        port, node_connection_params.is_secure());
     base::AutoLock lock(broker_hosts_lock_);
     broker_hosts_.emplace(target_process.get(), broker_host);
   }
@@ -579,6 +584,10 @@ void NodeController::AcceptBrokerClientInvitationOnIOThread(
     // At this point we don't know the inviter's name, so we can't yet insert it
     // into our |peers_| map. That will happen as soon as we receive an
     // AcceptInvitee message from them.
+#if defined(CASTANETS)
+    if (broker_->IsSecureConnection())
+      connection_params.SetSecure();
+#endif
     bootstrap_inviter_channel_ =
         NodeChannel::Create(this, std::move(connection_params), io_task_runner_,
                             ProcessErrorCallback());

--- a/mojo/public/cpp/platform/BUILD.gn
+++ b/mojo/public/cpp/platform/BUILD.gn
@@ -36,9 +36,19 @@ component("platform") {
   ]
 
   if(enable_castanets) {
-    public += [ "tcp_platform_handle_utils.h" ]
-    sources += [ "tcp_platform_handle_utils_posix.cc" ]
-    public_deps += [ "//base:base_static" ]
+    public += [
+      "tcp_platform_handle_utils.h",
+      "secure_socket_utils_posix.h",
+    ]
+    sources += [
+      "tcp_platform_handle_utils_posix.cc",
+      "secure_socket_utils_posix.cc",
+    ]
+    public_deps += [
+      "//base:base_static",
+      "//crypto",
+      "//third_party/boringssl",
+    ]
   }
 
   if (is_posix && (!is_nacl && !is_fuchsia)) {

--- a/mojo/public/cpp/platform/secure_socket_utils_posix.cc
+++ b/mojo/public/cpp/platform/secure_socket_utils_posix.cc
@@ -1,0 +1,111 @@
+// Copyright 2019 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "mojo/public/cpp/platform/secure_socket_utils_posix.h"
+
+#include "base/files/file_util.h"
+#include "base/memory/singleton.h"
+#include "base/path_service.h"
+#include "crypto/openssl_util.h"
+
+namespace mojo {
+
+namespace {
+
+constexpr char kTestCertFileName[] = "/localhost_cert.pem";
+
+base::FilePath GetTestCertsDirectory() {
+  base::FilePath path;
+  base::PathService::Get(base::DIR_SOURCE_ROOT, &path);
+  path = path.Append(FILE_PATH_LITERAL("net"));
+  path = path.Append(FILE_PATH_LITERAL("data"));
+  path = path.Append(FILE_PATH_LITERAL("ssl"));
+  path = path.Append(FILE_PATH_LITERAL("certificates"));
+  return path;
+}
+
+class SSLServerContext {
+ public:
+  static SSLServerContext* GetInstance() {
+    return base::Singleton<SSLServerContext,
+                           base::LeakySingletonTraits<SSLServerContext>>::get();
+  }
+  SSL_CTX* ssl_ctx() { return ssl_ctx_.get(); }
+
+ private:
+  friend struct base::DefaultSingletonTraits<SSLServerContext>;
+
+  SSLServerContext() {
+    crypto::EnsureOpenSSLInit();
+    OpenSSL_add_ssl_algorithms();
+    ssl_ctx_.reset(SSL_CTX_new(TLS_server_method()));
+    CHECK(ssl_ctx_);
+
+    std::string cert_file(GetTestCertsDirectory().value() + kTestCertFileName);
+    LOG(INFO) << "SSL certificate file: " << cert_file;
+
+    CHECK_GT(SSL_CTX_use_certificate_file(ssl_ctx_.get(),
+                                          cert_file.c_str(),
+                                          SSL_FILETYPE_PEM), 0);
+
+    CHECK_GT(SSL_CTX_use_PrivateKey_file(ssl_ctx_.get(),
+                                         cert_file.c_str(),
+                                         SSL_FILETYPE_PEM), 0);
+
+    CHECK(SSL_CTX_check_private_key(ssl_ctx_.get()));
+  }
+
+  bssl::UniquePtr<SSL_CTX> ssl_ctx_;
+};
+
+class SSLClientContext {
+ public:
+  static SSLClientContext* GetInstance() {
+    return base::Singleton<SSLClientContext,
+                           base::LeakySingletonTraits<SSLClientContext>>::get();
+  }
+  SSL_CTX* ssl_ctx() { return ssl_ctx_.get(); }
+
+ private:
+  friend struct base::DefaultSingletonTraits<SSLClientContext>;
+
+  SSLClientContext() {
+    crypto::EnsureOpenSSLInit();
+    OpenSSL_add_ssl_algorithms();
+    ssl_ctx_.reset(SSL_CTX_new(TLS_client_method()));
+    CHECK(ssl_ctx_);
+  }
+
+  bssl::UniquePtr<SSL_CTX> ssl_ctx_;
+};
+
+} // namespace
+
+SSL* AcceptSSLConnection(int socket) {
+  CHECK_GE(socket, 0);
+  SSL* ssl = SSL_new(SSLServerContext::GetInstance()->ssl_ctx());
+  CHECK(ssl);
+  SSL_set_fd(ssl, socket);
+  SSL_accept(ssl);
+  return ssl;
+}
+
+SSL* ConnectSSLConnection(int socket) {
+  CHECK_GE(socket, 0);
+  SSL* ssl = SSL_new(SSLClientContext::GetInstance()->ssl_ctx());
+  CHECK(ssl);
+  SSL_set_fd(ssl, socket);
+  SSL_connect(ssl);
+  return ssl;
+}
+
+ssize_t SecureSocketWrite(SSL* ssl, const void* bytes, size_t num_bytes) {
+  return SSL_write(ssl, bytes, num_bytes);
+}
+
+ssize_t SecureSocketRecvmsg(SSL* ssl, void* buf, size_t num_bytes) {
+  return SSL_read(ssl, buf, num_bytes);
+}
+
+}  // namespace mojo

--- a/mojo/public/cpp/platform/secure_socket_utils_posix.cc
+++ b/mojo/public/cpp/platform/secure_socket_utils_posix.cc
@@ -8,21 +8,142 @@
 #include "base/memory/singleton.h"
 #include "base/path_service.h"
 #include "crypto/openssl_util.h"
+#include "third_party/boringssl/src/include/openssl/ssl.h"
+
+#if defined(OS_TIZEN)
+#include "chromium_impl/content/common/paths_efl.h"
+#endif
 
 namespace mojo {
 
 namespace {
 
-constexpr char kTestCertFileName[] = "/localhost_cert.pem";
+constexpr char kCastanetsCertFileName[] = "castanets_cert.pem";
+constexpr char kCastanetsKeyFileName[] = "castanets_key.pem";
 
-base::FilePath GetTestCertsDirectory() {
+base::FilePath GetCertFileDirectory() {
   base::FilePath path;
-  base::PathService::Get(base::DIR_SOURCE_ROOT, &path);
-  path = path.Append(FILE_PATH_LITERAL("net"));
-  path = path.Append(FILE_PATH_LITERAL("data"));
-  path = path.Append(FILE_PATH_LITERAL("ssl"));
-  path = path.Append(FILE_PATH_LITERAL("certificates"));
+#if defined(OS_TIZEN)
+  base::PathService::Get(PathsEfl::DIR_USER_DATA, &path);
+#else
+  base::PathService::Get(base::DIR_TEMP, &path);
+#endif
   return path;
+}
+
+RSA* RSA_generate_key(int bits,
+                      unsigned long e_value,
+                      void* callback,
+                      void* cb_arg) {
+  assert(callback == NULL);
+  assert(cb_arg == NULL);
+
+  RSA* rsa = RSA_new();
+  BIGNUM* e = BN_new();
+
+  if (rsa == NULL || e == NULL || !BN_set_word(e, e_value) ||
+      !RSA_generate_key_ex(rsa, bits, e, NULL)) {
+    BN_free(e);
+    RSA_free(rsa);
+    return NULL;
+  }
+
+  BN_free(e);
+  return rsa;
+}
+
+// Generates a 2048-bit RSA key.
+EVP_PKEY* generate_key() {
+  // Allocate memory for the EVP_PKEY structure.
+  EVP_PKEY* pkey = EVP_PKEY_new();
+  if (!pkey) {
+    LOG(ERROR) << "Unable to create EVP_PKEY structure.";
+    return NULL;
+  }
+
+  // Generate the RSA key and assign it to pkey.
+  RSA* rsa = RSA_generate_key(2048, RSA_F4, NULL, NULL);
+  if (!EVP_PKEY_assign_RSA(pkey, rsa)) {
+    LOG(ERROR) << "Unable to generate 2048-bit RSA key.";
+    EVP_PKEY_free(pkey);
+    return NULL;
+  }
+  return pkey;
+}
+
+// Generates a self-signed x509 certificate.
+X509* generate_x509(EVP_PKEY* pkey) {
+  // Allocate memory for the X509 structure.
+  X509* x509 = X509_new();
+  if (!x509) {
+    LOG(ERROR) << "Unable to create X509 structure.";
+    return NULL;
+  }
+
+  // Set the serial number.
+  ASN1_INTEGER_set(X509_get_serialNumber(x509), 1);
+
+  // This certificate is valid from now until exactly one year from now.
+  X509_gmtime_adj(X509_get_notBefore(x509), 0);
+  X509_gmtime_adj(X509_get_notAfter(x509), 31536000L);
+
+  // Set the public key for our certificate.
+  X509_set_pubkey(x509, pkey);
+
+  // We want to copy the subject name to the issuer name.
+  X509_NAME* name = X509_get_subject_name(x509);
+
+  // Now set the issuer name.
+  X509_set_issuer_name(x509, name);
+
+  // Actually sign the certificate with our key.
+  if (!X509_sign(x509, pkey, EVP_sha1())) {
+    LOG(ERROR) << "Error signing certificate.";
+    X509_free(x509);
+    return NULL;
+  }
+  return x509;
+}
+
+bool write_to_disk(EVP_PKEY* pkey, X509* x509) {
+  base::FilePath dir = GetCertFileDirectory();
+  // Open the PEM file for writing the key to disk.
+  FILE* pkey_file =
+      fopen(dir.Append(kCastanetsKeyFileName).value().c_str(), "wb");
+
+  if (!pkey_file) {
+    LOG(ERROR) << "Unable to open "
+               << dir.Append(kCastanetsKeyFileName).value().c_str();
+    return false;
+  }
+
+  // Write the key to disk.
+  bool ret = PEM_write_PrivateKey(pkey_file, pkey, NULL, NULL, 0, NULL, NULL);
+  fclose(pkey_file);
+
+  if (!ret) {
+    LOG(ERROR) << "Unable to write private key to disk.";
+    return false;
+  }
+
+  // Open the PEM file for writing the certificate to disk.
+  FILE* x509_file =
+      fopen(dir.Append(kCastanetsCertFileName).value().c_str(), "wb");
+  if (!x509_file) {
+    LOG(ERROR) << "Unable to open "
+               << dir.Append(kCastanetsCertFileName).value().c_str();
+    return false;
+  }
+
+  // Write the certificate to disk.
+  ret = PEM_write_X509(x509_file, x509);
+  fclose(x509_file);
+
+  if (!ret) {
+    LOG(ERROR) << "Unable to write certificate to disk.";
+    return false;
+  }
+  return true;
 }
 
 class SSLServerContext {
@@ -37,23 +158,44 @@ class SSLServerContext {
   friend struct base::DefaultSingletonTraits<SSLServerContext>;
 
   SSLServerContext() {
+    EVP_PKEY* pkey = generate_key();
+    CHECK(pkey);
+
+    X509* x509 = generate_x509(pkey);
+    CHECK(x509);
+
+    bool ret = write_to_disk(pkey, x509);
+    EVP_PKEY_free(pkey);
+    X509_free(x509);
+    CHECK(ret);
+
     crypto::EnsureOpenSSLInit();
     OpenSSL_add_ssl_algorithms();
     ssl_ctx_.reset(SSL_CTX_new(TLS_server_method()));
     CHECK(ssl_ctx_);
 
-    std::string cert_file(GetTestCertsDirectory().value() + kTestCertFileName);
-    LOG(INFO) << "SSL certificate file: " << cert_file;
-
     CHECK_GT(SSL_CTX_use_certificate_file(ssl_ctx_.get(),
-                                          cert_file.c_str(),
-                                          SSL_FILETYPE_PEM), 0);
+                                          GetCertFileDirectory()
+                                              .Append(kCastanetsCertFileName)
+                                              .value()
+                                              .c_str(),
+                                          SSL_FILETYPE_PEM),
+             0);
 
     CHECK_GT(SSL_CTX_use_PrivateKey_file(ssl_ctx_.get(),
-                                         cert_file.c_str(),
-                                         SSL_FILETYPE_PEM), 0);
+                                         GetCertFileDirectory()
+                                             .Append(kCastanetsKeyFileName)
+                                             .value()
+                                             .c_str(),
+                                         SSL_FILETYPE_PEM),
+             0);
 
     CHECK(SSL_CTX_check_private_key(ssl_ctx_.get()));
+
+    unlink(
+        GetCertFileDirectory().Append(kCastanetsKeyFileName).value().c_str());
+    unlink(
+        GetCertFileDirectory().Append(kCastanetsCertFileName).value().c_str());
   }
 
   bssl::UniquePtr<SSL_CTX> ssl_ctx_;

--- a/mojo/public/cpp/platform/secure_socket_utils_posix.h
+++ b/mojo/public/cpp/platform/secure_socket_utils_posix.h
@@ -5,11 +5,11 @@
 #ifndef MOJO_PUBLIC_CPP_PLATFORM_SECURE_SOCKET_UTILS_POSIX_H_
 #define MOJO_PUBLIC_CPP_PLATFORM_SECURE_SOCKET_UTILS_POSIX_H_
 
-#include "base/component_export.h"
-#include "base/files/scoped_file.h"
+#include <sys/types.h>
 
-#include "third_party/boringssl/src/include/openssl/base.h"
-#include "third_party/boringssl/src/include/openssl/ssl.h"
+#include "base/component_export.h"
+
+typedef struct ssl_st SSL;
 
 namespace mojo {
 

--- a/mojo/public/cpp/platform/secure_socket_utils_posix.h
+++ b/mojo/public/cpp/platform/secure_socket_utils_posix.h
@@ -1,0 +1,30 @@
+// Copyright 2019 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MOJO_PUBLIC_CPP_PLATFORM_SECURE_SOCKET_UTILS_POSIX_H_
+#define MOJO_PUBLIC_CPP_PLATFORM_SECURE_SOCKET_UTILS_POSIX_H_
+
+#include "base/component_export.h"
+#include "base/files/scoped_file.h"
+
+#include "third_party/boringssl/src/include/openssl/base.h"
+#include "third_party/boringssl/src/include/openssl/ssl.h"
+
+namespace mojo {
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+SSL* AcceptSSLConnection(int socket);
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+SSL* ConnectSSLConnection(int socket);
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+ssize_t SecureSocketWrite(SSL* ssl, const void* bytes, size_t num_bytes);
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+ssize_t SecureSocketRecvmsg(SSL* socket, void* buf, size_t num_bytes);
+
+}  // namespace mojo
+
+#endif  // MOJO_PUBLIC_CPP_PLATFORM_SECURE_SOCKET_UTILS_POSIX_H_


### PR DESCRIPTION
This CL adds "--secure-connection" switch to allow the node channel to connect securely by using BoringSSL. Temporarily a self-signed certificate file is being used.