### PR TITLE
Fix build error since PR #188.

### DIFF
--- a/mojo/core/entrypoints.cc
+++ b/mojo/core/entrypoints.cc
@@ -354,7 +354,7 @@ MojoResult MojoSendInvitationImpl(
 #endif
 }
 #if defined(CASTANETS)
-MojoResult MojoRetryInvitation(
+MojoResult MojoRetryInvitationImpl(
     const struct MojoPlatformProcessHandle* old_process_handle,
     const struct MojoPlatformProcessHandle* process_handle,
     const struct MojoInvitationTransportEndpoint* transport_endpoint) {
@@ -435,7 +435,7 @@ MojoSystemThunks g_thunks = {sizeof(MojoSystemThunks),
                              MojoExtractMessagePipeFromInvitationImpl,
                              MojoSendInvitationImpl,
 #if defined(CASTANETS)
-                             MojoRetryInvitation,
+                             MojoRetryInvitationImpl,
 #endif
                              MojoAcceptInvitationImpl,
                              MojoSetQuotaImpl,

--- a/mojo/public/c/system/thunks.cc
+++ b/mojo/public/c/system/thunks.cc
@@ -464,13 +464,21 @@ MojoResult MojoSendInvitation(
     const MojoInvitationTransportEndpoint* transport_endpoint,
     MojoProcessErrorHandler error_handler,
     uintptr_t error_handler_context,
+#if defined(CASTANETS)
     const MojoSendInvitationOptions* options,
     base::RepeatingCallback<void()> tcp_success_callback) {
+#else
+    const MojoSendInvitationOptions* options) {
+#endif
   return INVOKE_THUNK(SendInvitation, invitation_handle, process_handle,
                       transport_endpoint, error_handler, error_handler_context,
+#if defined(CASTANETS)
                       options, std::move(tcp_success_callback));
+#else
+                      options);
+#endif
 }
-
+#if defined(CASTANETS)
 MojoResult MojoRetryInvitation(
     const struct MojoPlatformProcessHandle* old_process_handle,
     const struct MojoPlatformProcessHandle* process_handle,
@@ -478,7 +486,7 @@ MojoResult MojoRetryInvitation(
   return INVOKE_THUNK(RetryInvitation, old_process_handle, process_handle,
                       transport_endpoint);
 }
-
+#endif
 MojoResult MojoAcceptInvitation(
     const MojoInvitationTransportEndpoint* transport_endpoint,
     const MojoAcceptInvitationOptions* options,


### PR DESCRIPTION
This CL has two changes as below.

1) When build with gn option 'is_component_build = true'
below error occured.

error: duplicate symbol: MojoRetryInvitation

To fix this, use name |MojoRetryInvitationImpl|
instead of |MojoRetryInvitation| at entrypoints.cc.

2) Add additional guards for CASTANETS
which was missed out in PR #188 at thunks.cc.