### PR TITLE
Add --tcp-launch-timeout switch.

### DIFF
--- a/base/base_switches.cc
+++ b/base/base_switches.cc
@@ -123,6 +123,8 @@ const char kEnableForking[] = "enable-forking";
 
 // Specify distributed chrome server address.
 const char kServerAddress[] = "server-address";
+
+const char kTcpLaunchTimeout[] = "tcp-launch-timeout";
 #endif
 
 }  // namespace switches

--- a/base/base_switches.h
+++ b/base/base_switches.h
@@ -49,6 +49,7 @@ extern const char kOrderfileMemoryOptimization[];
 #if defined(CASTANETS)
 extern const char kEnableForking[];
 extern const char kServerAddress[];
+extern const char kTcpLaunchTimeout[];
 #endif
 
 }  // namespace switches


### PR DESCRIPTION
This switch specifies tcp launch timeout value to fallback
to launch renderer process via forking.

The behavior of this switch is as below.
1) out/Release/chrome --tcp-launch-timeout
Use default timeout value |kTcpLaunchTimeoutDefault|
in child_process_launcher_helper.cc

2) out/Release/chrome --tcp-launch-timeout=[timeout value]
Use the specified timeout value to fall through to launch
renderer process via unix domain socket.