### PR TITLE
Support Proxy Server in mojo TCP client socket.

### DIFF
--- a/content/app/content_main_runner_impl.cc
+++ b/content/app/content_main_runner_impl.cc
@@ -765,6 +765,27 @@ int ContentMainRunnerImpl::Initialize(const ContentMainParams& params) {
   base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
       switches::kEnableLogging, "stderr");
 #endif
+
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kProxyServer)) {
+    // Default Proxy Server
+    std::string proxy_addr = "127.0.0.1";
+    uint16_t proxy_port = 8080;
+    // Parse proxy server addr and port by ':'
+    std::string proxy_server =
+        base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(
+            switches::kProxyServer);
+    size_t pos = proxy_server.find(":");
+    if (pos != std::string::npos) {
+      proxy_addr = proxy_server.substr(0, pos);
+      proxy_port = std::stoi(proxy_server.substr(pos + 1));
+    } else if (!proxy_server.empty()) {
+      proxy_addr = proxy_server;
+    }
+    LOG(INFO) << "Use Proxy Server for mojo TCP => " << proxy_addr << ":"
+              << proxy_port;
+    mojo::SetProxyServer(proxy_addr, proxy_port);
+  }
 #endif  // CASTANETS
 
 #if defined(OS_WIN)

--- a/mojo/public/cpp/platform/tcp_platform_handle_utils.h
+++ b/mojo/public/cpp/platform/tcp_platform_handle_utils.h
@@ -27,6 +27,9 @@ PlatformHandle CreateTCPClientHandle(const uint16_t port,
                                      std::string server_address = "");
 
 COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+void SetProxyServer(const std::string address, const uint16_t port);
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
 bool TCPClientConnect(const base::ScopedFD& fd,
                       std::string server_address,
                       const uint16_t port);


### PR DESCRIPTION
Proxy Server for mojo TCP client sockets can be enabled using by '--proxy-server' switch.

out/Default/chrome --proxy-server={proxy server address}:{proxy server port number}
