### PR TITLE
Support both server and client TCP sockets on all processes

### DIFF
--- a/content/browser/child_process_launcher_helper.h
+++ b/content/browser/child_process_launcher_helper.h
@@ -243,6 +243,7 @@ class ChildProcessLauncherHelper :
   std::unique_ptr<TimeoutMonitor> relaunch_renderer_process_monitor_timeout_;
   base::WaitableEvent success_or_timeout_event_;
   bool tcp_connected_;
+  bool remote_process_ = false;
 #endif
 
   bool terminate_on_shutdown_;

--- a/content/browser/child_process_launcher_helper_android.cc
+++ b/content/browser/child_process_launcher_helper_android.cc
@@ -65,19 +65,24 @@ base::Optional<mojo::NamedPlatformChannel>
 ChildProcessLauncherHelper::CreateNamedPlatformChannelOnClientThread() {
 #if defined(CASTANETS)
   DCHECK_CURRENTLY_ON(client_thread_id_);
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kEnableForking))
+  if (!remote_process_)
     return base::nullopt;
 
-  mojo::NamedPlatformChannel::Options options;
-  if (GetProcessType() == switches::kRendererProcess)
-    options.port = mojo::kCastanetsRendererPort;
-  if (GetProcessType() == switches::kUtilityProcess)
-    options.port = mojo::kCastanetsUtilityPort;
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  if (!command_line->HasSwitch(switches::kServerAddress) ||
+      command_line->GetSwitchValueASCII(switches::kServerAddress).empty()) {
+    mojo::NamedPlatformChannel::Options options;
+    options.port = (GetProcessType() == switches::kRendererProcess)
+                       ? mojo::kCastanetsRendererPort
+                       : mojo::kCastanetsUtilityPort;
 
-  // This socket pair is not used, however it is added
-  // to avoid failure of validation check of codes afterwards.
-  mojo_channel_.emplace();
-  return mojo::NamedPlatformChannel(options);
+    // This socket pair is not used, however it is added
+    // to avoid failure of validation check of codes afterwards.
+    mojo_channel_.emplace();
+    return mojo::NamedPlatformChannel(options);
+  }
+
+  return base::nullopt;
 #else
   return base::nullopt;
 #endif

--- a/content/child/child_thread_impl.cc
+++ b/content/child/child_thread_impl.cc
@@ -285,7 +285,7 @@ base::Optional<mojo::IncomingInvitation> InitializeMojoIPCChannel() {
 #if defined(CASTANETS)
 base::Optional<mojo::IncomingInvitation> InitializeMojoIPCChannelTCP() {
   TRACE_EVENT0("startup", "InitializeMojoIPCChannelTCP");
-  mojo::PlatformChannelEndpoint endpoint;
+  mojo::PlatformHandle handle;
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
   std::string server_address =
       command_line->HasSwitch(switches::kServerAddress)
@@ -297,23 +297,23 @@ base::Optional<mojo::IncomingInvitation> InitializeMojoIPCChannelTCP() {
   uint16_t port = (process_type == switches::kRendererProcess)
                       ? mojo::kCastanetsRendererPort
                       : mojo::kCastanetsUtilityPort;
+  bool secure_connection = false;
   if (server_address.empty()) {
     LOG(INFO) << "Listen on port:" << port;
-    endpoint = mojo::PlatformChannelEndpoint(mojo::CreateTCPServerHandle(port));
+    handle = mojo::CreateTCPServerHandle(port);
+    secure_connection = command_line->HasSwitch(switches::kSecureConnection);
   } else {
-    LOG(INFO) << "Connect to " << server_address << ":" << port;
-    endpoint = mojo::PlatformChannelEndpoint(
-        mojo::CreateTCPClientHandle(port, server_address));
+    handle = mojo::CreateTCPSocketHandle();
   }
   // Mojo isn't supported on all child process types.
   // TODO(crbug.com/604282): Support Mojo in the remaining processes.
-  if (!endpoint.is_valid()) {
+  if (!handle.is_valid()) {
     LOG(WARNING) << "Failed to connect " << process_type << " process.";
     return base::nullopt;
   }
 
-  return mojo::IncomingInvitation::Accept(std::move(endpoint),
-                                          server_address.empty());
+  return mojo::IncomingInvitation::AcceptTcpSocket(
+      (std::move(handle)), server_address, port, secure_connection);
 }
 #endif
 

--- a/mojo/core/broker_castanets.h
+++ b/mojo/core/broker_castanets.h
@@ -31,7 +31,7 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
       CastanetsFenceManager* fence_manager);
 
   static scoped_refptr<BrokerCastanets> CreateInChildProcess(
-      PlatformHandle handle,
+      ConnectionParams connection_params,
       scoped_refptr<base::TaskRunner> io_task_runner,
       CastanetsFenceManager* fence_manager);
 
@@ -47,7 +47,7 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
   // Returns the platform handle that should be used to establish a NodeChannel
   // to the process which is inviting us to join its network. This is the first
   // handle read off the Broker channel upon construction.
-  PlatformChannelEndpoint GetInviterEndpoint();
+  ConnectionParams GetInviterConnectionParams();
 
   // Request a shared buffer from the broker process. Blocks the current thread.
   base::WritableSharedMemoryRegion GetWritableSharedMemoryRegion(
@@ -97,9 +97,6 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
   // Send |handle| to the client, to be used to establish a NodeChannel to us.
   bool SendChannel(PlatformHandle handle);
 
-  // Send InitData to the client for node channel connection.
-  bool SendBrokerInit(int port, bool secure_connection);
-
 #if defined(OS_WIN)
   // Sends a named channel to the client. Like above, but for named pipes.
   void SendNamedChannel(const base::StringPiece16& pipe_name);
@@ -113,16 +110,16 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
                         std::vector<PlatformHandle> handles) override;
   void OnChannelError(Channel::Error error) override;
 
-  bool IsSecureConnection() const { return secure_connection_; }
+  bool is_tcp_connection() const { return tcp_connection_; }
 
   const ProcessErrorCallback process_error_callback_;
 
  private:
   // Note: This is blocking, and will wait for the first message over
   // the endpoint handle in |handle|.
-  BrokerCastanets(PlatformHandle handle,
-                           scoped_refptr<base::TaskRunner> io_task_runner,
-                           CastanetsFenceManager* fence_manager);
+  BrokerCastanets(ConnectionParams connection_params,
+                  scoped_refptr<base::TaskRunner> io_task_runner,
+                  CastanetsFenceManager* fence_manager);
 
   BrokerCastanets(base::ProcessHandle client_process,
                   ConnectionParams connection_params,
@@ -131,7 +128,15 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
 
   ~BrokerCastanets() override;
 
-  void StartChannelOnIOThread();
+  void Initialize(ConnectionParams connection_params,
+                  scoped_refptr<base::TaskRunner> io_task_runner);
+
+  void StartChannelOnIOThread(ConnectionParams connection_params,
+                              uint16_t port,
+                              bool secure_connection);
+
+  // Send InitData to the client for node channel connection.
+  bool SendBrokerInit(int port, bool secure_connection);
 
   void OnBufferRequest(uint32_t num_bytes);
 
@@ -152,14 +157,13 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
                               bool write_lock = true);
 
   bool tcp_connection_ = false;
-  bool secure_connection_ = false;
 
   // Handle to the broker process, used for synchronous IPCs.
   PlatformHandle sync_channel_;
 
-  // Channel endpoint connected to the inviter process. Recieved in the first
+  // Connection Params connected to the inviter process. Received in the first
   // first message over |sync_channel_|.
-  PlatformChannelEndpoint inviter_endpoint_;
+  ConnectionParams inviter_connection_params_;
 
   scoped_refptr<Channel> channel_;
 

--- a/mojo/core/broker_castanets.h
+++ b/mojo/core/broker_castanets.h
@@ -44,9 +44,8 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
 
   void ResetBrokerChannel(ConnectionParams connection_params);
 
-  // Returns the platform handle that should be used to establish a NodeChannel
-  // to the process which is inviting us to join its network. This is the first
-  // handle read off the Broker channel upon construction.
+  // Returns ConnectionParams that should be used to establish a NodeChannel
+  // to the process which is inviting us to join its network.
   ConnectionParams GetInviterConnectionParams();
 
   // Request a shared buffer from the broker process. Blocks the current thread.
@@ -161,7 +160,7 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
   // Handle to the broker process, used for synchronous IPCs.
   PlatformHandle sync_channel_;
 
-  // Connection Params connected to the inviter process. Received in the first
+  // ConnectionParams connected to the inviter process. Received in the first
   // first message over |sync_channel_|.
   ConnectionParams inviter_connection_params_;
 

--- a/mojo/core/connection_params.h
+++ b/mojo/core/connection_params.h
@@ -38,13 +38,20 @@ class MOJO_SYSTEM_IMPL_EXPORT ConnectionParams {
 
 #if defined(CASTANETS)
   bool is_secure() const { return secure_connection_; }
-  void SetSecure() { secure_connection_ = true; }
+  void SetSecure(bool secure_connection = true) {
+    secure_connection_ = secure_connection;
+  }
 
+  const std::string& tcp_address() const { return tcp_address_; }
   uint16_t tcp_port() const { return tcp_port_; }
-  void SetTcpPort(uint16_t port) { tcp_port_ = port; }
+  void SetTcpClient(std::string address, uint16_t port) {
+    tcp_address_ = address;
+    tcp_port_ = port;
+  }
 
  private:
   bool secure_connection_ = false;
+  std::string tcp_address_;
   uint16_t tcp_port_ = 0;
 #endif
 

--- a/mojo/core/connection_params.h
+++ b/mojo/core/connection_params.h
@@ -40,8 +40,12 @@ class MOJO_SYSTEM_IMPL_EXPORT ConnectionParams {
   bool is_secure() const { return secure_connection_; }
   void SetSecure() { secure_connection_ = true; }
 
+  uint16_t tcp_port() const { return tcp_port_; }
+  void SetTcpPort(uint16_t port) { tcp_port_ = port; }
+
  private:
   bool secure_connection_ = false;
+  uint16_t tcp_port_ = 0;
 #endif
 
  private:

--- a/mojo/core/core.cc
+++ b/mojo/core/core.cc
@@ -1433,6 +1433,9 @@ MojoResult Core::SendInvitation(
                                          attached_ports[0].second,
                                          connection_name);
   } else {
+#if defined(CASTANETS)
+    connection_params.SetTcpPort(options->tcp_port);
+#endif
     GetNodeController()->SendBrokerClientInvitation(
         target_process, std::move(connection_params), attached_ports,
 #if defined(CASTANETS)

--- a/mojo/core/core.cc
+++ b/mojo/core/core.cc
@@ -1368,8 +1368,12 @@ MojoResult Core::SendInvitation(
   if (!transport_endpoint->platform_handles)
     return MOJO_RESULT_INVALID_ARGUMENT;
   if (transport_endpoint->type != MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL &&
-      transport_endpoint->type !=
-          MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER) {
+      transport_endpoint->type != MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER
+#if defined(CASTANETS)
+      && transport_endpoint->type !=
+             MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_TCP_CLIENT
+#endif
+      ) {
     return MOJO_RESULT_UNIMPLEMENTED;
   }
 
@@ -1434,7 +1438,16 @@ MojoResult Core::SendInvitation(
                                          connection_name);
   } else {
 #if defined(CASTANETS)
-    connection_params.SetTcpPort(options->tcp_port);
+    if (transport_endpoint->type ==
+        MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_TCP_CLIENT) {
+      connection_params.SetTcpClient(
+          std::string(options->tcp_address, options->tcp_address_length),
+          options->tcp_port);
+    } else if (transport_endpoint->type ==
+               MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER) {
+      if (transport_endpoint->secure_connection)
+        connection_params.SetSecure();
+    }
 #endif
     GetNodeController()->SendBrokerClientInvitation(
         target_process, std::move(connection_params), attached_ports,
@@ -1464,8 +1477,12 @@ MojoResult Core::AcceptInvitation(
   if (!transport_endpoint->platform_handles)
     return MOJO_RESULT_INVALID_ARGUMENT;
   if (transport_endpoint->type != MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL &&
-      transport_endpoint->type !=
-          MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER) {
+      transport_endpoint->type != MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER
+#if defined(CASTANETS)
+      && transport_endpoint->type !=
+             MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_TCP_CLIENT
+#endif
+      ) {
     return MOJO_RESULT_UNIMPLEMENTED;
   }
 
@@ -1496,6 +1513,19 @@ MojoResult Core::AcceptInvitation(
     connection_params =
         ConnectionParams(PlatformChannelEndpoint(std::move(endpoint)));
   }
+#if defined(CASTANETS)
+  if (transport_endpoint->type ==
+      MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_TCP_CLIENT) {
+    connection_params.SetTcpClient(
+        std::string(transport_endpoint->tcp_address,
+                    transport_endpoint->tcp_address_length),
+        transport_endpoint->tcp_port);
+  } else if (transport_endpoint->type ==
+             MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER) {
+    if (transport_endpoint->secure_connection)
+      connection_params.SetSecure();
+  }
+#endif
 
   bool is_isolated =
       options && (options->flags & MOJO_ACCEPT_INVITATION_FLAG_ISOLATED);

--- a/mojo/core/node_controller.cc
+++ b/mojo/core/node_controller.cc
@@ -247,13 +247,20 @@ void NodeController::AcceptBrokerClientInvitation(
   base::ElapsedTimer timer;
 #if defined(CASTANETS)
   broker_ = BrokerCastanets::CreateInChildProcess(
-      connection_params.TakeEndpoint().TakePlatformHandle(),
-      io_task_runner_,
-      fence_manager_.get());
+      std::move(connection_params), io_task_runner_, fence_manager_.get());
+  connection_params = broker_->GetInviterConnectionParams();
+  if (!connection_params.endpoint().is_valid() &&
+      !connection_params.server_endpoint().is_valid()) {
+    // Most likely the inviter's side of the channel has already been closed and
+    // the broker was unable to negotiate a NodeChannel pipe. In this case we
+    // can cancel our connection to our inviter.
+    DVLOG(1) << "Cannot connect to invalid inviter channel.";
+    CancelPendingPortMerges();
+    return;
+  }
 #else
   broker_ = std::make_unique<Broker>(
       connection_params.TakeEndpoint().TakePlatformHandle());
-#endif
   PlatformChannelEndpoint endpoint = broker_->GetInviterEndpoint();
   if (!endpoint.is_valid()) {
     // Most likely the inviter's side of the channel has already been closed and
@@ -264,6 +271,7 @@ void NodeController::AcceptBrokerClientInvitation(
     return;
   }
   connection_params = ConnectionParams(std::move(endpoint));
+#endif
 #endif
 
   io_task_runner_->PostTask(
@@ -392,7 +400,7 @@ scoped_refptr<base::SyncDelegate> NodeController::GetSyncDelegate(
 
   base::AutoLock lock(broker_hosts_lock_);
   auto it = broker_hosts_.find(process);
-  if (it != broker_hosts_.end())
+  if (it != broker_hosts_.end() && it->second->is_tcp_connection())
     return it->second;
 
   CHECK_GE(process, 0);
@@ -453,35 +461,19 @@ void NodeController::SendBrokerClientInvitationOnIOThread(
 #if defined(CASTANETS)
   bool channel_ok = false;
   ConnectionParams node_connection_params;
-  if (connection_params.endpoint().is_valid()) {
-    // Unix Domain Socket
+  scoped_refptr<BrokerCastanets> broker_host =
+      BrokerCastanets::CreateInBrowserProcess(
+          target_process.get(), std::move(connection_params),
+          process_error_callback, fence_manager_.get());
+  node_connection_params = broker_host->GetInviterConnectionParams();
+  channel_ok = node_connection_params.endpoint().is_valid() ||
+               node_connection_params.server_endpoint().is_valid();
+  if (!channel_ok && !broker_host->is_tcp_connection()) {
+    // IPC Unix Domain Socket
     PlatformChannel node_channel;
     node_connection_params = ConnectionParams(node_channel.TakeLocalEndpoint());
-    // BrokerHost owns itself.
-    BrokerHost* broker_host =
-        new BrokerHost(target_process.get(), std::move(connection_params),
-                       process_error_callback);
     channel_ok = broker_host->SendChannel(
         node_channel.TakeRemoteEndpoint().TakePlatformHandle());
-  } else {
-    // TCP Server Socket
-    uint16_t port = 0;
-    node_connection_params =
-        ConnectionParams(mojo::PlatformChannelServerEndpoint(
-            mojo::PlatformHandle(CreateTCPServerHandle(port, &port))));
-    if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-        switches::kSecureConnection))
-      node_connection_params.SetSecure();
-
-    scoped_refptr<BrokerCastanets> broker_host =
-        BrokerCastanets::CreateInBrowserProcess(target_process.get(),
-                                                std::move(connection_params),
-                                                process_error_callback,
-                                                fence_manager_.get());
-    channel_ok = broker_host->SendBrokerInit(
-        port, node_connection_params.is_secure());
-    base::AutoLock lock(broker_hosts_lock_);
-    broker_hosts_.emplace(target_process.get(), broker_host);
   }
 #else
   PlatformChannel node_channel;
@@ -514,9 +506,8 @@ void NodeController::SendBrokerClientInvitationOnIOThread(
 #if defined(CASTANETS)
   {
     base::AutoLock broker_lock(broker_hosts_lock_);
-    auto host = broker_hosts_.find(target_process.get());
-    if (host != broker_hosts_.end())
-      host->second->SetNodeChannel(channel);
+    broker_host->SetNodeChannel(channel);
+    broker_hosts_.emplace(target_process.get(), std::move(broker_host));
   }
 #endif
 
@@ -584,10 +575,6 @@ void NodeController::AcceptBrokerClientInvitationOnIOThread(
     // At this point we don't know the inviter's name, so we can't yet insert it
     // into our |peers_| map. That will happen as soon as we receive an
     // AcceptInvitee message from them.
-#if defined(CASTANETS)
-    if (broker_->IsSecureConnection())
-      connection_params.SetSecure();
-#endif
     bootstrap_inviter_channel_ =
         NodeChannel::Create(this, std::move(connection_params), io_task_runner_,
                             ProcessErrorCallback());

--- a/mojo/public/c/system/invitation.h
+++ b/mojo/public/c/system/invitation.h
@@ -92,6 +92,12 @@ typedef uint32_t MojoInvitationTransportType;
 #define MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER \
   ((MojoInvitationTransportType)1)
 
+// Similar to CHANNEL transport, but used for an endpoint which requires an
+// additional step to connect an outbound connection. This corresponds to TCP
+// client socket on Castanets.
+#define MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_TCP_CLIENT \
+  ((MojoInvitationTransportType)2)
+
 // A transport endpoint over which an invitation may be sent or received via
 // |MojoSendInvitation()| or |MojoAcceptInvitation()| respectively.
 struct MOJO_ALIGNAS(8) MojoInvitationTransportEndpoint {
@@ -113,9 +119,22 @@ struct MOJO_ALIGNAS(8) MojoInvitationTransportEndpoint {
   //   - On other POSIX systems, this is a single Unix domain socket file
   //     descriptor.
   MOJO_POINTER_FIELD(const struct MojoPlatformHandle*, platform_handles);
+
+#if defined(CASTANETS)
+  // TCP address and port number for TCP Client Socket
+  MOJO_POINTER_FIELD(const char*, tcp_address);
+  uint32_t tcp_address_length;
+  uint16_t tcp_port;
+  bool secure_connection;
+#endif
 };
+#if defined(CASTANETS)
+MOJO_STATIC_ASSERT(sizeof(MojoInvitationTransportEndpoint) == 24 + 16,
+                   "MojoInvitationTransportEndpoint has wrong size.");
+#else
 MOJO_STATIC_ASSERT(sizeof(MojoInvitationTransportEndpoint) == 24,
                    "MojoInvitationTransportEndpoint has wrong size.");
+#endif
 
 // Flags passed to |MojoCreateInvitation()| via |MojoCreateInvitationOptions|.
 typedef uint32_t MojoCreateInvitationFlags;
@@ -207,12 +226,20 @@ struct MOJO_ALIGNAS(8) MojoSendInvitationOptions {
   uint32_t isolated_connection_name_length;
 
 #if defined(CASTANETS)
-  // TCP destination port number for TCP Client Socket
+  // TCP address and port number for TCP Client Socket
+  MOJO_POINTER_FIELD(const char*, tcp_address);
+  uint32_t tcp_address_length;
   uint16_t tcp_port;
+  bool secure_connection;
 #endif
 };
+#if defined(CASTANETS)
+MOJO_STATIC_ASSERT(sizeof(MojoSendInvitationOptions) == 24 + 16,
+                   "MojoSendInvitationOptions has wrong size");
+#else
 MOJO_STATIC_ASSERT(sizeof(MojoSendInvitationOptions) == 24,
                    "MojoSendInvitationOptions has wrong size");
+#endif
 
 // Flags passed to |MojoAcceptInvitation()| via |MojoAcceptInvitationOptions|.
 typedef uint32_t MojoAcceptInvitationFlags;

--- a/mojo/public/c/system/invitation.h
+++ b/mojo/public/c/system/invitation.h
@@ -205,6 +205,11 @@ struct MOJO_ALIGNAS(8) MojoSendInvitationOptions {
   // exist for the given name at any time.
   MOJO_POINTER_FIELD(const char*, isolated_connection_name);
   uint32_t isolated_connection_name_length;
+
+#if defined(CASTANETS)
+  // TCP destination port number for TCP Client Socket
+  uint16_t tcp_port;
+#endif
 };
 MOJO_STATIC_ASSERT(sizeof(MojoSendInvitationOptions) == 24,
                    "MojoSendInvitationOptions has wrong size");

--- a/mojo/public/cpp/platform/platform_channel.cc
+++ b/mojo/public/cpp/platform/platform_channel.cc
@@ -161,6 +161,12 @@ PlatformChannel::PlatformChannel(PlatformChannel&& other) = default;
 
 PlatformChannel::~PlatformChannel() = default;
 
+#if defined(CASTANETS)
+PlatformChannel::PlatformChannel(PlatformChannelEndpoint local_endpoint) {
+  local_endpoint_ = std::move(local_endpoint);
+}
+#endif
+
 PlatformChannel& PlatformChannel::operator=(PlatformChannel&& other) = default;
 
 void PlatformChannel::PrepareToPassRemoteEndpoint(HandlePassingInfo* info,

--- a/mojo/public/cpp/platform/platform_channel.h
+++ b/mojo/public/cpp/platform/platform_channel.h
@@ -51,6 +51,10 @@ class COMPONENT_EXPORT(MOJO_CPP_PLATFORM) PlatformChannel {
   PlatformChannel(PlatformChannel&& other);
   ~PlatformChannel();
 
+#if defined(CASTANETS)
+  PlatformChannel(PlatformChannelEndpoint local_endpoint);
+#endif
+
   PlatformChannel& operator=(PlatformChannel&& other);
 
   const PlatformChannelEndpoint& local_endpoint() const {

--- a/mojo/public/cpp/platform/tcp_platform_handle_utils.h
+++ b/mojo/public/cpp/platform/tcp_platform_handle_utils.h
@@ -20,8 +20,16 @@ const size_t kCastanetsRendererPort = 8008;
 const size_t kCastanetsUtilityPort = 7007;
 
 COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+PlatformHandle CreateTCPSocketHandle();
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
 PlatformHandle CreateTCPClientHandle(const uint16_t port,
                                      std::string server_address = "");
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+bool TCPClientConnect(const base::ScopedFD& fd,
+                      std::string server_address,
+                      const uint16_t port);
 
 COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
 PlatformHandle CreateTCPServerHandle(uint16_t port,
@@ -32,7 +40,7 @@ bool TCPServerAcceptConnection(const base::PlatformFile server_socket,
                                base::ScopedFD* accept_socket);
 
 COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
-bool IsTcpSocket(const base::ScopedFD& fd);
+bool IsNetworkSocket(const base::ScopedFD& fd);
 
 COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
 std::string GetPeerAddress(const base::ScopedFD& fd);

--- a/mojo/public/cpp/platform/tcp_platform_handle_utils.h
+++ b/mojo/public/cpp/platform/tcp_platform_handle_utils.h
@@ -31,6 +31,12 @@ COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
 bool TCPServerAcceptConnection(const base::PlatformFile server_socket,
                                base::ScopedFD* accept_socket);
 
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+bool IsTcpSocket(const base::ScopedFD& fd);
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+std::string GetPeerAddress(const base::ScopedFD& fd);
+
 }  // namespace mojo
 
 #endif  // MOJO_EDK_EMBEDDER_TCP_PLATFORM_HANDLE_UTILS_H_

--- a/mojo/public/cpp/system/invitation.cc
+++ b/mojo/public/cpp/system/invitation.cc
@@ -62,6 +62,8 @@ void SendInvitation(ScopedInvitationHandle invitation,
 #if defined(CASTANETS)
                     base::StringPiece isolated_connection_name,
                     base::RepeatingCallback<void()> tcp_success_callback = {},
+                    bool secure_connection = false,
+                    base::StringPiece tcp_address = base::StringPiece(),
                     uint16_t tcp_port = 0) {
 #else
                     base::StringPiece isolated_connection_name) {
@@ -96,7 +98,10 @@ void SendInvitation(ScopedInvitationHandle invitation,
         static_cast<uint32_t>(isolated_connection_name.size());
   }
 #if defined(CASTANETS)
+  options.tcp_address = tcp_address.data();
+  options.tcp_address_length = static_cast<uint32_t>(tcp_address.size());
   options.tcp_port = tcp_port;
+  options.secure_connection = secure_connection;
   MojoResult result = MojoSendInvitation(
       invitation.get().value(), &process_handle, &endpoint, error_handler,
       error_handler_context, &options, tcp_success_callback);
@@ -109,6 +114,7 @@ void SendInvitation(ScopedInvitationHandle invitation,
   if (result == MOJO_RESULT_OK)
     ignore_result(invitation.release());
 }
+
 #if defined(CASTANETS)
 void RetryInvitation(base::ProcessHandle old_process,
                      base::ProcessHandle process,
@@ -202,30 +208,21 @@ void OutgoingInvitation::Send(OutgoingInvitation invitation,
 
 #if defined(CASTANETS)
 // static
-void OutgoingInvitation::Send(OutgoingInvitation invitation,
-                              base::ProcessHandle target_process,
-                              PlatformChannelEndpoint server_endpoint,
-                              const ProcessErrorCallback& error_callback,
-                              uint16_t tcp_port) {
-  SendInvitation(std::move(invitation.handle_), target_process,
-                 server_endpoint.TakePlatformHandle(),
-                 MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL,
-                 MOJO_SEND_INVITATION_FLAG_NONE, error_callback, "",
-                 base::RepeatingCallback<void()>(), tcp_port);
-}
-
-// static
-void OutgoingInvitation::Send(
+void OutgoingInvitation::SendTcpSocket(
     OutgoingInvitation invitation,
     base::ProcessHandle target_process,
-    PlatformChannelServerEndpoint server_endpoint,
+    PlatformHandle platform_handle,
     const ProcessErrorCallback& error_callback,
-    base::RepeatingCallback<void()> tcp_success_callback) {
-  SendInvitation(std::move(invitation.handle_), target_process,
-                 server_endpoint.TakePlatformHandle(),
-                 MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER,
-                 MOJO_SEND_INVITATION_FLAG_NONE, error_callback, "",
-                 tcp_success_callback);
+    base::RepeatingCallback<void()> tcp_success_callback,
+    bool secure_connection,
+    std::string address,
+    uint16_t tcp_port) {
+  SendInvitation(
+      std::move(invitation.handle_), target_process, std::move(platform_handle),
+      address.empty() ? MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER
+                      : MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_TCP_CLIENT,
+      MOJO_SEND_INVITATION_FLAG_NONE, error_callback, "", tcp_success_callback,
+      secure_connection, base::StringPiece(address), tcp_port);
 }
 
 // static
@@ -280,12 +277,7 @@ IncomingInvitation& IncomingInvitation::operator=(IncomingInvitation&& other) =
 
 // static
 IncomingInvitation IncomingInvitation::Accept(
-    PlatformChannelEndpoint channel_endpoint
-#if defined(CASTANETS)
-    ,
-    bool server
-#endif
-    ) {
+    PlatformChannelEndpoint channel_endpoint) {
   MojoPlatformHandle endpoint_handle;
   PlatformHandle::ToMojoPlatformHandle(channel_endpoint.TakePlatformHandle(),
                                        &endpoint_handle);
@@ -294,10 +286,6 @@ IncomingInvitation IncomingInvitation::Accept(
   MojoInvitationTransportEndpoint transport_endpoint;
   transport_endpoint.struct_size = sizeof(transport_endpoint);
   transport_endpoint.type = MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL;
-#if defined(CASTANETS)
-  if (server)
-    transport_endpoint.type = MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER;
-#endif
   transport_endpoint.num_platform_handles = 1;
   transport_endpoint.platform_handles = &endpoint_handle;
 
@@ -339,6 +327,38 @@ ScopedMessagePipeHandle IncomingInvitation::AcceptIsolated(
       ScopedInvitationHandle(InvitationHandle(invitation_handle))};
   return invitation.ExtractMessagePipe(kIsolatedPipeName);
 }
+
+#if defined(CASTANETS)
+IncomingInvitation IncomingInvitation::AcceptTcpSocket(PlatformHandle handle,
+                                                       std::string address,
+                                                       uint16_t port,
+                                                       bool secure_connection) {
+  MojoPlatformHandle endpoint_handle;
+  PlatformHandle::ToMojoPlatformHandle(std::move(handle), &endpoint_handle);
+  CHECK_NE(endpoint_handle.type, MOJO_PLATFORM_HANDLE_TYPE_INVALID);
+
+  MojoInvitationTransportEndpoint transport_endpoint;
+  transport_endpoint.struct_size = sizeof(transport_endpoint);
+  transport_endpoint.type =
+      (address.empty()) ? MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER
+                        : MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_TCP_CLIENT;
+  transport_endpoint.num_platform_handles = 1;
+  transport_endpoint.platform_handles = &endpoint_handle;
+  transport_endpoint.tcp_address = address.c_str();
+  transport_endpoint.tcp_address_length = address.length();
+  transport_endpoint.tcp_port = port;
+  transport_endpoint.secure_connection = secure_connection;
+
+  MojoHandle invitation_handle;
+  MojoResult result =
+      MojoAcceptInvitation(&transport_endpoint, nullptr, &invitation_handle);
+  if (result != MOJO_RESULT_OK)
+    return IncomingInvitation();
+
+  return IncomingInvitation(
+      ScopedInvitationHandle(InvitationHandle(invitation_handle)));
+}
+#endif
 
 ScopedMessagePipeHandle IncomingInvitation::ExtractMessagePipe(
     base::StringPiece name) {

--- a/mojo/public/cpp/system/invitation.h
+++ b/mojo/public/cpp/system/invitation.h
@@ -100,19 +100,16 @@ class MOJO_CPP_SYSTEM_EXPORT OutgoingInvitation {
                    const ProcessErrorCallback& error_callback = {});
 
 #if defined(CASTANETS)
-  // Similar to above, but sends |invitation| via TCP client socket with
-  // |tcp_port|.
-  static void Send(OutgoingInvitation invitation,
-                   base::ProcessHandle target_process,
-                   PlatformChannelEndpoint channel_endpoint,
-                   const ProcessErrorCallback& error_callback,
-                   uint16_t tcp_port);
-
-  static void Send(OutgoingInvitation invitation,
-                   base::ProcessHandle target_process,
-                   PlatformChannelServerEndpoint server_endpoint,
-                   const ProcessErrorCallback& error_callback,
-                   base::RepeatingCallback<void()> tcp_success_callback);
+  // Similar to above, but sends |invitation| using by TCP socket
+  static void SendTcpSocket(
+      OutgoingInvitation invitation,
+      base::ProcessHandle target_process,
+      PlatformHandle platform_handle,
+      const ProcessErrorCallback& error_callback,
+      base::RepeatingCallback<void()> tcp_success_callback,
+      bool secure_connection,
+      std::string address = "",
+      uint16_t tcp_port = 0);
 
   static void Retry(base::ProcessHandle old_process,
                     base::ProcessHandle process,
@@ -179,17 +176,19 @@ class MOJO_CPP_SYSTEM_EXPORT IncomingInvitation {
   // the other end of that channel. If the invitation was sent using a
   // |PlatformChannelServerEndpoint|, then |channel_endpoint| should be created
   // by |NamedPlatformChannel::ConnectToServer|.
-  static IncomingInvitation Accept(PlatformChannelEndpoint channel_endpoint
-#if defined(CASTANETS)
-                                   ,
-                                   bool server = false
-#endif
-                                   );
+  static IncomingInvitation Accept(PlatformChannelEndpoint channel_endpoint);
 
   // Accepts an incoming isolated invitation from |channel_endpoint|. See
   // notes on |OutgoingInvitation::SendIsolated()|.
   static ScopedMessagePipeHandle AcceptIsolated(
       PlatformChannelEndpoint channel_endpoint);
+
+#if defined(CASTANETS)
+  static IncomingInvitation AcceptTcpSocket(PlatformHandle handle,
+                                            std::string address,
+                                            uint16_t port,
+                                            bool secure_connection);
+#endif
 
   // Extracts an attached message pipe from this invitation. This may succeed
   // even if no such pipe was attached, though the extracted pipe will

--- a/mojo/public/cpp/system/invitation.h
+++ b/mojo/public/cpp/system/invitation.h
@@ -97,13 +97,23 @@ class MOJO_CPP_SYSTEM_EXPORT OutgoingInvitation {
   static void Send(OutgoingInvitation invitation,
                    base::ProcessHandle target_process,
                    PlatformChannelServerEndpoint server_endpoint,
-#if defined(CASTANETS)
-                   const ProcessErrorCallback& error_callback = {},
-                   base::RepeatingCallback<void()> tcp_success_callback = {});
-#else
                    const ProcessErrorCallback& error_callback = {});
-#endif
+
 #if defined(CASTANETS)
+  // Similar to above, but sends |invitation| via TCP client socket with
+  // |tcp_port|.
+  static void Send(OutgoingInvitation invitation,
+                   base::ProcessHandle target_process,
+                   PlatformChannelEndpoint channel_endpoint,
+                   const ProcessErrorCallback& error_callback,
+                   uint16_t tcp_port);
+
+  static void Send(OutgoingInvitation invitation,
+                   base::ProcessHandle target_process,
+                   PlatformChannelServerEndpoint server_endpoint,
+                   const ProcessErrorCallback& error_callback,
+                   base::RepeatingCallback<void()> tcp_success_callback);
+
   static void Retry(base::ProcessHandle old_process,
                     base::ProcessHandle process,
                     PlatformChannelEndpoint channel_endpoint);
@@ -169,7 +179,12 @@ class MOJO_CPP_SYSTEM_EXPORT IncomingInvitation {
   // the other end of that channel. If the invitation was sent using a
   // |PlatformChannelServerEndpoint|, then |channel_endpoint| should be created
   // by |NamedPlatformChannel::ConnectToServer|.
-  static IncomingInvitation Accept(PlatformChannelEndpoint channel_endpoint);
+  static IncomingInvitation Accept(PlatformChannelEndpoint channel_endpoint
+#if defined(CASTANETS)
+                                   ,
+                                   bool server = false
+#endif
+                                   );
 
   // Accepts an incoming isolated invitation from |channel_endpoint|. See
   // notes on |OutgoingInvitation::SendIsolated()|.


### PR DESCRIPTION
This patch helps to make a TCP connection immediately between browser and
renderer without delay. If no value in the server address parameter of
castanets, the process creates TCP server socket instead of TCP client
socket.

Desktop browser process requires 2 renderer processes.

Run 2 renderer processes as server
$ out/Default/chrome --type=renderer
Run browser process
$ out/Default/chrome --server-address=<Server Address> [URL]

Signed-off-by: Insoon Kim <is46.kim@samsung.com>