### PR TITLE
Make BrokerCastanets a ref-counted class.

### DIFF
--- a/base/memory/castanets_memory_syncer.cc
+++ b/base/memory/castanets_memory_syncer.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "base/memory/castanets_memory_syncer.h"
-#include "base/memory/castanets_memory_mapping.h"
 
 namespace base {
 
@@ -38,7 +37,7 @@ void UnknownMemorySyncer::SetFdInTransit(int fd) {
 }
 
 std::unique_ptr<ExternalMemorySyncer> UnknownMemorySyncer::ConvertToExternal(
-    SyncDelegate* delegate) {
+    scoped_refptr<SyncDelegate> delegate) {
   if (!pending_syncs_.empty() && mapping_info_) {
     void* memory = nullptr;
     if (!mapping_info_->HasMapping())
@@ -63,7 +62,7 @@ void UnknownMemorySyncer::SyncMemory(size_t offset, size_t sync_size) {
 }
 
 ExternalMemorySyncer::ExternalMemorySyncer(
-    SyncDelegate* delegate,
+    scoped_refptr<SyncDelegate> delegate,
     scoped_refptr<CastanetsMemoryMapping> mapping)
     : delegate_(delegate), mapping_info_(mapping) {}
 

--- a/base/memory/shared_memory_tracker.cc
+++ b/base/memory/shared_memory_tracker.cc
@@ -213,7 +213,8 @@ void SharedMemoryTracker::RemoveMapping(const UnguessableToken& guid,
   }
 }
 
-void SharedMemoryTracker::MapExternalMemory(int fd, SyncDelegate* delegate) {
+void SharedMemoryTracker::MapExternalMemory(
+    int fd, scoped_refptr<SyncDelegate> delegate) {
   CHECK(delegate);
   std::unique_ptr<UnknownMemorySyncer> unknown_memory = TakeUnknownMemory(fd);
   if (!unknown_memory)
@@ -230,7 +231,7 @@ void SharedMemoryTracker::MapExternalMemory(int fd, SyncDelegate* delegate) {
 }
 
 CastanetsMemorySyncer* SharedMemoryTracker::MapExternalMemory(
-    const UnguessableToken& guid, SyncDelegate* delegate) {
+    const UnguessableToken& guid, scoped_refptr<SyncDelegate> delegate) {
   CHECK(delegate);
   std::unique_ptr<UnknownMemorySyncer> unknown_memory = TakeUnknownMemory(guid);
   CHECK(unknown_memory);

--- a/base/memory/shared_memory_tracker.h
+++ b/base/memory/shared_memory_tracker.h
@@ -74,10 +74,11 @@ class BASE_EXPORT SharedMemoryTracker : public trace_event::MemoryDumpProvider {
 
   void AddFDInTransit(const UnguessableToken& guid, int fd);
 
-  void MapExternalMemory(int fd, SyncDelegate* delegate);
-  void MapInternalMemory(int fd);
+  void MapExternalMemory(int fd, scoped_refptr<SyncDelegate> delegate);
   CastanetsMemorySyncer* MapExternalMemory(const UnguessableToken& guid,
-                                           SyncDelegate* delegate);
+      scoped_refptr<SyncDelegate> delegate);
+
+  void MapInternalMemory(int fd);
 
   void OnBufferCreated(const UnguessableToken& guid, SyncDelegate* syncer);
 

--- a/mojo/core/broker_castanets.cc
+++ b/mojo/core/broker_castanets.cc
@@ -683,5 +683,21 @@ void BrokerCastanets::OnChannelError(Channel::Error error) {
   }
 }
 
+scoped_refptr<BrokerCastanets> BrokerCastanets::CreateInBrowserProcess(
+    base::ProcessHandle client_process,
+    ConnectionParams connection_params,
+    const ProcessErrorCallback& process_error_callback,
+    CastanetsFenceManager* fence_manager) {
+  return new BrokerCastanets(client_process, std::move(connection_params),
+                             process_error_callback, fence_manager);
+}
+
+scoped_refptr<BrokerCastanets> BrokerCastanets::CreateInChildProcess(
+    PlatformHandle handle,
+    scoped_refptr<base::TaskRunner> io_task_runner,
+    CastanetsFenceManager* fence_manager) {
+  return new BrokerCastanets(std::move(handle), io_task_runner, fence_manager);
+}
+
 }  // namespace core
 }  // namespace mojo

--- a/mojo/core/broker_castanets.h
+++ b/mojo/core/broker_castanets.h
@@ -24,13 +24,16 @@ class NodeChannel;
 // to fulfill shared memory allocation requests on some platforms.
 class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
  public:
-  // Note: This is blocking, and will wait for the first message over
-  // the endpoint handle in |handle|.
-  explicit BrokerCastanets(PlatformHandle handle,
-                           scoped_refptr<base::TaskRunner> io_task_runner,
-                           CastanetsFenceManager* fence_manager);
+  static scoped_refptr<BrokerCastanets> CreateInBrowserProcess(
+      base::ProcessHandle client_process,
+      ConnectionParams connection_params,
+      const ProcessErrorCallback& process_error_callback,
+      CastanetsFenceManager* fence_manager);
 
-  ~BrokerCastanets() override;
+  static scoped_refptr<BrokerCastanets> CreateInChildProcess(
+      PlatformHandle handle,
+      scoped_refptr<base::TaskRunner> io_task_runner,
+      CastanetsFenceManager* fence_manager);
 
   void SetNodeChannel(scoped_refptr<NodeChannel> node_channel) {
     CHECK(node_channel);
@@ -91,11 +94,6 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
                       uint32_t stride,
                       const void* data);
 
-  BrokerCastanets(base::ProcessHandle client_process,
-                  ConnectionParams connection_params,
-                  const ProcessErrorCallback& process_error_callback,
-                  CastanetsFenceManager* fence_manager);
-
   // Send |handle| to the client, to be used to establish a NodeChannel to us.
   bool SendChannel(PlatformHandle handle);
 
@@ -118,6 +116,19 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
   const ProcessErrorCallback process_error_callback_;
 
  private:
+  // Note: This is blocking, and will wait for the first message over
+  // the endpoint handle in |handle|.
+  BrokerCastanets(PlatformHandle handle,
+                           scoped_refptr<base::TaskRunner> io_task_runner,
+                           CastanetsFenceManager* fence_manager);
+
+  BrokerCastanets(base::ProcessHandle client_process,
+                  ConnectionParams connection_params,
+                  const ProcessErrorCallback& process_error_callback,
+                  CastanetsFenceManager* fence_manager);
+
+  ~BrokerCastanets() override;
+
   void StartChannelOnIOThread();
 
   void OnBufferRequest(uint32_t num_bytes);

--- a/mojo/core/channel_posix.cc
+++ b/mojo/core/channel_posix.cc
@@ -25,6 +25,7 @@
 #include "mojo/public/cpp/platform/socket_utils_posix.h"
 
 #if defined(CASTANETS)
+#include "base/memory/castanets_memory_syncer.h"
 #include "base/memory/shared_memory_tracker.h"
 #include "mojo/public/cpp/platform/tcp_platform_handle_utils.h"
 #endif
@@ -566,7 +567,7 @@ class ChannelPosix : public Channel,
       std::vector<PlatformHandleInTransit> handles = message_view.TakeHandles();
       if (!handles.empty()) {
 #if defined(CASTANETS)
-        base::SyncDelegate* delegate =
+        scoped_refptr<base::SyncDelegate> delegate =
             Core::Get()->GetNodeController()->GetSyncDelegate(
                 remote_process().get());
         if (delegate)

--- a/mojo/core/node_controller.h
+++ b/mojo/core/node_controller.h
@@ -147,7 +147,8 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
 
   void WaitSyncSharedBuffer(const base::UnguessableToken& guid);
 
-  base::SyncDelegate* GetSyncDelegate(base::ProcessHandle process);
+  scoped_refptr<base::SyncDelegate> GetSyncDelegate(
+      base::ProcessHandle process);
 #endif
 
   // Request that the Node be shut down cleanly. This may take an arbitrarily
@@ -376,10 +377,10 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
 #if !defined(OS_MACOSX) && !defined(OS_NACL_SFI) && !defined(OS_FUCHSIA)
   // Broker for sync shared buffer creation on behalf of broker clients.
 #if defined(CASTANETS)
-  std::unique_ptr<BrokerCastanets> broker_;
+  scoped_refptr<BrokerCastanets> broker_;
 
   base::Lock broker_hosts_lock_;
-  std::unordered_map<base::ProcessHandle, std::unique_ptr<BrokerCastanets>>
+  std::unordered_map<base::ProcessHandle, scoped_refptr<BrokerCastanets>>
       broker_hosts_;
 
   std::unique_ptr<CastanetsFenceManager> fence_manager_;


### PR DESCRIPTION
If NodeChannel::WriteChannelMessage() performs on the IO thread and simultaneously NodeController::Sync() performs on some other thread, a deadlock may occur.

#### IO Thread
```
NodeChannel::WriteChannelMessage() { Lock(channel_lock_) }
NodeController::GetSyncDelegate() { Lock(broker_hosts_lock_) }
```

#### A Thread
```
NodeController::Sync() { Lock(broker_hosts_lock_) }
NodeChannel::WriteChannelMessage() { Lock(channel_lock_) }
```

This CL removes locking broker_hosts_lock_ in NodeController::Sync() and makes BrokerCastanets a ref-counted class.