### PR TITLE
Enable GPU compositing and fix the WebGL issue with --enable-forking.

### DIFF
--- a/content/app/content_main_runner_impl.cc
+++ b/content/app/content_main_runner_impl.cc
@@ -743,8 +743,6 @@ int ContentMainRunnerImpl::Initialize(const ContentMainParams& params) {
   // Android doesnot support SW compositing, kDisableGpuCompositing has to be
   // removed when testing on android.
   base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      switches::kDisableGpuCompositing);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
       switches::kDisableAcceleratedVideoDecode);
 
   base::CommandLine::ForCurrentProcess()->AppendSwitch(

--- a/gpu/command_buffer/client/implementation_base.cc
+++ b/gpu/command_buffer/client/implementation_base.cc
@@ -174,11 +174,15 @@ gpu::ContextResult ImplementationBase::Initialize(
 void ImplementationBase::WaitForCmd() {
   TRACE_EVENT0("gpu", "ImplementationBase::WaitForCmd");
 #if defined(CASTANETS)
+  // Synchronize the result because some commands require initialization.
+  mojo::SyncSharedMemory(transfer_buffer_->shared_memory_guid(),
+                         GetResultShmOffset(), kMaxSizeOfSimpleResult);
   // Call this api to synchronize the result shared memory.
   helper_->SyncResultData(GetResultShmId(), GetResultShmOffset(),
                           kMaxSizeOfSimpleResult);
   helper_->Finish();
 
+  // Wait for command execution result.
   mojo::WaitSyncSharedMemory(transfer_buffer_->shared_memory_guid());
 #else
   helper_->Finish();

--- a/gpu/command_buffer/service/common_decoder.cc
+++ b/gpu/command_buffer/service/common_decoder.cc
@@ -387,9 +387,6 @@ error::Error CommonDecoder::HandleSyncResultData(
       command_buffer_service_->GetTransferBuffer(args.id);
   mojo::SyncSharedMemory(buffer->backing()->GetGUID(), args.offset, args.size);
 
-  // Set result data to '0' for use in the next command on Castanets.
-  // Some apis should set data to non-zero, it can cause an issue.
-  memset(buffer->memory(), 0, args.size);
   return error::kNoError;
 }
 #endif


### PR DESCRIPTION
Enable GPU compositing as a default option for Castanets.
WebGL doesn't run with enable-forking mode because the result is initiated to 0
at the wrong time. So, synchronize the result memory from renderer process.