### PR TITLE
fixup! Inform the browser of the shared memory created by the renderer.

### DIFF
--- a/mojo/core/broker_castanets.cc
+++ b/mojo/core/broker_castanets.cc
@@ -448,8 +448,7 @@ base::WritableSharedMemoryRegion BrokerCastanets::GetWritableSharedMemoryRegion(
         BrokerMessageType::BUFFER_CREATED, 0, 0, &buffer_guid);
     buffer_guid->guid_high = r.GetGUID().GetHighForSerialization();
     buffer_guid->guid_low = r.GetGUID().GetLowForSerialization();
-    SocketWrite(sync_channel_.GetFD().get(), out_message->data(),
-                out_message->data_num_bytes());
+    channel_->Write(std::move(out_message));
     return r;
   }
 


### PR DESCRIPTION
Use broker channel to send the BUFFER_CREATED (non-sync msg) instead of
synch_channel_. This avoids receiving malformed message on browser side on
different test scenarios.

Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>