### PR TITLE
Fix SVACE and Coverity issues

### DIFF
--- a/third_party/meerkat/BUILD.gn
+++ b/third_party/meerkat/BUILD.gn
@@ -30,6 +30,8 @@ core_sources = [
   "Component/mmBASE/BaseAPI/bThread.h",
   "Component/mmBASE/BaseAPI/ifaddrs.cpp",
   "Component/mmBASE/BaseAPI/ifaddrs.h",
+  "Component/mmBASE/BaseAPI/string_util.cpp",
+  "Component/mmBASE/BaseAPI/string_util.h",
 
   "Component/mmBASE/SubSystem/Debugger.cpp",
   "Component/mmBASE/SubSystem/Debugger.h",

--- a/third_party/meerkat/Component/SOURCE.LIST
+++ b/third_party/meerkat/Component/SOURCE.LIST
@@ -17,7 +17,8 @@ SOURCES +=	bFile			\
 		bTask			\
 		Debugger		\
 		Dispatcher		\
-		ifaddrs
+		ifaddrs                 \
+                string_util
 
 SOURCES +=	pTcpClient		\
 		pTcpServer		\

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bFile.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bFile.cpp
@@ -25,9 +25,11 @@
 //
 //////////////////////////////////////////////////////////////////////
 
+#include "bFile.h"
+
 #include <sys/stat.h>
 #include "Debugger.h"
-#include "bFile.h"
+#include "string_util.h"
 
 
 //////////////////////////////////////////////////////////////////////
@@ -44,9 +46,7 @@ using namespace mmBase;
 CbFile::CbFile(const CHAR* psz_file_path) {
   m_pHandle = NULL;
   ///< 생성자 에서는 open할 file의 path를 저장한다.
-  memset(m_szFullPath, 0, sizeof(CHAR) * MAX_PATH);
-  strncpy(m_szFullPath, psz_file_path,
-          strlen(psz_file_path) > MAX_PATH ? MAX_PATH : strlen(psz_file_path));
+  strlcpy(m_szFullPath, psz_file_path, sizeof(m_szFullPath));
 }
 
 /**

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bMessage.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bMessage.cpp
@@ -22,9 +22,10 @@
 #include <crtdbg.h>
 #endif
 
-#include "posixAPI.h"
-#include "bMessage.h"
 #include "Debugger.h"
+#include "bMessage.h"
+#include "posixAPI.h"
+#include "string_util.h"
 
 using namespace mmBase;
 
@@ -47,7 +48,7 @@ CbMessage::CbMessage(const char* name) {
   m_iMQhandle = MQ_INVALIDHANDLE;
   if (name != NULL) {
     if (strlen(name) < MQ_MAXNAMELENGTH) {
-      strcpy(m_szMQname, name);
+      strlcpy(m_szMQname, name, sizeof(m_szMQname));
       CreateMsgQueue(name);
     } else {
       DPRINT(COMM, DEBUG_FATAL, "MsgQueue Create Fail--Too long Queue Name\n");

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bMessage.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bMessage.cpp
@@ -150,8 +150,8 @@ int CbMessage::DestroyMsgQueue(void) {
     scanprevptr->next = scanptr->next;
   }
   __OSAL_Mutex_UnLock(&g_MsqQHeader.hMutex);
-  __OSAL_Mutex_UnLock(&pList->hMutex);
 
+  __OSAL_Mutex_Lock(&pList->hMutex);
   travptr = pList->first;
 
   while (travptr != NULL) {
@@ -161,6 +161,7 @@ int CbMessage::DestroyMsgQueue(void) {
     free(travprevptr);
   }
   __OSAL_Mutex_UnLock(&pList->hMutex);
+
   __OSAL_Event_Destroy(&pList->hEvent);
   __OSAL_Mutex_Destroy(&pList->hMutex);
   free(pList->queuename);

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bMessage.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bMessage.cpp
@@ -102,7 +102,7 @@ int CbMessage::CreateMsgQueue(const char* name) {
 
   pMQHead->i_waitcount = 0;
   pMQHead->i_available = 0;
-  strcpy(pMQHead->queuename, name);
+  strlcpy(pMQHead->queuename, name, strlen(name) + 1);
   pMQHead->first = NULL;
   pMQHead->last = NULL;
   pMQHead->pThreadmsgIF = (void*)this;

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bSocket.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bSocket.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include "bSocket.h"
+#include "string_util.h"
 
 using namespace mmBase;
 
@@ -163,10 +164,8 @@ CbSocket::SOCKET_ERRORCODE CbSocket::Accept(OSAL_Socket_Handle iSock,
     return SOCK_ACCEPT_FAIL;
   }
 
-  int c_addrLen = strlen(inet_ntoa(addr_in.sin_addr)) + 1;
-  m_szClintAddr = new CHAR[c_addrLen];
-  memset(m_szClintAddr, 0, c_addrLen);
-  strcpy(m_szClintAddr, inet_ntoa(addr_in.sin_addr));
+  m_szClintAddr = new CHAR[strlen(inet_ntoa(addr_in.sin_addr)) + 1];
+  strlcpy(m_szClintAddr, inet_ntoa(addr_in.sin_addr), sizeof(m_szClintAddr));
 
   int iCount = MAX_DUP_COUNT;
   while (iCount--) {

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bSocket.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bSocket.cpp
@@ -271,7 +271,7 @@ CbSocket::SOCKET_ERRORCODE CbSocket::Recv(OSAL_Socket_Handle iSock, int nbyte) {
   ret = __OSAL_Socket_Recv(iSock, buf, toread, &readbyte);
   if (ret == OSAL_Socket_Error) {
     DPRINT(COMM, DEBUG_WARN, "Socket Read Fail --[Socket Already Closed??]\n");
-    SAFE_DELETE(buf);
+    SAFE_FREE(buf);
     __OSAL_Mutex_UnLock(&m_hEventmutex);
     return SOCK_READ_FAIL;
   }
@@ -344,7 +344,7 @@ CbSocket::SOCKET_ERRORCODE CbSocket::RecvFrom(OSAL_Socket_Handle iSock,
   if (ret == OSAL_Socket_Error) {
     DPRINT(COMM, DEBUG_ERROR,
            "Socket Read Fail -- [Socket Already Closed??]\n");
-    SAFE_DELETE(buf);
+    SAFE_FREE(buf);
     __OSAL_Mutex_UnLock(&m_hEventmutex);
     return SOCK_READ_FAIL;
   }

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bSocket.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bSocket.cpp
@@ -50,7 +50,10 @@ CbSocket::CbSocket() {
  * @brief         Destructor.
  * @remarks       Destructor.
  */
-CbSocket::~CbSocket() {}
+CbSocket::~CbSocket() {
+  __OSAL_Mutex_Destroy(&m_hEventmutex);
+  SAFE_DELETE(m_szClintAddr);
+}
 
 /**
  * @brief         Open.
@@ -165,6 +168,9 @@ CbSocket::SOCKET_ERRORCODE CbSocket::Accept(OSAL_Socket_Handle iSock,
     __OSAL_Mutex_UnLock(&m_hEventmutex);
     return SOCK_ACCEPT_FAIL;
   }
+
+  if (m_szClintAddr)
+    SAFE_DELETE(m_szClintAddr);
 
   m_szClintAddr = new CHAR[strlen(inet_ntoa(addr_in.sin_addr)) + 1];
   strlcpy(m_szClintAddr, inet_ntoa(addr_in.sin_addr), sizeof(m_szClintAddr));

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bSocket.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bSocket.cpp
@@ -172,8 +172,9 @@ CbSocket::SOCKET_ERRORCODE CbSocket::Accept(OSAL_Socket_Handle iSock,
   if (m_szClintAddr)
     SAFE_DELETE(m_szClintAddr);
 
-  m_szClintAddr = new CHAR[strlen(inet_ntoa(addr_in.sin_addr)) + 1];
-  strlcpy(m_szClintAddr, inet_ntoa(addr_in.sin_addr), sizeof(m_szClintAddr));
+  size_t addr_len = strlen(inet_ntoa(addr_in.sin_addr)) + 1;
+  m_szClintAddr = new CHAR[addr_len];
+  strlcpy(m_szClintAddr, inet_ntoa(addr_in.sin_addr), addr_len);
 
   int iCount = MAX_DUP_COUNT;
   while (iCount--) {

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bSocket.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bSocket.cpp
@@ -42,6 +42,8 @@ CbSocket::CbSocket() {
   m_hSock = 0;
   m_szClintAddr = NULL;
   m_hEventmutex = __OSAL_Mutex_Create();
+  m_nPort = 0;
+  m_type = ACT_TCP_SERVER;
 }
 
 /**

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bSocket.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bSocket.cpp
@@ -272,6 +272,7 @@ CbSocket::SOCKET_ERRORCODE CbSocket::Recv(OSAL_Socket_Handle iSock, int nbyte) {
   if (ret == OSAL_Socket_Error) {
     DPRINT(COMM, DEBUG_WARN, "Socket Read Fail --[Socket Already Closed??]\n");
     SAFE_DELETE(buf);
+    __OSAL_Mutex_UnLock(&m_hEventmutex);
     return SOCK_READ_FAIL;
   }
   OnReceive(iSock, GetClientAddress(), m_nPort, buf, readbyte);
@@ -344,6 +345,7 @@ CbSocket::SOCKET_ERRORCODE CbSocket::RecvFrom(OSAL_Socket_Handle iSock,
     DPRINT(COMM, DEBUG_ERROR,
            "Socket Read Fail -- [Socket Already Closed??]\n");
     SAFE_DELETE(buf);
+    __OSAL_Mutex_UnLock(&m_hEventmutex);
     return SOCK_READ_FAIL;
   }
   char* pszsourceAddr = inet_ntoa(senderaddr_in.sin_addr);

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bSocket.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bSocket.cpp
@@ -32,7 +32,7 @@
 using namespace mmBase;
 
 #define MAX_DUP_COUNT 10
-bool mmBase::g_InitializeNetworking;
+bool mmBase::g_InitializeNetworking = FALSE;
 
 /**
  * @brief         Constructor.
@@ -479,19 +479,18 @@ CbSocket::SOCKET_ERRORCODE CbSocket::SetBlockMode(OSAL_Socket_Handle iSock,
  * @remarks       Initialize network enviroment
  */
 BOOL mmBase::PFM_NetworkInitialize(void) {
-  if (g_InitializeNetworking) {
+  if (g_InitializeNetworking)
     return TRUE;
-  }
 
-  if (__OSAL_Socket_Init() == OSAL_Socket_Success) {
-    g_InitializeNetworking = TRUE;
-    DPRINT(COMM, DEBUG_INFO, "Network Initialize success\n");
-    return TRUE;
-  } else {
+  if (__OSAL_Socket_Init() != OSAL_Socket_Success) {
     g_InitializeNetworking = FALSE;
     DPRINT(COMM, DEBUG_ERROR, "Network Initialize Fail!!!\n");
     return FALSE;
   }
+
+  g_InitializeNetworking = TRUE;
+  DPRINT(COMM, DEBUG_INFO, "Network Initialize success\n");
+  return TRUE;
 }
 
 /**

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bTask.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bTask.cpp
@@ -39,10 +39,11 @@ CbTask::CbTask() {
  * @remarks       »ý¼ºÀÚ
  * @param         msgqname          message queue name
  */
-CbTask::CbTask(const char* pszTaskName) : CbThread(pszTaskName) {
+CbTask::CbTask(const char* pszTaskName) : CbThread() {
   m_bHasMsgQueue = false;
   m_key = __OSAL_Mutex_Create();
   if (pszTaskName != NULL) {
+    CbThread::SetName(pszTaskName);
     if (CreateMsgQueue(pszTaskName) < 0) {
       DPRINT(COMM, DEBUG_ERROR,
              "[Warnning] Cannot Create Message Queue--Create Thread without "

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bThread.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bThread.cpp
@@ -22,15 +22,13 @@ using namespace mmBase;
  * @brief         持失切
  * @remarks       持失切
  */
-CbThread::CbThread() {
-  m_bThreading = false;
-  m_bRun = false;
+CbThread::CbThread()
+    : m_bRun(false), m_bThreading(false), m_pArgs(0), m_nPriority(0) {
   strlcpy(m_szThreadName, "Annonymous", sizeof(m_szThreadName));
 }
 
-CbThread::CbThread(const CHAR* pszName) {
-  m_bThreading = false;
-  m_bRun = false;
+CbThread::CbThread(const CHAR* pszName)
+    : m_bRun(false), m_bThreading(false), m_pArgs(0), m_nPriority(0) {
   strlcpy(m_szThreadName, pszName, sizeof(m_szThreadName));
 }
 

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bThread.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bThread.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "bThread.h"
+#include "string_util.h"
 
 using namespace mmBase;
 /**
@@ -24,15 +25,13 @@ using namespace mmBase;
 CbThread::CbThread() {
   m_bThreading = false;
   m_bRun = false;
-  memset(m_szThreadName, 0, 64);
-  strcpy(m_szThreadName, "Annonymous");
+  strlcpy(m_szThreadName, "Annonymous", sizeof(m_szThreadName));
 }
 
 CbThread::CbThread(const CHAR* pszName) {
   m_bThreading = false;
   m_bRun = false;
-  memset(m_szThreadName, 0, 64);
-  strcpy(m_szThreadName, pszName);
+  strlcpy(m_szThreadName, pszName, sizeof(m_szThreadName));
 }
 
 /**

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bThread.h
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bThread.h
@@ -23,11 +23,11 @@
 #ifndef __INCLUDE_COMMON_THREAD_H__
 #define __INCLUDE_COMMON_THREAD_H__
 
+#include "Debugger.h"
 #include "bDataType.h"
 #include "bGlobDef.h"
-
 #include "posixAPI.h"
-#include "Debugger.h"
+#include "string_util.h"
 
 namespace mmBase {
 class CbThread {
@@ -37,12 +37,7 @@ class CbThread {
   virtual ~CbThread();
 
   bool SetName(const CHAR* pszThreadName) {
-    memset(m_szThreadName, 0, 64);
-#ifdef WIN32
-    strcpy_s(m_szThreadName, pszThreadName);
-#else
-    strcpy(m_szThreadName, pszThreadName);
-#endif
+    strlcpy(m_szThreadName, pszThreadName, sizeof(m_szThreadName));
     return true;
   }
   int StartMainLoop(void* args);

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/bThread.h
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/bThread.h
@@ -62,7 +62,6 @@ class CbThread {
  public:
   char m_szThreadName[64];
   OSAL_Thread_Handle m_hMainThread;
-  OSAL_Thread_Handle m_hMsgThread;
   bool m_bRun;
   bool m_bThreading;
   void* m_pArgs;

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/ifaddrs.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/ifaddrs.cpp
@@ -82,7 +82,7 @@ int set_flags(struct ifaddrs* ifaddr) {
   if (rc == -1) {
     return -1;
   }
-  ifaddr->ifa_flags = ifr.ifr_flags;
+  ifaddr->ifa_flags = (unsigned int)(ifr.ifr_flags);
   return 0;
 }
 

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/ifaddrs.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/ifaddrs.cpp
@@ -208,6 +208,7 @@ int getifaddrs(struct ifaddrs** result) {
                 }
                 if (populate_ifaddrs(newest, address_msg, RTA_DATA(rta),
                                      RTA_PAYLOAD(rta)) != 0) {
+                  close(fd);
                   freeifaddrs(start);
                   *result = nullptr;
                   return -1;

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/string_util.cpp
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/string_util.cpp
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2019 Samsung Electronics. All rights reserved.
+ *  Copyright 2013 The Chromium Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can be
+ *  found in the LICENSE file.
+ *
+ *  This file defines utility functions for working with strings.
+ */
+
+#include "string_util.h"
+
+namespace mmBase {
+
+template <typename CHAR>
+size_t lcpyT(CHAR* dst, const CHAR* src, size_t dst_size) {
+  for (size_t i = 0; i < dst_size; ++i) {
+    if ((dst[i] = src[i]) == 0)  // We hit and copied the terminating NULL.
+      return i;
+  }
+
+  // We were left off at dst_size.  We over copied 1 byte.  Null terminate.
+  if (dst_size != 0)
+    dst[dst_size - 1] = 0;
+
+  // Count the rest of the |src|, and return it's length in characters.
+  while (src[dst_size])
+    ++dst_size;
+  return dst_size;
+}
+
+size_t strlcpy(char* dst, const char* src, size_t dst_size) {
+  return lcpyT<char>(dst, src, dst_size);
+}
+
+}  // namespace mmBase

--- a/third_party/meerkat/Component/mmBASE/BaseAPI/string_util.h
+++ b/third_party/meerkat/Component/mmBASE/BaseAPI/string_util.h
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2019 Samsung Electronics. All rights reserved.
+ *  Copyright 2013 The Chromium Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can be
+ *  found in the LICENSE file.
+ *
+ *  This file defines utility functions for working with strings.
+ */
+
+#include <stdio.h>
+
+namespace mmBase {
+
+// BSD-style safe and consistent string copy functions.
+// Copies |src| to |dst|, where |dst_size| is the total allocated size of |dst|.
+// Copies at most |dst_size|-1 characters, and always NULL terminates |dst|, as
+// long as |dst_size| is not 0.  Returns the length of |src| in characters.
+// If the return value is >= dst_size, then the output was truncated.
+// NOTE: All sizes are in number of characters, NOT in bytes.
+size_t strlcpy(char* dst, const char* src, size_t dst_size);
+
+}  // namespace mmBase

--- a/third_party/meerkat/Component/mmBASE/SubSystem/Debugger.cpp
+++ b/third_party/meerkat/Component/mmBASE/SubSystem/Debugger.cpp
@@ -74,7 +74,7 @@ void* debugLoop(void* args) {
 
   while (true) {
     DPRINT(GLOB, DEBUG_INFO, "START DEBUG MONITOR DAEMON\n");
-    ignore_result(scanf("%s", input));
+    ignore_result(scanf("%63s", input));
 
     if (!strcmp(input, "debug")) {
       for (;;) {
@@ -84,7 +84,7 @@ void* debugLoop(void* args) {
         RAW_PRINT("(0x3) Set Module Debug Flag\n");
         RAW_PRINT("(0x9) Exit.\n");
         RAW_PRINT("0x");
-        ignore_result(scanf("%s", strNum));
+        ignore_result(scanf("%63s", strNum));
         num = atoi(strNum);
         if (num == 9)
           break;
@@ -100,7 +100,7 @@ void* debugLoop(void* args) {
             RAW_PRINT("(0x5) Set Debug Level - All\n");
             RAW_PRINT("(0x9) Exit.\n");
             RAW_PRINT("0x");
-            ignore_result(scanf("%s", strSel));
+            ignore_result(scanf("%31s", strSel));
             sel = atoi(strSel);
 
             if (sel == 9)
@@ -131,7 +131,7 @@ void* debugLoop(void* args) {
             RAW_PRINT("(0x2) Set Debug Format - Detail\n");
             RAW_PRINT("(0x9) Exit.\n");
             RAW_PRINT("0x");
-            ignore_result(scanf("%s", strSel));
+            ignore_result(scanf("%31s", strSel));
             sel = atoi(strSel);
 
             if (sel == 9)
@@ -160,7 +160,7 @@ void* debugLoop(void* args) {
             }
             RAW_PRINT("(0x9) Exit.\n");
             RAW_PRINT("0x");
-            ignore_result(scanf("%s", strSel));
+            ignore_result(scanf("%31s", strSel));
             sel = atoi(strSel);
             if (sel == 9) {
               break;
@@ -171,7 +171,7 @@ void* debugLoop(void* args) {
                 RAW_PRINT("(0x2) OFF\n");
                 char strOnOff[32];
                 int OnOff = 0;
-                ignore_result(scanf("%s", strOnOff));
+                ignore_result(scanf("%31s", strOnOff));
                 OnOff = atoi(strOnOff);
                 if (OnOff == 1) {
                   SetModuleDebugFlag((MODULE_ID)(sel - 1), true);

--- a/third_party/meerkat/Component/mmBASE/SubSystem/Debugger.cpp
+++ b/third_party/meerkat/Component/mmBASE/SubSystem/Debugger.cpp
@@ -232,7 +232,7 @@ void InitDebugInfo(BOOL bRunning, BOOL create_files) {
     FILE* fpfmt = fopen(DBG_FORMAT_STREAM, "r");
     if (fpfmt == NULL) {
       fpfmt = fopen(DBG_FORMAT_STREAM, "w");
-      if (fpf) {
+      if (fpfmt) {
         fprintf(fpfmt, "%d", (int)init_dbg_format);
         ignore_result(fscanf(fpfmt, "%d", (int*)&g_fmtDebug));
         fclose(fpfmt);

--- a/third_party/meerkat/Component/mmDiscovery/discovery_client.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/discovery_client.cpp
@@ -18,6 +18,8 @@
 #include <vector>
 #include <iostream>
 
+#include "string_util.h"
+
 using namespace mmBase;
 using namespace mmProto;
 using namespace std;
@@ -81,7 +83,7 @@ VOID CDiscoveryClient::DataRecv(OSAL_Socket_Handle iEventSock,
     if (!strncmp(pData, DISCOVERY_PACKET_PREFIX,
                  strlen(DISCOVERY_PACKET_PREFIX))) {
       discoveryInfo_t info = {{0}, -1, -1, {0}};
-      strncpy(info.address, pszsource_addr, sizeof(info.address) - 1);
+      strlcpy(info.address, pszsource_addr, sizeof(info.address));
       t_HandlePacket(&info, pData + strlen(DISCOVERY_PACKET_PREFIX));
       // Ignore response from itself
       if (!self_discovery_enabled_ &&
@@ -115,7 +117,7 @@ VOID CDiscoveryClient::t_HandlePacket(discoveryInfo_t* info /*out*/,
     string result[2];
 
     char substring[64] = {'\0'};
-    strcpy(substring, it->c_str());
+    strlcpy(substring, it->c_str(), sizeof(substring));
     char* subptr = strtok(substring, ":");
     while (index < 2) {
       result[index] = subptr;
@@ -128,8 +130,8 @@ VOID CDiscoveryClient::t_HandlePacket(discoveryInfo_t* info /*out*/,
     } else if (result[0] == kMonitorPort) {
       info->monitor_port = atoi(result[1].c_str());
     } else if (result[0] == kRequestFrom) {
-      strncpy(info->request_from, result[1].c_str(),
-              sizeof(info->request_from) - 1);
+      strlcpy(info->request_from, result[1].c_str(),
+                      sizeof(info->request_from));
     }
   }
 }

--- a/third_party/meerkat/Component/mmDiscovery/discovery_client.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/discovery_client.cpp
@@ -83,7 +83,7 @@ VOID CDiscoveryClient::DataRecv(OSAL_Socket_Handle iEventSock,
     if (!strncmp(pData, DISCOVERY_PACKET_PREFIX,
                  strlen(DISCOVERY_PACKET_PREFIX))) {
       discoveryInfo_t info = {{0}, -1, -1, {0}};
-      strlcpy(info.address, pszsource_addr, sizeof(info.address));
+      mmBase::strlcpy(info.address, pszsource_addr, sizeof(info.address));
       t_HandlePacket(&info, pData + strlen(DISCOVERY_PACKET_PREFIX));
       // Ignore response from itself
       if (!self_discovery_enabled_ &&
@@ -117,7 +117,7 @@ VOID CDiscoveryClient::t_HandlePacket(discoveryInfo_t* info /*out*/,
     string result[2];
 
     char substring[64] = {'\0'};
-    strlcpy(substring, it->c_str(), sizeof(substring));
+    mmBase::strlcpy(substring, it->c_str(), sizeof(substring));
     char* subptr = strtok(substring, ":");
     while (index < 2) {
       result[index] = subptr;
@@ -130,7 +130,7 @@ VOID CDiscoveryClient::t_HandlePacket(discoveryInfo_t* info /*out*/,
     } else if (result[0] == kMonitorPort) {
       info->monitor_port = atoi(result[1].c_str());
     } else if (result[0] == kRequestFrom) {
-      strlcpy(info->request_from, result[1].c_str(),
+      mmBase::strlcpy(info->request_from, result[1].c_str(),
                       sizeof(info->request_from));
     }
   }

--- a/third_party/meerkat/Component/mmDiscovery/discovery_server.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/discovery_server.cpp
@@ -65,10 +65,10 @@ VOID CDiscoveryServer::DataRecv(OSAL_Socket_Handle iEventSock,
     CHAR eco_body[256] = {
         '\0',
     };
-    sprintf(eco_body,
-            "discovery://type:query-response,"
-            "service-port:%d,monitor-port:%d,request-from:%s",
-            m_service_port, m_monitor_port, pszsource_addr);
+    snprintf(eco_body, sizeof(eco_body) - 1,
+             "discovery://type:query-response,"
+             "service-port:%d,monitor-port:%d,request-from:%s",
+             m_service_port, m_monitor_port, pszsource_addr);
     CpUdpServer::DataSend(pszsource_addr, eco_body, strlen(eco_body),
                           source_port);
   }

--- a/third_party/meerkat/Component/mmDiscovery/discovery_server.h
+++ b/third_party/meerkat/Component/mmDiscovery/discovery_server.h
@@ -18,6 +18,7 @@
 #define __INCLUDE_DISCOVERY_SERVER_H__
 
 #include "pUdpServer.h"
+#include "string_util.h"
 
 #define DEFAULT_SERVICE_PORT 10090
 #define DEFAULT_MONITOR_PORT 10091
@@ -29,7 +30,7 @@ class CDiscoveryServer : public mmProto::CpUdpServer {
     m_monitor_port = DEFAULT_MONITOR_PORT;
   }
   CDiscoveryServer(const CHAR* msgqname) : CpUdpServer(msgqname) {
-    strcpy(name, msgqname);
+    mmBase::strlcpy(name, msgqname, sizeof(name));
     m_service_port = DEFAULT_SERVICE_PORT;
     m_monitor_port = DEFAULT_MONITOR_PORT;
   }

--- a/third_party/meerkat/Component/mmDiscovery/discovery_server.h
+++ b/third_party/meerkat/Component/mmDiscovery/discovery_server.h
@@ -28,11 +28,13 @@ class CDiscoveryServer : public mmProto::CpUdpServer {
   CDiscoveryServer() : CpUdpServer() {
     m_service_port = DEFAULT_SERVICE_PORT;
     m_monitor_port = DEFAULT_MONITOR_PORT;
+    m_query_request_count = 0;
   }
   CDiscoveryServer(const CHAR* msgqname) : CpUdpServer(msgqname) {
     mmBase::strlcpy(name, msgqname, sizeof(name));
     m_service_port = DEFAULT_SERVICE_PORT;
     m_monitor_port = DEFAULT_MONITOR_PORT;
+    m_query_request_count = 0;
   }
 
   virtual ~CDiscoveryServer() {}

--- a/third_party/meerkat/Component/mmDiscovery/monitor_client.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/monitor_client.cpp
@@ -149,8 +149,8 @@ VOID MonitorClient::ParseRtt() {
   }
   while (fscanf(file, " %1023s", buffer) == 1) {
     if (!strncmp(buffer, "min/avg/max/mdev", strlen("min/avg/max/mdev"))) {
-      ignore_result(fscanf(file, " %s", skip));
-      ignore_result(fscanf(file, " %s", buffer));
+      ignore_result(fscanf(file, " %2s", skip));
+      ignore_result(fscanf(file, " %1023s", buffer));
 
       std::string full_str(buffer);
       std::string delimiter = "/";

--- a/third_party/meerkat/Component/mmDiscovery/monitor_server.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/monitor_server.cpp
@@ -160,11 +160,10 @@ void MonitorThread::CheckBandwidth() {
           close(sock);
           return;
         }
-        ethtool_cmd_speed(&edata);
-        current_max_speed = edata.speed * 100;  // convert to kbps
+        current_max_speed = edata.speed * 1024;
       } else if (!strncmp(ifa->ifa_name, "wlan", 4)) {
         // TODO (djmix.kim) : For now, set 30Mbps by force in wifi.
-        current_max_speed = 30000;
+        current_max_speed = 30 * 1024;
       } else {
         // TODO (djmix.kim) : How to check mobile network (3g, 4g...)?
       }

--- a/third_party/meerkat/Component/mmDiscovery/monitor_server.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/monitor_server.cpp
@@ -191,6 +191,7 @@ void MonitorThread::CheckBandwidth() {
 
 void MonitorThread::CheckMemoryUsage() {
   long int mem, peak_mem, virtual_mem, peak_virtual_mem;
+  mem = peak_mem = virtual_mem = peak_virtual_mem = 0;
 #if !defined(WIN32)
   char buffer[1024] = "";
   FILE* file;
@@ -211,11 +212,7 @@ void MonitorThread::CheckMemoryUsage() {
   } else {
       DPRINT(COMM, DEBUG_ERROR,
          "Could not open /proc/self/status - errno(%d)\n", errno);
-    mem = peak_mem = virtual_mem = peak_virtual_mem = 0;
   }
-#else
-  // TODO
-  mem = peak_mem = virtual_mem = peak_virtual_mem = 0;
 #endif // !defined(WIN32)
   if (parent_) {
     parent_->Mem(mem);

--- a/third_party/meerkat/Component/mmDiscovery/monitor_server.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/monitor_server.cpp
@@ -36,6 +36,7 @@
 #endif
 
 #include "monitor_server.h"
+#include "string_util.h"
 
 using namespace mmBase;
 using namespace mmProto;
@@ -93,7 +94,7 @@ VOID ServerSocket::DataRecv(OSAL_Socket_Handle sock,
     char buf_[MAX_MONITOR_MSG_BUFF] = {
         '\0',
     };
-    strncpy(buf_, monitor_info_.c_str(), monitor_info_.length());
+    strlcpy(buf_, monitor_info_.c_str(), sizeof(buf_));
     CpTcpServer::DataSend(sock, buf_, monitor_info_.length());
   }
 }
@@ -148,7 +149,7 @@ void MonitorThread::CheckBandwidth() {
       }
 
       if (!strncmp(ifa->ifa_name, "eth", 3)) {
-        strncpy(ifr.ifr_name, ifa->ifa_name, sizeof(ifr.ifr_name));
+        strlcpy(ifr.ifr_name, ifa->ifa_name, sizeof(ifr.ifr_name));
         ifr.ifr_data = &edata;
 
         edata.cmd = ETHTOOL_GSET;

--- a/third_party/meerkat/Component/mmDiscovery/monitor_server.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/monitor_server.cpp
@@ -94,7 +94,7 @@ VOID ServerSocket::DataRecv(OSAL_Socket_Handle sock,
     char buf_[MAX_MONITOR_MSG_BUFF] = {
         '\0',
     };
-    strlcpy(buf_, monitor_info_.c_str(), sizeof(buf_));
+    mmBase::strlcpy(buf_, monitor_info_.c_str(), sizeof(buf_));
     CpTcpServer::DataSend(sock, buf_, monitor_info_.length());
   }
 }
@@ -149,7 +149,7 @@ void MonitorThread::CheckBandwidth() {
       }
 
       if (!strncmp(ifa->ifa_name, "eth", 3)) {
-        strlcpy(ifr.ifr_name, ifa->ifa_name, sizeof(ifr.ifr_name));
+        mmBase::strlcpy(ifr.ifr_name, ifa->ifa_name, sizeof(ifr.ifr_name));
         ifr.ifr_data = &edata;
 
         edata.cmd = ETHTOOL_GSET;

--- a/third_party/meerkat/Component/mmDiscovery/monitor_server.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/monitor_server.cpp
@@ -46,12 +46,6 @@ static unsigned long long last_total_user, last_total_user_low, last_total_sys,
     last_total_idle;
 #endif
 
-#if defined(ANDROID)
-static inline __u32 ethtool_cmd_speed(const struct ethtool_cmd *ep) {
-  return (ep->speed_hi << 16) | ep->speed;
-}
-#endif
-
 ServerSocket::ServerSocket(MonitorServer* parent)
     : CpTcpServer(), parent_(parent) {}
 

--- a/third_party/meerkat/Component/mmDiscovery/service_provider.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/service_provider.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "string_util.h"
 #include "timeAPI.h"
 
 using namespace mmBase;
@@ -61,7 +62,7 @@ VOID ServiceProvider::AddServiceInfo(CHAR* address,
   ServiceInfo* new_info = new ServiceInfo;
 
   new_info->key = key;
-  strncpy(new_info->address, address, strlen(address));
+  strlcpy(new_info->address, address, sizeof(new_info->address));
   new_info->service_port = service_port;
   new_info->monitor_port = monitor_port;
   __OSAL_TIME_GetTimeMS(&new_info->last_update_time);

--- a/third_party/meerkat/Component/mmDiscovery/service_provider.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/service_provider.cpp
@@ -62,7 +62,7 @@ VOID ServiceProvider::AddServiceInfo(CHAR* address,
   ServiceInfo* new_info = new ServiceInfo;
 
   new_info->key = key;
-  strlcpy(new_info->address, address, sizeof(new_info->address));
+  mmBase::strlcpy(new_info->address, address, sizeof(new_info->address));
   new_info->service_port = service_port;
   new_info->monitor_port = monitor_port;
   __OSAL_TIME_GetTimeMS(&new_info->last_update_time);

--- a/third_party/meerkat/Component/mmDiscovery/service_server.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/service_server.cpp
@@ -88,13 +88,15 @@ VOID CServiceServer::DataRecv(OSAL_Socket_Handle iEventSock,
     }
 
     char server_address[35] = {'\0',};
-    sprintf(server_address, "--enable-castanets=%s", pszsource_addr);
+    snprintf(server_address, sizeof(server_address) - 1,
+             "--enable-castanets=%s", pszsource_addr);
     argv.push_back(server_address);
 
     // TODO: |server_address_old| should be remove after applying
     // https://github.com/Samsung/Castanets/pull/75.
     char server_address_old[35] = {'\0',};
-    sprintf(server_address_old, "--server-address=%s", pszsource_addr);
+    snprintf(server_address_old, sizeof(server_address_old) - 1,
+             "--server-address=%s", pszsource_addr);
     argv.push_back(server_address_old);
 
 #if defined(ANDROID)

--- a/third_party/meerkat/Component/mmNM/UnitTest/src/ut_NetTunneling.cpp
+++ b/third_party/meerkat/Component/mmNM/UnitTest/src/ut_NetTunneling.cpp
@@ -18,6 +18,7 @@
 #include "bDataType.h"
 #include "NetTunProc.h"
 #include "osal.h"
+#include "string_util.h"
 
 #define STUN_SERVER_IP "168.219.193.94"
 #define TUN_DEFAULT_PORT 5000
@@ -44,8 +45,7 @@ int main(int argc, char** argv) {
     {
       if (argc > i) {
         server_ip = new char[16];
-        memset(server_ip, 0, 16);
-        strcpy(server_ip, argv[i + 1]);
+        mmBase::strlcpy(server_ip, argv[i + 1], sizeof(server_ip));
       }
     } else if (!strcmp(argv[i], "-stun_port"))  // TUN_DEFAULT_PORT
     {

--- a/third_party/meerkat/Component/mmNM/server/NetworkService.cpp
+++ b/third_party/meerkat/Component/mmNM/server/NetworkService.cpp
@@ -41,6 +41,8 @@ CNetworkService::CNetworkService(const CHAR* msgqname,
 
 CNetworkService::~CNetworkService() {
   CpUdpServer::Destroy();
+  SAFE_DELETE(m_pRoutingTable);
+  SAFE_DELETE(m_pszBindServerAddress);
 }
 
 BOOL CNetworkService::StartServer(int port, int readperonce) {

--- a/third_party/meerkat/Component/mmNM/server/NetworkService.cpp
+++ b/third_party/meerkat/Component/mmNM/server/NetworkService.cpp
@@ -15,7 +15,9 @@
  */
 
 #include "NetworkService.h"
+
 #include "netUtil.h"
+#include "string_util.h"
 
 using namespace mmBase;
 using namespace mmProto;
@@ -29,8 +31,8 @@ CNetworkService::CNetworkService(const CHAR* msgqname,
                                  unsigned short stun_port)
     : CpUdpServer(msgqname) {
   m_pszBindServerAddress = new char[strlen(pszBindAddress) + 1];
-  memset(m_pszBindServerAddress, 0, strlen(pszBindAddress) + 1);
-  strcpy(m_pszBindServerAddress, pszBindAddress);
+  strlcpy(m_pszBindServerAddress, pszBindAddress,
+                  sizeof(m_pszBindServerAddress));
   m_stun_port = stun_port;
 
   CpUdpServer::Create();

--- a/third_party/meerkat/Component/mmNM/tunneling/NetTunProc.cpp
+++ b/third_party/meerkat/Component/mmNM/tunneling/NetTunProc.cpp
@@ -15,10 +15,11 @@
  */
 
 #include "NetTunProc.h"
-#include "timeAPI.h"
-#include "StunClient.h"
 
+#include "StunClient.h"
 #include "netUtil.h"
+#include "string_util.h"
+#include "timeAPI.h"
 
 using namespace mmBase;
 using namespace mmProto;
@@ -57,8 +58,7 @@ CNetTunProc::CNetTunProc(const char* pszTaskName,
 
   m_hasTarget = false;
 
-  memset(m_args.server_ip, 0, 16);
-  strcpy(m_args.server_ip, server_ip);
+  strlcpy(m_args.server_ip, server_ip, sizeof(m_args.server_ip));
 }
 
 CNetTunProc::~CNetTunProc() {}

--- a/third_party/meerkat/Component/mmNM/tunneling/RmtServer.h
+++ b/third_party/meerkat/Component/mmNM/tunneling/RmtServer.h
@@ -24,9 +24,7 @@ typedef void (*pfReceiver)(int type, char* addr, int port, int len, void* data);
 
 class CRmtServer : public mmProto::CpUdpServer {
  public:
-  CRmtServer(const CHAR* msgqname)
-      : CpUdpServer(msgqname) { /*strcpy(name,msgqname);*/
-  }
+  CRmtServer(const CHAR* msgqname) : CpUdpServer(msgqname) {}
   virtual ~CRmtServer() {}
 
   BOOL RemoteServerStart(pfReceiver receiver, int port, int readperonce = 1024);

--- a/third_party/meerkat/Component/mmNM/tunneling/TunDrv.cpp
+++ b/third_party/meerkat/Component/mmNM/tunneling/TunDrv.cpp
@@ -38,6 +38,7 @@
 
 #include "bGlobDef.h"
 #include "Debugger.h"
+#include "string_util.h"
 
 #ifndef OTUNSETNOCSUM
 #define OTUNSETIFF (('T' << 8) | 202)
@@ -85,7 +86,7 @@ int CTunDrv::Open(char* dev, char* pb_addr) {
 
   if (*dev) {
     DPRINT(COMM, DEBUG_ERROR, "cp ifname [%s]\n", dev);
-    strncpy(ifr.ifr_name, dev, IFNAMSIZ);
+    mmBase::strlcpy(ifr.ifr_name, dev, sizeof(ifr.ifr_name));
   }
 
   if (ioctl(fd, TUNSETIFF, (void*)&ifr) < 0) {
@@ -100,7 +101,7 @@ int CTunDrv::Open(char* dev, char* pb_addr) {
       return -1;
     }
   }
-  strcpy(dev, ifr.ifr_name);
+  mmBase::strlcpy(dev, ifr.ifr_name, sizeof(dev));
   DPRINT(COMM, DEBUG_ERROR, "Set IFF [%s]\n", dev);
 
   char cmd_buf[1024];

--- a/third_party/meerkat/Component/mmOSAL/daemonAPI.cpp
+++ b/third_party/meerkat/Component/mmOSAL/daemonAPI.cpp
@@ -138,7 +138,8 @@ VOID __OSAL_DaemonAPI_Daemonize(const char* name) {
   }
 
   /* Write the daemon PID to a PID file */
-  sprintf(pid_path, "/run/%s.pid", name);
+  memset(pid_path, 0, sizeof(pid_path));
+  snprintf(pid_path, sizeof(pid_path) - 1, "/run/%s.pid", name);
 
   pid_fd = open(pid_path, O_RDWR | O_CREAT, 0640);
 
@@ -150,7 +151,7 @@ VOID __OSAL_DaemonAPI_Daemonize(const char* name) {
     exit(EXIT_FAILURE);
   }
 
-  sprintf(str, "%d\n", getpid());
+  snprintf(str, sizeof(str) - 1, "%d\n", getpid());
 
   ignore_result(write(pid_fd, str, strlen(str)));
 

--- a/third_party/meerkat/Component/mmOSAL/daemonAPI.cpp
+++ b/third_party/meerkat/Component/mmOSAL/daemonAPI.cpp
@@ -160,8 +160,11 @@ VOID __OSAL_DaemonAPI_Daemonize(const char* name) {
   sigemptyset(&new_action.sa_mask);
   new_action.sa_flags = 0;
 
-  sigaction(SIGHUP, &new_action, NULL);
-  sigaction(SIGTERM, &new_action, NULL);
+  if (sigaction(SIGHUP, &new_action, NULL) == -1)
+    exit(EXIT_FAILURE);
+
+  if (sigaction(SIGTERM, &new_action, NULL) == -1)
+    exit(EXIT_FAILURE);
 
   running = 1;
 

--- a/third_party/meerkat/Component/mmOSAL/socketAPI.cpp
+++ b/third_party/meerkat/Component/mmOSAL/socketAPI.cpp
@@ -254,11 +254,10 @@ OSAL_Socket_Return __OSAL_Socket_BlockMode(OSAL_Socket_Handle sock,
                                            bool bBlocking) {
 #if defined(LINUX)
   int OldFlags = fcntl(sock, F_GETFL);
-  if (bBlocking)
-    fcntl(sock, F_SETFL, OldFlags & O_NONBLOCK);
-
-  else
-    fcntl(sock, F_SETFL, OldFlags | O_NONBLOCK);
+  if (bBlocking && (fcntl(sock, F_SETFL, OldFlags & O_NONBLOCK) == -1))
+    return OSAL_Socket_Error;
+  else if (fcntl(sock, F_SETFL, OldFlags | O_NONBLOCK) == -1)
+    return OSAL_Socket_Error;
 #endif
   return OSAL_Socket_Success;
 }

--- a/third_party/meerkat/Component/mmOSAL/timeAPI.cpp
+++ b/third_party/meerkat/Component/mmOSAL/timeAPI.cpp
@@ -40,7 +40,7 @@ OSAL_Time_Return __OSAL_TIME_GetTimeMS(UINT64* ptimeval) {
 #elif defined(LINUX)
   struct timeval tv;
   gettimeofday(&tv, NULL);
-  *ptimeval = ((tv.tv_sec * 1000) + (tv.tv_usec / 1000));
+  *ptimeval = ((UINT64)(tv.tv_sec) * 1000) + ((UINT64)(tv.tv_usec) / 1000);
   return OSAL_Time_Success;
 #endif
 }

--- a/third_party/meerkat/Component/mmSH/attatic/NTClient.cpp
+++ b/third_party/meerkat/Component/mmSH/attatic/NTClient.cpp
@@ -47,8 +47,7 @@ int main(int argc, char** argv) {
     {
       if (argc > i) {
         server_ip = new char[16];
-        memset(server_ip, 0, 16);
-        strcpy(server_ip, argv[i + 1]);
+        mmBase::strlcpy(server_ip, argv[i + 1], sizeof(server_ip));
       }
     } else if (!strcmp(argv[i], "-stun_port"))  // TUN_DEFAULT_PORT
     {

--- a/third_party/meerkat/Component/mmSH/attatic/NTServer.cpp
+++ b/third_party/meerkat/Component/mmSH/attatic/NTServer.cpp
@@ -15,11 +15,11 @@
  */
 
 #include "Debugger.h"
+#include "NetworkService.h"
 #include "bDataType.h"
 #include "bGlobDef.h"
-
-#include "NetworkService.h"
 #include "osal.h"
+#include "string_util.h"
 
 #define VTUN_DEV_LEN 20
 
@@ -45,8 +45,7 @@ int main(int argc, char** argv) {
     {
       if (argc > i) {
         server_ip = new char[16];
-        memset(server_ip, 0, 16);
-        strcpy(server_ip, argv[i + 1]);
+        mmBase::strlcpy(server_ip, argv[i + 1], sizeof(server_ip));
       }
     } else if (!strcmp(argv[i], "-stun_port"))  // TUN_DEFAULT_PORT
     {

--- a/third_party/meerkat/Component/mmSH/client_runner.cpp
+++ b/third_party/meerkat/Component/mmSH/client_runner.cpp
@@ -140,7 +140,7 @@ static void RequestRunService(DBusMessage* msg, DBusConnection* conn,
 
   char* message = (char*) malloc(message_string.length() + 1);
   if (message) {
-    strlcpy(message, message_string.c_str(), sizeof(message));
+    strlcpy(message, message_string.c_str(), message_string.length() + 1);
 
     ServiceProvider* ic = CSTI<ServiceProvider>::getInstancePtr();
     if (ic->Count() > 0) {

--- a/third_party/meerkat/Component/mmSH/client_runner.cpp
+++ b/third_party/meerkat/Component/mmSH/client_runner.cpp
@@ -140,8 +140,7 @@ static void RequestRunService(DBusMessage* msg, DBusConnection* conn,
 
   char* message = (char*) malloc(message_string.length() + 1);
   if (message) {
-    memset(message, 0, message_string.length() + 1);
-    strncpy(message, message_string.c_str(), message_string.length());
+    strlcpy(message, message_string.c_str(), sizeof(message));
 
     ServiceProvider* ic = CSTI<ServiceProvider>::getInstancePtr();
     if (ic->Count() > 0) {
@@ -299,7 +298,7 @@ int ClientRunner::Run() {
       Monitor* meta = new Monitor;
       INT32 magic = sequence_id * 100 + i;
       sprintf(meta->id, UUIDS_MDC, magic);
-      strncpy(meta->address, info->address, sizeof(meta->address));
+      strlcpy(meta->address, info->address, sizeof(meta->address));
       meta->service_port = info->service_port;
       meta->monitor_port = info->monitor_port;
 

--- a/third_party/meerkat/Component/mmSH/client_runner.cpp
+++ b/third_party/meerkat/Component/mmSH/client_runner.cpp
@@ -298,7 +298,8 @@ int ClientRunner::Run() {
 
       Monitor* meta = new Monitor;
       INT32 magic = sequence_id * 100 + i;
-      sprintf(meta->id, UUIDS_MDC, magic);
+      memset(meta->id, 0, sizeof(meta->id));
+      snprintf(meta->id, sizeof(meta->id) - 1, UUIDS_MDC, magic);
       strlcpy(meta->address, info->address, sizeof(meta->address));
       meta->service_port = info->service_port;
       meta->monitor_port = info->monitor_port;

--- a/third_party/meerkat/Component/mmSH/client_runner.h
+++ b/third_party/meerkat/Component/mmSH/client_runner.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <memory>
 #include <string>
 
 class ClientRunner {

--- a/third_party/meerkat/Component/mmSH/server_runner.h
+++ b/third_party/meerkat/Component/mmSH/server_runner.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <memory>
 #include <string>
 
 class ServerRunner {

--- a/third_party/meerkat/Component/mmSOCK/UnitTest/src/ut_tcpserver.cpp
+++ b/third_party/meerkat/Component/mmSOCK/UnitTest/src/ut_tcpserver.cpp
@@ -23,6 +23,7 @@
 #endif
 
 #include "pTcpServer.h"
+#include "string_util.h"
 
 using namespace mmBase;
 using namespace mmProto;
@@ -33,7 +34,7 @@ class CCustomTcpServer : public CpTcpServer {
  public:
   CCustomTcpServer() : CpTcpServer() {}
   CCustomTcpServer(const CHAR* msgqname) : CpTcpServer(msgqname) {
-    strcpy(name, msgqname);
+    strlcpy(name, msgqname, sizeof(name));
   }
   virtual ~CCustomTcpServer() {}
 

--- a/third_party/meerkat/Component/mmSOCK/UnitTest/src/ut_udpserver.cpp
+++ b/third_party/meerkat/Component/mmSOCK/UnitTest/src/ut_udpserver.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "pUdpServer.h"
+#include "string_util.h"
 
 using namespace mmBase;
 using namespace mmProto;
@@ -23,7 +24,7 @@ class CCustomUdpServer : public CpUdpServer {
  public:
   CCustomUdpServer() : CpUdpServer() {}
   CCustomUdpServer(const CHAR* msgqname) : CpUdpServer(msgqname) {
-    strcpy(name, msgqname);
+    strlcpy(name, msgqname, sizeof(name));
   }
   virtual ~CCustomUdpServer() {}
 

--- a/third_party/meerkat/Component/mmSOCK/pTcpClient.cpp
+++ b/third_party/meerkat/Component/mmSOCK/pTcpClient.cpp
@@ -16,6 +16,8 @@
 
 #include "pTcpClient.h"
 
+#include "string_util.h"
+
 using namespace mmBase;
 using namespace mmProto;
 /**
@@ -58,8 +60,7 @@ BOOL CpTcpClient::Create() {
  * @remarks       this method is not used in this project
  */
 BOOL CpTcpClient::Open(const CHAR* pAddress, INT32 iPort) {
-  memset(m_pServerAddress, 0, IPV4_ADDR_LEN);
-  strcpy(m_pServerAddress, pAddress);
+  strlcpy(m_pServerAddress, pAddress, sizeof(m_pServerAddress));
 
   if (OSAL_Socket_Success !=
       CbSocket::Open(AF_INET, SOCK_STREAM, IPPROTO_TCP, ACT_TCP_CLIENT)) {

--- a/third_party/meerkat/Component/mmSOCK/pTcpClient.cpp
+++ b/third_party/meerkat/Component/mmSOCK/pTcpClient.cpp
@@ -77,7 +77,7 @@ BOOL CpTcpClient::Create() {
  * @remarks       this method is not used in this project
  */
 BOOL CpTcpClient::Open(const CHAR* pAddress, INT32 iPort) {
-  strlcpy(m_pServerAddress, pAddress, sizeof(m_pServerAddress));
+  mmBase::strlcpy(m_pServerAddress, pAddress, sizeof(m_pServerAddress));
 
   if (OSAL_Socket_Success !=
       CbSocket::Open(AF_INET, SOCK_STREAM, IPPROTO_TCP, ACT_TCP_CLIENT)) {

--- a/third_party/meerkat/Component/mmSOCK/pTcpClient.cpp
+++ b/third_party/meerkat/Component/mmSOCK/pTcpClient.cpp
@@ -47,8 +47,7 @@ CpTcpClient::~CpTcpClient() {}
  * @remarks       this method is not used in this project
  */
 BOOL CpTcpClient::Create() {
-  BOOL bRet = PFM_NetworkInitialize();
-  if (bRet == FALSE) {
+  if (!PFM_NetworkInitialize()) {
     DPRINT(COMM, DEBUG_ERROR, "Platform Network Initialize Fail\n");
     return FALSE;
   }

--- a/third_party/meerkat/Component/mmSOCK/pTcpServer.cpp
+++ b/third_party/meerkat/Component/mmSOCK/pTcpServer.cpp
@@ -350,8 +350,8 @@ BOOL CpTcpServer::OnAccept(OSAL_Socket_Handle iSock, CHAR* szConnectorAddr) {
   CHECK_ALLOC(pNewConnection);
 
   char name_buf[128];
-  memset(name_buf, 0, 128);
-  sprintf(name_buf, "%s%d", m_szThreadName, iSock);
+  memset(name_buf, 0, sizeof(name_buf));
+  snprintf(name_buf, sizeof(name_buf) - 1, "%s%d", m_szThreadName, iSock);
 
   CpAcceptSock* pAcceptSocket = new CpAcceptSock(name_buf);
   pAcceptSocket->Activate(iSock, (VOID*)this, ReceiveCallback,

--- a/third_party/meerkat/Component/mmSOCK/pTcpServer.cpp
+++ b/third_party/meerkat/Component/mmSOCK/pTcpServer.cpp
@@ -31,7 +31,11 @@ using namespace mmBase;
 using namespace mmProto;
 
 CpAcceptSock::CpAcceptSock(const CHAR* pszQname)
-    : mmBase::CbTask(pszQname), m_nReadBytePerOnce(-1), m_hListenerMonitor(0) {
+    : mmBase::CbTask(pszQname),
+      m_lpDataCallback(NULL),
+      m_pListenerPtr(NULL),
+      m_nReadBytePerOnce(-1),
+      m_hListenerMonitor(0) {
   m_hTerminateEvent = __OSAL_Event_Create();
   m_hTerminateMutex = __OSAL_Mutex_Create();
   OSAL_Socket_Return ret = __OSAL_Socket_InitEvent(&m_hListenerEvent);

--- a/third_party/meerkat/Component/mmSOCK/pTcpServer.cpp
+++ b/third_party/meerkat/Component/mmSOCK/pTcpServer.cpp
@@ -25,6 +25,8 @@
 
 #include "pTcpServer.h"
 
+#include "string_util.h"
+
 using namespace mmBase;
 using namespace mmProto;
 
@@ -345,12 +347,15 @@ BOOL CpTcpServer::OnAccept(OSAL_Socket_Handle iSock, CHAR* szConnectorAddr) {
   pNewConnection->clientSock = iSock;
   if (szConnectorAddr != NULL) {
     if (strlen(szConnectorAddr) < 16) {
-      strcpy(pNewConnection->clientAddr, szConnectorAddr);
+      strlcpy(pNewConnection->clientAddr, szConnectorAddr,
+                      sizeof(pNewConnection->clientAddr));
     } else {
-      strcpy(pNewConnection->clientAddr, "invalid addr");
+      strlcpy(pNewConnection->clientAddr, "invalid addr",
+                      sizeof(pNewConnection->clientAddr));
     }
   } else {
-    strcpy(pNewConnection->clientAddr, "invalid addr");
+    strlcpy(pNewConnection->clientAddr, "invalid addr",
+                    sizeof(pNewConnection->clientAddr));
   }
 
   pNewConnection->pConnectionHandle = pAcceptSocket;

--- a/third_party/meerkat/Component/mmSOCK/pTcpServer.cpp
+++ b/third_party/meerkat/Component/mmSOCK/pTcpServer.cpp
@@ -360,14 +360,14 @@ BOOL CpTcpServer::OnAccept(OSAL_Socket_Handle iSock, CHAR* szConnectorAddr) {
   pNewConnection->clientSock = iSock;
   if (szConnectorAddr != NULL) {
     if (strlen(szConnectorAddr) < 16) {
-      strlcpy(pNewConnection->clientAddr, szConnectorAddr,
+      mmBase::strlcpy(pNewConnection->clientAddr, szConnectorAddr,
                       sizeof(pNewConnection->clientAddr));
     } else {
-      strlcpy(pNewConnection->clientAddr, "invalid addr",
+      mmBase::strlcpy(pNewConnection->clientAddr, "invalid addr",
                       sizeof(pNewConnection->clientAddr));
     }
   } else {
-    strlcpy(pNewConnection->clientAddr, "invalid addr",
+    mmBase::strlcpy(pNewConnection->clientAddr, "invalid addr",
                     sizeof(pNewConnection->clientAddr));
   }
 

--- a/third_party/meerkat/Component/mmSOCK/pTcpServer.cpp
+++ b/third_party/meerkat/Component/mmSOCK/pTcpServer.cpp
@@ -135,8 +135,7 @@ CpTcpServer::~CpTcpServer() {}
  * @remarks       this method is not used in this project
  */
 BOOL CpTcpServer::Create() {
-  BOOL bRet = PFM_NetworkInitialize();
-  if (bRet == FALSE) {
+  if (!PFM_NetworkInitialize()) {
     DPRINT(COMM, DEBUG_ERROR, "Platform Network Initialize Fail\n");
     return FALSE;
   }

--- a/third_party/meerkat/Component/mmSOCK/pTcpServer.h
+++ b/third_party/meerkat/Component/mmSOCK/pTcpServer.h
@@ -38,8 +38,8 @@ class CpAcceptSock : public mmBase::CbTask, public mmBase::CbSocket {
   };
 
  public:
-  CpAcceptSock(const CHAR* pszQname) : mmBase::CbTask(pszQname) {}
-  virtual ~CpAcceptSock() {}
+  CpAcceptSock(const CHAR* pszQname);
+  ~CpAcceptSock();
 
   VOID Activate(OSAL_Socket_Handle iSock,
                 VOID* pListenerPtr,
@@ -113,9 +113,6 @@ class CpTcpServer : public mmBase::CbTask, public mmBase::CbSocket {
 
   CHAR* Address(OSAL_Socket_Handle iSock);
 
-  VOID SessionLock() { __OSAL_Mutex_Lock(&m_hSessionMutex); }
-  VOID SessionUnLock() { __OSAL_Mutex_UnLock(&m_hSessionMutex); }
-
  protected:
   virtual BOOL OnAccept(OSAL_Socket_Handle iSock, CHAR* szConnectorAddr);
   virtual VOID OnReceive(OSAL_Socket_Handle iEventSock,
@@ -143,8 +140,6 @@ class CpTcpServer : public mmBase::CbTask, public mmBase::CbSocket {
   void Endup(void) {}
 
  protected:
-  OSAL_Mutex_Handle m_hSessionMutex;
-
   OSAL_Event_Handle m_hTerminateEvent;
   OSAL_Mutex_Handle m_hTerminateMutex;
   OSAL_Socket_EventObj m_hListenerEvent;

--- a/third_party/meerkat/Component/mmSOCK/pUdpClient.cpp
+++ b/third_party/meerkat/Component/mmSOCK/pUdpClient.cpp
@@ -45,8 +45,7 @@ CpUdpClient::~CpUdpClient() {}
  * @remarks       this method is not used in this project
  */
 BOOL CpUdpClient::Create() {
-  BOOL bRet = PFM_NetworkInitialize();
-  if (bRet == FALSE) {
+  if (!PFM_NetworkInitialize()) {
     DPRINT(COMM, DEBUG_ERROR, "Platform Network Initialize Fail\n");
     return FALSE;
   }

--- a/third_party/meerkat/Component/mmSOCK/pUdpClient.cpp
+++ b/third_party/meerkat/Component/mmSOCK/pUdpClient.cpp
@@ -19,26 +19,40 @@
 using namespace mmBase;
 using namespace mmProto;
 /**
- * @brief         »ı¼ºÀÚ
- * @remarks       »ı¼ºÀÚ
+ * @brief         Â»Ã½Â¼ÂºÃ€Ãš
+ * @remarks       Â»Ã½Â¼ÂºÃ€Ãš
  */
-CpUdpClient::CpUdpClient() : CbTask(UDP_CLIENT_MQNAME) {
-  m_nReadBytePerOnce = -1;
+CpUdpClient::CpUdpClient()
+    : CbTask(UDP_CLIENT_MQNAME), m_nReadBytePerOnce(-1), m_hListenerMonitor(0) {
+  m_hTerminateEvent = __OSAL_Event_Create();
+  m_hTerminateMutex = __OSAL_Mutex_Create();
+  OSAL_Socket_Return ret = __OSAL_Socket_InitEvent(&m_hListenerEvent);
+  if (ret == OSAL_Socket_Error)
+    DPRINT(COMM, DEBUG_ERROR, "Socket Monitor Event Init Fail!!\n");
 }
 
 /**
- * @brief         »ı¼ºÀÚ
- * @remarks       »ı¼ºÀÚ
+ * @brief         æŒå¤±åˆ‡
+ * @remarks       æŒå¤±åˆ‡
  */
-CpUdpClient::CpUdpClient(const CHAR* msgqname) : CbTask(msgqname) {
-  m_nReadBytePerOnce = -1;
+CpUdpClient::CpUdpClient(const CHAR* msgqname)
+    : CbTask(msgqname), m_nReadBytePerOnce(-1), m_hListenerMonitor(0) {
+  m_hTerminateEvent = __OSAL_Event_Create();
+  m_hTerminateMutex = __OSAL_Mutex_Create();
+  OSAL_Socket_Return ret = __OSAL_Socket_InitEvent(&m_hListenerEvent);
+  if (ret == OSAL_Socket_Error)
+    DPRINT(COMM, DEBUG_ERROR, "Socket Monitor Event Init Fail!!\n");
 }
 
 /**
- * @brief         ¼Ò¸êÀÚ.
- * @remarks       ¼Ò¸êÀÚ.
+ * @brief         ç¤¾ç‘šåˆ‡.
+ * @remarks       ç¤¾ç‘šåˆ‡.
  */
-CpUdpClient::~CpUdpClient() {}
+CpUdpClient::~CpUdpClient() {
+  __OSAL_Event_Destroy(&m_hTerminateEvent);
+  __OSAL_Mutex_Destroy(&m_hTerminateMutex);
+  __OSAL_Socket_DeInitEvent(m_hListenerEvent);
+}
 
 /**
  * @brief         this method is not used in this project
@@ -80,13 +94,6 @@ BOOL CpUdpClient::SetTTL(UCHAR ttl) {
  * @remarks       this method is not used in this project
  */
 BOOL CpUdpClient::Start(INT32 nReadPerOnce, INT32 lNetworkEvent) {
-  m_hTerminateEvent = __OSAL_Event_Create();
-  m_hTerminateMutex = __OSAL_Mutex_Create();
-
-  OSAL_Socket_Return ret = __OSAL_Socket_InitEvent(&m_hListenerEvent);
-  if (ret == OSAL_Socket_Error) {
-    DPRINT(COMM, DEBUG_ERROR, "Socket Monitor Event Init Fail!!\n");
-  }
   m_hListenerMonitor = lNetworkEvent;
   __OSAL_Socket_RegEvent(m_hSock, &m_hListenerEvent, m_hListenerMonitor);
 
@@ -113,9 +120,6 @@ BOOL CpUdpClient::Stop(OSAL_Socket_Handle iSock) {
  * @remarks       this method is not used in this project
  */
 BOOL CpUdpClient::Close() {
-  __OSAL_Event_Destroy(&m_hTerminateEvent);
-  __OSAL_Mutex_Destroy(&m_hTerminateMutex);
-  __OSAL_Socket_DeInitEvent(m_hListenerEvent);
   return TRUE;
 }
 

--- a/third_party/meerkat/Component/mmSOCK/pUdpServer.cpp
+++ b/third_party/meerkat/Component/mmSOCK/pUdpServer.cpp
@@ -41,8 +41,7 @@ CpUdpServer::~CpUdpServer() {}
  * @remarks       this method is not used in this project
  */
 BOOL CpUdpServer::Create() {
-  BOOL bRet = PFM_NetworkInitialize();
-  if (bRet == FALSE) {
+  if (!PFM_NetworkInitialize()) {
     DPRINT(COMM, DEBUG_ERROR, "Platform Network Initialize Fail\n");
   }
 


### PR DESCRIPTION
This patch fixes SVACE(66 issues) and Coverity(42 issues) in meerkat.

1) [SVACE] Fix SIZEOF_POINTER_TYPE
2) [Coverity] Fix Unchecked return value
3) [SVACE] Fix UNINIT.CTOR.MANY
4) [SVACE] Remove unused member variable
5) [SVACE] Fix NULL_AFTER_DEREF
6) [SVACE] Fix memory_leak
7) [SVACE] Fix PROC_USE.VULNERABLE
8) [Coverity] Fix Useless call
9) [Coverity] Fix Unintentional integer overflow
10) [Coverity] Fix Resource leak
11) [Coverity] Fix dereference null return value
12) [Coverity] Fix Incorrect deallocator used
13) [Coverity] Fix Missing unlock / Double unlock
14) [SVACE] Fix STATIC_OVERFLOW.SCANF
15) [Coverity] Fix HANDLE_LEAK
16) [Coverity] Fix UNINIT.CTOR.MANY
17) [Coverity] Fix UNINIT.LOCAL_VAR.EX
18) [Coverity] Fix UNREACHABLE_CODE
19) [SVACE] Replace strcpy to strlcpy