### PR TITLE
Enable accelerated path for canvas2d when MSAA is used with BGRA format.

### DIFF
--- a/third_party/skia/src/gpu/gl/GrGLCaps.cpp
+++ b/third_party/skia/src/gpu/gl/GrGLCaps.cpp
@@ -1484,6 +1484,12 @@ void GrGLCaps::initConfigTable(const GrContextOptions& contextOptions,
                 fConfigTable[kBGRA_8888_GrPixelConfig].fFlags |=
                     ConfigInfo::kRenderableWithMSAA_Flag;
             }
+#if defined(CASTANETS)
+            else {
+                fConfigTable[kBGRA_8888_GrPixelConfig].fFlags |=
+                    ConfigInfo::kRenderableWithMSAA_Flag;
+            }
+#endif
         } else if (ctxInfo.hasExtension("GL_APPLE_texture_format_BGRA8888")) {
             // This APPLE extension introduces complexity on ES2. It leaves the internal format
             // as RGBA, but allows BGRA as the external format. From testing, it appears that the


### PR DESCRIPTION
When MSAA is used with BGRA color type, SkSurface creation fails which
make canvas2d fallback to sw path. So this change forcefully allows
SkSurface to be created with BGRA colortype with msaa sample count set.