### PR TITLE
Inform the browser of the shared memory created by the renderer.

### DIFF
--- a/base/memory/shared_memory_tracker.h
+++ b/base/memory/shared_memory_tracker.h
@@ -70,10 +70,16 @@ class BASE_EXPORT SharedMemoryTracker : public trace_event::MemoryDumpProvider {
   scoped_refptr<CastanetsMemoryMapping> FindMappedMemory(
       const UnguessableToken& id);
 
+  SyncDelegate* FindCreatedBuffer(const UnguessableToken& id);
+
   void AddFDInTransit(const UnguessableToken& guid, int fd);
 
   void MapExternalMemory(int fd, SyncDelegate* delegate);
   void MapInternalMemory(int fd);
+  CastanetsMemorySyncer* MapExternalMemory(const UnguessableToken& guid,
+                                           SyncDelegate* delegate);
+
+  void OnBufferCreated(const UnguessableToken& guid, SyncDelegate* syncer);
 
   CastanetsMemorySyncer* GetSyncer(const UnguessableToken& guid);
 #endif
@@ -129,6 +135,9 @@ class BASE_EXPORT SharedMemoryTracker : public trace_event::MemoryDumpProvider {
 
   Lock holders_lock_;
   std::map<UnguessableToken, CastanetsMemoryHolder> holders_;
+
+  Lock created_buffer_lock_;
+  std::map<UnguessableToken, SyncDelegate*> created_buffers_;
 #endif
 
   DISALLOW_COPY_AND_ASSIGN(SharedMemoryTracker);

--- a/mojo/core/broker_messages.h
+++ b/mojo/core/broker_messages.h
@@ -20,6 +20,7 @@ enum BrokerMessageType : uint32_t {
   BUFFER_SYNC,
 #if defined(CASTANETS)
   BUFFER_SYNC_2D,
+  BUFFER_CREATED,
 #endif
 };
 


### PR DESCRIPTION
In case of the command buffer, the renderer creates a shared memory and then share it with the Browser. And both the browser and renderer try to write data onto the shared memory and sync it.
At that point, the browser doesn't know which renderer(node) to send sync data to. Thus, this CL adds a new broker message for informing the browser of the shared memory created by the renderer.