### PR TITLE
[WIP] Support castanets for windows port.

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -1613,7 +1613,12 @@ jumbo_component("base") {
       "memory/shared_memory_helper.h",
       "strings/string16.cc",
     ]
-
+    if (enable_castanets) {
+      sources += [
+        "memory/shared_memory_helper.cc",
+        "memory/shared_memory_helper.h",
+      ]
+    }
     deps += [
       "//base/trace_event/etw_manifest:chrome_events_win",
       "//base/win:base_win_buildflags",

--- a/base/memory/shared_memory_helper.h
+++ b/base/memory/shared_memory_helper.h
@@ -10,13 +10,17 @@
 
 #if defined(CASTANETS)
 #include "base/memory/platform_shared_memory_region.h"
-#endif // defined(CASTANETS)
+#endif  // defined(CASTANETS)
 
 #include <fcntl.h>
 
 namespace base {
 
 #if !defined(OS_ANDROID)
+#if defined(OS_WIN)
+bool CreateAnonymousSharedMemory(const SharedMemoryCreateOptions& options,
+                                 win::ScopedHandle* handle);
+#else
 // Makes a temporary file, fdopens it, and then unlinks it. |fd| is populated
 // with the opened fd. |readonly_fd| is populated with the opened fd if
 // options.share_read_only is true. |path| is populated with the location of
@@ -33,6 +37,7 @@ bool PrepareMapFile(ScopedFD fd,
                     ScopedFD readonly_fd,
                     int* mapped_file,
                     int* readonly_mapped_file);
+#endif
 #elif defined(OS_ANDROID) && defined(CASTANETS)
 bool CreateAnonymousSharedMemory(const SharedMemoryCreateOptions& options,
                                  ScopedFD* fd,
@@ -45,7 +50,7 @@ bool CreateAnonymousSharedMemory(const SharedMemoryCreateOptions& options,
 subtle::PlatformSharedMemoryRegion BASE_EXPORT
 CreateAnonymousSharedMemoryIfNeeded(const UnguessableToken& guid,
                                     const SharedMemoryCreateOptions& option);
-#endif // defined(CASTANETS)
+#endif  // defined(CASTANETS)
 
 }  // namespace base
 

--- a/base/process/process_handle.h
+++ b/base/process/process_handle.h
@@ -31,6 +31,8 @@ typedef DWORD ProcessId;
 typedef HANDLE UserTokenHandle;
 const ProcessHandle kNullProcessHandle = NULL;
 const ProcessId kNullProcessId = 0;
+const ProcessHandle kCastanetsProcessHandle = NULL;
+const ProcessId kCastanetsProcessId = -1;
 #elif defined(OS_FUCHSIA)
 typedef zx_handle_t ProcessHandle;
 typedef zx_koid_t ProcessId;

--- a/base/win/scoped_handle_verifier.cc
+++ b/base/win/scoped_handle_verifier.cc
@@ -70,7 +70,9 @@ ScopedHandleVerifier* ScopedHandleVerifier::Get() {
 
 bool CloseHandleWrapper(HANDLE handle) {
   if (!::CloseHandle(handle))
+#if !defined(CASTANETS)
     CHECK(false);  // CloseHandle failed.
+#endif
   return true;
 }
 

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -41,7 +41,7 @@ declare_args() {
   # warnings with known toolchains. Allow overriding this e.g. for Chromium
   # builds on Linux that could use a different version of the compiler.
   # With GCC, warnings in no-Chromium code are always not treated as errors.
-  treat_warnings_as_errors = true
+  treat_warnings_as_errors = !is_win
 
   # Normally, Android builds are lightly optimized, even for debug builds, to
   # keep binary size down. Setting this flag to true disables such optimization

--- a/cc/paint/paint_typeface.cc
+++ b/cc/paint/paint_typeface.cc
@@ -6,6 +6,9 @@
 #include "build/build_config.h"
 #include "third_party/skia/include/core/SkFontMgr.h"
 #include "third_party/skia/include/ports/SkFontConfigInterface.h"
+#if defined(OS_WIN) && defined(CASTANETS)
+#include "third_party/skia/include/ports/SkTypeface_win.h"
+#endif
 
 namespace cc {
 
@@ -141,7 +144,11 @@ void PaintTypeface::CreateSkTypeface() {
       // This is a fallthrough in all cases in FontCache::CreateTypeface, so
       // this is done unconditionally. Since we create the typeface upon
       // PaintTypeface creation, this should be safe in all cases.
+#if defined(OS_WIN) && defined(CASTANETS)
+      auto fm(SkFontMgr_New_DirectWrite());
+#else
       auto fm(SkFontMgr::RefDefault());
+#endif
       sk_typeface_ = fm->legacyMakeTypeface(family_name_.c_str(), font_style_);
       break;
     }

--- a/chrome/renderer/chrome_render_frame_observer.cc
+++ b/chrome/renderer/chrome_render_frame_observer.cc
@@ -500,7 +500,7 @@ void ChromeRenderFrameObserver::UpdateBrowserControlsState(
     content::BrowserControlsState constraints,
     content::BrowserControlsState current,
     bool animate) {
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(OS_WIN)
   return;
 #else
   render_frame()->GetRenderView()->UpdateBrowserControlsState(constraints,

--- a/components/services/font/public/cpp/font_service_thread.cc
+++ b/components/services/font/public/cpp/font_service_thread.cc
@@ -11,7 +11,9 @@
 #include <fcntl.h>
 #include <stdint.h>
 #include <sys/stat.h>
+#if !defined(OS_WIN)
 #include <unistd.h>
+#endif
 #endif
 
 #include "base/bind.h"
@@ -45,15 +47,12 @@ bool FontServiceThread::MatchFamilyName(
   bool out_valid = false;
   // This proxies to the other thread, which proxies to mojo. Only on the reply
   // from mojo do we return from this.
-#if defined(CASTANETS)
+#if defined(CASTANETS) && !defined(OS_WIN)
   SkFontConfigInterface* fc =
       SkFontConfigInterface::GetSingletonDirectInterface();
   out_valid =
-      fc->matchFamilyName(family_name,
-                          requested_style,
-                          out_font_identity,
-                          out_family_name,
-                          out_style);
+      fc->matchFamilyName(family_name, requested_style, out_font_identity,
+                          out_family_name, out_style);
 #else
   base::WaitableEvent done_event;
   task_runner()->PostTask(
@@ -127,7 +126,7 @@ scoped_refptr<MappedFontFile> FontServiceThread::OpenStream(
     const SkFontConfigInterface::FontIdentity& identity) {
   DCHECK_NE(GetThreadId(), base::PlatformThread::CurrentId());
 
-#if defined(CASTANETS)
+#if defined(CASTANETS) && !defined(OS_WIN)
   int result_fd = open(identity.fString.c_str(), O_RDONLY);
   base::File stream_file(result_fd);
 #else

--- a/content/browser/renderer_host/render_message_filter.cc
+++ b/content/browser/renderer_host/render_message_filter.cc
@@ -189,7 +189,7 @@ void RenderMessageFilter::SetThreadPriorityOnFileThread(
 #if defined(OS_LINUX) || defined(CASTANETS)
 void RenderMessageFilter::SetThreadPriority(int32_t ns_tid,
                                             base::ThreadPriority priority) {
-#if defined(OS_ANDROID)
+#if defined(OS_ANDROID) || defined(OS_WIN)
   return;
 #else
   constexpr base::TaskTraits kTraits = {

--- a/content/renderer/media/audio/mojo_audio_output_ipc.cc
+++ b/content/renderer/media/audio/mojo_audio_output_ipc.cc
@@ -239,7 +239,7 @@ void MojoAudioOutputIPC::Created(
 
 #if defined(CASTANETS)
   // If socket_handle is invalid.
-  if (socket_handle < 0) {
+  if ((int)socket_handle < 0) {
     // Request to create TCP server on browser process and get the port number.
     stream_->RequestTCPConnect(base::BindOnce(
         &MojoAudioOutputIPC::RequestTCPConnectCallback, base::Unretained(this),
@@ -267,8 +267,11 @@ void MojoAudioOutputIPC::RequestTCPConnectCallback(
     LOG(ERROR) << __func__ << " tcp_client_handle is not valid.";
     return;
   }
-
+#if defined(OS_WIN)
+  base::PlatformFile socket_handle(tcp_client_handle.GetHandle().Get());
+#else
   base::PlatformFile socket_handle = tcp_client_handle.ReleaseFD();
+#endif
   delegate_->OnStreamCreated(std::move(shared_memory_region), socket_handle,
                              expected_state_ == kPlaying);
 

--- a/media/audio/audio_sync_reader.h
+++ b/media/audio/audio_sync_reader.h
@@ -26,6 +26,9 @@
 #if defined(OS_POSIX)
 #include "base/file_descriptor_posix.h"
 #endif
+#if defined(OS_WIN)
+#include "base/files/file.h"
+#endif
 
 namespace media {
 

--- a/media/mojo/services/mojo_audio_output_stream.cc
+++ b/media/mojo/services/mojo_audio_output_stream.cc
@@ -74,9 +74,15 @@ void MojoAudioOutputStream::RequestTCPConnect(
   // Ack with the port number.
   std::move(callback).Run(port);
 
+#if defined(OS_WIN)
+  base::win::ScopedHandle accept_handle;
+  mojo::TCPServerAcceptConnection(server_handle.GetHandle().Get(), &accept_handle);
+  delegate_->OnTCPConnected(accept_handle.Take());
+#else
   base::ScopedFD accept_handle;
   mojo::TCPServerAcceptConnection(server_handle.GetFD().get(), &accept_handle);
   delegate_->OnTCPConnected(accept_handle.release());
+#endif
 }
 #endif
 

--- a/mojo/core/BUILD.gn
+++ b/mojo/core/BUILD.gn
@@ -137,9 +137,13 @@ template("core_impl_source_set") {
     }
 
     if (enable_castanets) {
+      if (is_posix || is_win) {
+        sources += [
+          "broker_castanets.cc",
+          "broker_castanets.h",
+        ]
+      }
       sources += [
-        "broker_castanets.cc",
-        "broker_castanets.h",
         "castanets_fence.cc",
         "castanets_fence.h",
       ]

--- a/mojo/core/broker_host.cc
+++ b/mojo/core/broker_host.cc
@@ -65,12 +65,12 @@ bool BrokerHost::PrepareHandlesForClient(
 bool BrokerHost::SendChannel(PlatformHandle handle) {
   CHECK(handle.is_valid());
   CHECK(channel_);
-
 #if defined(OS_WIN)
   InitData* data;
   Channel::MessagePtr message =
       CreateBrokerMessage(BrokerMessageType::INIT, 1, 0, &data);
   data->pipe_name_length = 0;
+  data->port = -1;
 #else
 #if defined(CASTANETS)
   InitData* data;

--- a/mojo/core/scoped_process_handle.cc
+++ b/mojo/core/scoped_process_handle.cc
@@ -44,7 +44,7 @@ ScopedProcessHandle ScopedProcessHandle::CloneFrom(base::ProcessHandle handle) {
   if (handle == base::kNullProcessHandle)
     return ScopedProcessHandle();
 
-#if defined(OS_WIN)
+#if defined(OS_WIN) && !defined(CASTANETS)
   BOOL ok = ::DuplicateHandle(GetCurrentProcessHandle(), handle,
                               GetCurrentProcessHandle(), &handle, 0, FALSE,
                               DUPLICATE_SAME_ACCESS);
@@ -58,6 +58,9 @@ ScopedProcessHandle& ScopedProcessHandle::operator=(ScopedProcessHandle&&) =
 
 bool ScopedProcessHandle::is_valid() const {
 #if defined(OS_WIN)
+# if defined(CASTANETS)
+  return true;
+#endif
   return handle_.IsValid();
 #else
   return handle_ != base::kNullProcessHandle;
@@ -81,6 +84,9 @@ base::ProcessHandle ScopedProcessHandle::release() {
 }
 
 ScopedProcessHandle ScopedProcessHandle::Clone() const {
+#if defined(OS_WIN) && defined(CASTANETS)
+  return ScopedProcessHandle(get());
+#endif
   if (is_valid())
     return CloneFrom(get());
   return ScopedProcessHandle();

--- a/mojo/public/cpp/platform/BUILD.gn
+++ b/mojo/public/cpp/platform/BUILD.gn
@@ -40,10 +40,15 @@ component("platform") {
       "tcp_platform_handle_utils.h",
       "secure_socket_utils_posix.h",
     ]
-    sources += [
-      "tcp_platform_handle_utils_posix.cc",
-      "secure_socket_utils_posix.cc",
-    ]
+    if (is_posix) {
+      sources += [
+        "tcp_platform_handle_utils_posix.cc",
+        "secure_socket_utils_posix.cc",
+      ]
+    }
+    if (is_win) {
+      sources += [ "tcp_platform_handle_utils_win.cc" ]
+    }
     public_deps += [
       "//base:base_static",
       "//crypto",

--- a/mojo/public/cpp/platform/named_platform_channel_win.cc
+++ b/mojo/public/cpp/platform/named_platform_channel_win.cc
@@ -46,6 +46,12 @@ base::string16 GetPipeNameFromServerName(
 PlatformChannelServerEndpoint NamedPlatformChannel::CreateServerEndpoint(
     const Options& options,
     ServerName* server_name) {
+#if defined(CASTANETS)
+  if (options.port > -1) {
+    uint16_t port = options.port;
+    return PlatformChannelServerEndpoint((CreateTCPServerHandle(port, &port)));
+  }
+#endif
   ServerName name = options.server_name;
   if (name.empty())
     name = GenerateRandomServerName();

--- a/mojo/public/cpp/platform/tcp_platform_handle_utils.h
+++ b/mojo/public/cpp/platform/tcp_platform_handle_utils.h
@@ -27,24 +27,39 @@ PlatformHandle CreateTCPClientHandle(const uint16_t port,
                                      std::string server_address = "");
 
 COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
-bool TCPClientConnect(const base::ScopedFD& fd,
-                      std::string server_address,
-                      const uint16_t port);
-
-COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
 PlatformHandle CreateTCPServerHandle(uint16_t port,
                                      uint16_t* out_port = nullptr);
 
 COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
 bool TCPServerAcceptConnection(const base::PlatformFile server_socket,
+#if defined(OS_WIN)
+                               base::win::ScopedHandle* handle);
+#else
                                base::ScopedFD* accept_socket);
+#endif
+#if defined(OS_WIN)
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+bool TCPClientConnect(const base::win::ScopedHandle& fd,
+                      std::string server_address,
+                      const uint16_t port);
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+bool IsNetworkSocket(const base::win::ScopedHandle& fd);
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+std::string GetPeerAddress(const base::win::ScopedHandle& fd);
+#else
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+bool TCPClientConnect(const base::ScopedFD& fd,
+                      std::string server_address,
+                      const uint16_t port);
 
 COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
 bool IsNetworkSocket(const base::ScopedFD& fd);
 
 COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
 std::string GetPeerAddress(const base::ScopedFD& fd);
-
+#endif
 }  // namespace mojo
 
 #endif  // MOJO_EDK_EMBEDDER_TCP_PLATFORM_HANDLE_UTILS_H_

--- a/mojo/public/cpp/platform/tcp_platform_handle_utils_win.cc
+++ b/mojo/public/cpp/platform/tcp_platform_handle_utils_win.cc
@@ -1,0 +1,209 @@
+// Copyright 2019 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tcp_platform_handle_utils.h"
+
+#ifndef UNICODE
+#define UNICODE
+#endif
+
+#define WIN32_LEAN_AND_MEAN
+
+// Need to link with Ws2_32.lib
+#pragma comment(lib, "Ws2_32.lib")
+
+#include <errno.h>
+#include <windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#include "base/base_switches.h"
+#include "base/command_line.h"
+#include "base/files/file_util.h"
+#include "base/posix/eintr_wrapper.h"
+
+static int init = 0;
+namespace mojo {
+
+PlatformHandle CreateTCPSocketHandle() {
+  // Create the inet socket.
+  if (init == 0) {
+    WSADATA wsaData;
+    int iResult = WSAStartup(MAKEWORD(2, 2), &wsaData);
+    if (iResult != 0) {
+      LOG(ERROR) << "WSAStartup failed with error: "<< iResult;
+      return PlatformHandle();
+    }
+    init = 1;
+  }
+  PlatformHandle handle(base::win::ScopedHandle((HANDLE)socket(AF_INET, SOCK_STREAM, 0)));
+  //socket_handle.needs_connection = needs_connection;
+  if (!handle.is_valid()) {
+    PLOG(ERROR) << "Failed to create AF_INET socket.";
+    return PlatformHandle();
+  }
+
+  // Now set it as non-blocking.
+  if (0 && !base::SetNonBlocking((int)handle.GetHandle().Get())) {
+    PLOG(ERROR) << "base::SetNonBlocking() failed " << handle.GetHandle().Get();
+    return PlatformHandle();
+  }
+  return handle;
+}
+
+PlatformHandle CreateTCPClientHandle(const uint16_t port,
+                                     std::string server_address) {
+  char temp_string[20];
+  sprintf(temp_string, "%zu", port);
+  if (server_address.empty()) {
+    base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+    if (command_line->HasSwitch(switches::kServerAddress))
+      server_address =
+          command_line->GetSwitchValueASCII(switches::kServerAddress);
+    else
+      server_address = "127.0.0.1";
+  }
+  PlatformHandle handle = CreateTCPSocketHandle();
+  if (!handle.is_valid())
+    return PlatformHandle();
+
+  LOG(INFO) << "Connecting TCP Socket to " << server_address << ":" << port;
+  if (!TCPClientConnect(handle.GetHandle(), server_address, port))
+    return PlatformHandle();
+  return handle;
+}
+bool TCPClientConnect(const base::win::ScopedHandle& fd,
+                      std::string server_address,
+                      const uint16_t port) {
+  struct addrinfo *result = NULL, hints;
+  int iResult;
+  // IPv4
+  SOCKADDR_IN ServerAddr;
+  ServerAddr.sin_family = AF_INET;
+  // Port no.
+  ServerAddr.sin_port = htons(port);
+  // The IP address
+  ServerAddr.sin_addr.s_addr = inet_addr(server_address.c_str());
+
+  if (HANDLE_EINTR(connect((SOCKET)fd.Get(), (SOCKADDR*)&ServerAddr,
+                       sizeof(ServerAddr))) < 0) {
+    PLOG(ERROR) << "connect " << fd.Get();
+    return false;
+  }
+
+  //static const int kOn = 1;
+  //setsockopt(fd.Get(), IPPROTO_TCP, TCP_NODELAY, &kOn, sizeof(kOn));
+
+  LOG(INFO) << "TCP Client connected to " << server_address << ":" << port
+            << ", fd:" << fd.Get();
+  return true;
+}
+
+PlatformHandle CreateTCPServerHandle(uint16_t port, uint16_t* out_port) {
+  char temp_string[20];
+  sprintf(temp_string, "%zu", port);
+  struct addrinfo* result = NULL;
+  struct addrinfo hints;
+  int iResult;
+  SOCKADDR_IN local;
+  local.sin_family = AF_INET;
+  local.sin_addr.s_addr = INADDR_ANY;
+  /* Port MUST be in Network Byte Order */
+  local.sin_port = htons(port);
+
+  // TCP socket
+  PlatformHandle handle = CreateTCPSocketHandle();
+  if (!handle.is_valid())
+    return PlatformHandle();
+
+  static const int kOn = 1;
+#ifdef OS_ANDROID
+  setsockopt(handle.get().handle, SOL_SOCKET, 15, &kOn, sizeof(kOn));
+#else
+  setsockopt((SOCKET)handle.GetHandle().Get(), SOL_SOCKET, SO_REUSEADDR, (char*)&kOn,
+             sizeof(kOn));
+#endif
+  // Bind the socket.
+  if (bind((SOCKET)handle.GetHandle().Get(), (SOCKADDR*)&local, sizeof(local)) < 0) {
+    PLOG(ERROR) << "bind " << handle.GetHandle().Get();
+    return PlatformHandle();
+  }
+
+  // Start listening on the socket.
+  if (listen((SOCKET)handle.GetHandle().Get(), SOMAXCONN) < 0) {
+    PLOG(ERROR) << "listen" << handle.GetHandle().Get();
+    return PlatformHandle();
+  }
+
+  // Get port number
+  if (port == 0) {
+    CHECK(out_port);
+    SOCKADDR_IN sin;
+    socklen_t len = sizeof(sin);
+    if (getsockname((SOCKET)handle.GetHandle().Get(), (struct sockaddr*)&sin, &len) < 0) {
+      PLOG(ERROR) << "getsockname() " << handle.GetHandle().Get();
+	  return PlatformHandle();
+    }
+    port = *out_port = ntohs(sin.sin_port);
+  }
+  return handle;
+}
+
+bool TCPServerAcceptConnection(const base::PlatformFile server_socket,
+#if defined(OS_WIN)
+                               base::win::ScopedHandle* accept_socket) {
+#else
+                               base::ScopedFD* accept_socket) {
+#endif
+  DCHECK(server_socket);
+  accept_socket->Close();
+
+#if defined(OS_NACL)
+  NOTREACHED();
+  return false;
+#else
+  HANDLE handle = (HANDLE)accept((SOCKET)server_socket, NULL, 0);
+  base::win::ScopedHandle accept_handle(handle);
+  if (!accept_handle.IsValid()) {
+    PLOG(ERROR) << "accept " << server_socket;
+    return false;
+  }
+
+  if (0 && !base::SetNonBlocking((int)accept_handle.Get())) {
+    PLOG(ERROR) << "base::SetNonBlocking() failed "
+                << accept_handle.Get();
+    // It's safe to keep listening on |server_handle| even if the attempt to set
+    // O_NONBLOCK failed on the client fd.
+    return true;
+  }
+
+  *accept_socket = std::move(accept_handle);
+
+  return true;
+#endif  // defined(OS_NACL)
+}
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+bool IsNetworkSocket(const base::win::ScopedHandle& fd) {
+  // TODO (suyambu.rm) check why this method returns false
+  return true;
+  struct sockaddr_storage addr;
+  socklen_t len = sizeof(addr);
+  if (!getsockname((int)fd.Get(), (struct sockaddr*)&addr, &len)) {
+    return (addr.ss_family == AF_INET);
+  }
+  return false;
+}
+
+COMPONENT_EXPORT(MOJO_CPP_PLATFORM)
+std::string GetPeerAddress(const base::win::ScopedHandle& fd) {
+  SOCKADDR_IN addr;
+  socklen_t addr_size = sizeof(addr);
+  if (!getpeername((int)fd.Get(), (struct sockaddr*)&addr, &addr_size))
+    return inet_ntoa(addr.sin_addr);
+  return std::string();
+}
+
+}  // namespace mojo
+

--- a/third_party/blink/renderer/platform/fonts/skia/font_cache_skia.cc
+++ b/third_party/blink/renderer/platform/fonts/skia/font_cache_skia.cc
@@ -252,7 +252,7 @@ PaintTypeface FontCache::CreateTypeface(
   }
 #endif
 
-#if defined(OS_LINUX) || defined(OS_WIN)
+#if defined(OS_LINUX) || (defined(OS_WIN) && !defined(CASTANETS))
   // On linux if the fontManager has been overridden then we should be calling
   // the embedder provided font Manager rather than calling
   // SkTypeface::CreateFromName which may redirect the call to the default font
@@ -266,7 +266,6 @@ PaintTypeface FontCache::CreateTypeface(
     return PaintTypeface::FromSkTypeface(std::move(tf));
   }
 #endif
-
   // FIXME: Use m_fontManager, matchFamilyStyle instead of
   // legacyCreateTypeface on all platforms.
   return PaintTypeface::FromFamilyNameAndFontStyle(

--- a/ui/gfx/gpu_memory_buffer.h
+++ b/ui/gfx/gpu_memory_buffer.h
@@ -16,7 +16,7 @@
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/gfx_export.h"
 
-#if defined(OS_LINUX) || defined(CASTANETS)
+#if defined(OS_LINUX) || (defined(CASTANETS) && !defined(OS_WIN))
 #include "ui/gfx/native_pixmap_handle.h"
 #elif defined(OS_MACOSX) && !defined(OS_IOS)
 #include "ui/gfx/mac/io_surface.h"
@@ -57,7 +57,7 @@ struct GFX_EXPORT GpuMemoryBufferHandle {
   base::SharedMemoryHandle handle;
   uint32_t offset;
   int32_t stride;
-#if defined(OS_LINUX) || defined(CASTANETS)
+#if defined(OS_LINUX) || (defined(CASTANETS) && !defined(OS_WIN))
   NativePixmapHandle native_pixmap_handle;
   uint32_t tbm_surface;
   uint32_t media_packet;

--- a/ui/gfx/ipc/gfx_param_traits_macros.h
+++ b/ui/gfx/ipc/gfx_param_traits_macros.h
@@ -18,7 +18,7 @@
 #include "ui/gfx/selection_bound.h"
 #include "ui/gfx/swap_result.h"
 
-#if defined(OS_LINUX) || defined(CASTANETS)
+#if defined(OS_LINUX) || (defined(CASTANETS) && !defined(OS_WIN))
 #include "ui/gfx/native_pixmap_handle.h"
 #endif
 
@@ -51,7 +51,7 @@ IPC_STRUCT_TRAITS_BEGIN(gfx::GpuMemoryBufferHandle)
   IPC_STRUCT_TRAITS_MEMBER(handle)
   IPC_STRUCT_TRAITS_MEMBER(offset)
   IPC_STRUCT_TRAITS_MEMBER(stride)
-#if defined(OS_LINUX) || defined (CASTANETS)
+#if defined(OS_LINUX) || (defined(CASTANETS) && !defined(OS_WIN))
   IPC_STRUCT_TRAITS_MEMBER(native_pixmap_handle)
   IPC_STRUCT_TRAITS_MEMBER(tbm_surface)
   IPC_STRUCT_TRAITS_MEMBER(media_packet)
@@ -68,7 +68,7 @@ IPC_STRUCT_TRAITS_BEGIN(gfx::GpuMemoryBufferId)
   IPC_STRUCT_TRAITS_MEMBER(id)
 IPC_STRUCT_TRAITS_END()
 
-#if defined(OS_LINUX) || defined(CASTANETS)
+#if defined(OS_LINUX) || (defined(CASTANETS) && !defined(OS_WIN))
 IPC_STRUCT_TRAITS_BEGIN(gfx::NativePixmapPlane)
   IPC_STRUCT_TRAITS_MEMBER(stride)
   IPC_STRUCT_TRAITS_MEMBER(offset)

--- a/ui/gfx/native_pixmap_handle.h
+++ b/ui/gfx/native_pixmap_handle.h
@@ -13,7 +13,7 @@
 #include "build/build_config.h"
 #include "ui/gfx/gfx_export.h"
 
-#if defined(OS_LINUX) || defined(CASTANETS)
+#if defined(OS_LINUX) || (defined(CASTANETS) && !defined(OS_WIN))
 #include "base/file_descriptor_posix.h"
 #endif
 
@@ -54,7 +54,7 @@ struct GFX_EXPORT NativePixmapHandle {
 
   ~NativePixmapHandle();
 
-#if defined(OS_LINUX) || defined(CASTANETS)
+#if defined(OS_LINUX) || (defined(CASTANETS) && !defined(OS_WIN))
   // File descriptors for the underlying memory objects (usually dmabufs).
   std::vector<base::FileDescriptor> fds;
 #endif


### PR DESCRIPTION
This change is to support castanets for windows port and still a wip.
If there is any inputs/pointers please let me know.

Current status:
Web page renders fine when we run on standalone and different windows machines. (With --disable-gpu-compositing)
(i) Workaround has been added for font crash (when accessing font on renderer side) by creating new FontManager on renderer.
(ii) Events are not working still.
(iii) 10 ms sleep is added on channel_win.cc after winsoc write, without which incorrect msgs are observed during communication.
(iv) Gpu support is not yet done.