### PR TITLE
Apply zlib,webp based compression for sync data.

### DIFF
--- a/cc/raster/one_copy_raster_buffer_provider.cc
+++ b/cc/raster/one_copy_raster_buffer_provider.cc
@@ -362,9 +362,9 @@ void OneCopyRasterBufferProvider::PlaybackToStagingBuffer(
 #if defined(CASTANETS)
     if (std::string("renderer") ==
         base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
-      mojo::SyncSharedMemory(
-          buffer->GetHandle().handle.GetGUID(), 0,
-          staging_buffer->size.width() * staging_buffer->size.height() * 4);
+      mojo::SyncSharedMemory2d(
+          buffer->GetHandle().handle.GetGUID(), staging_buffer->size.width(),
+          staging_buffer->size.height(), buffer->stride(0)/staging_buffer->size.width());
     }
 #endif
     buffer->Unmap();

--- a/cc/tiles/tile_manager.cc
+++ b/cc/tiles/tile_manager.cc
@@ -143,18 +143,15 @@ class RasterTaskImpl : public TileTask {
           size_t offset_y =
               (invalid_content_rect_.y() - content_rect_.y()) * bytes_per_pixel;
           size_t linear_offset = offset_x + (offset_y * content_rect_.width());
-
           // Send bytes the size of invalid_content_rect.
-          for (int i = 0; i < invalid_content_rect_.height(); i++) {
-            mojo::SyncSharedMemory(
-                sw_backing->SharedMemoryGuid(), linear_offset,
-                invalid_content_rect_.width() * bytes_per_pixel);
-            linear_offset += content_rect_.width() * bytes_per_pixel;
-          }
+          mojo::SyncSharedMemory2d(
+              sw_backing->SharedMemoryGuid(), invalid_content_rect_.width(),
+              invalid_content_rect_.height(), bytes_per_pixel, linear_offset,
+              content_rect_.width() * bytes_per_pixel);
         } else {
-          mojo::SyncSharedMemory(
-              sw_backing->SharedMemoryGuid(), 0,
-              content_rect_.width() * content_rect_.height() * bytes_per_pixel);
+          mojo::SyncSharedMemory2d(
+              sw_backing->SharedMemoryGuid(),
+              content_rect_.width(), content_rect_.height(), bytes_per_pixel);
         }
       }
     }

--- a/mojo/core/BUILD.gn
+++ b/mojo/core/BUILD.gn
@@ -157,6 +157,9 @@ template("core_impl_source_set") {
       deps += [
         "//base:base_static",
         "//mojo/public/cpp/platform:platform",
+        "//third_party/libwebp:libwebp_dec",
+        "//third_party/libwebp:libwebp_enc",
+        "//third_party/zlib/google:compression_utils",
       ]
     }
     if (is_android) {

--- a/mojo/core/broker_castanets.h
+++ b/mojo/core/broker_castanets.h
@@ -12,6 +12,7 @@
 #include "mojo/core/embedder/process_error_callback.h"
 #include "mojo/core/platform_handle_in_transit.h"
 #include "mojo/public/cpp/platform/platform_channel_endpoint.h"
+#include "mojo/public/cpp/system/sync.h"
 
 namespace mojo {
 namespace core {
@@ -60,7 +61,8 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
 
   bool SyncSharedBuffer(const base::UnguessableToken& guid,
                         size_t offset,
-                        size_t sync_size);
+                        size_t sync_size,
+                        BrokerCompressionMode compression_mode);
 
   bool SyncSharedBuffer(base::WritableSharedMemoryMapping& mapping,
                         size_t offset,
@@ -72,16 +74,20 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
                     uint32_t offset,
                     uint32_t sync_bytes,
                     uint32_t buffer_bytes,
+                    uint32_t original_size,
+                    uint32_t compression_mode,
                     const void* data);
 
   void AddSyncFence(const base::UnguessableToken& guid, uint32_t fence_id);
 
   // Sync 2-dimensional memory for partial rasterization,
   bool SyncSharedBuffer2d(const base::UnguessableToken& guid,
-                          size_t offset,
-                          size_t sync_size,
                           size_t width,
-                          size_t stride);
+                          size_t height,
+                          size_t bytes_per_pixel,
+                          size_t offset,
+                          size_t stride,
+                          BrokerCompressionMode compression_mode);
 
   void OnBufferSync2d(uint64_t guid_high,
                       uint64_t guid_low,
@@ -91,6 +97,8 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
                       uint32_t buffer_bytes,
                       uint32_t width,
                       uint32_t stride,
+                      uint32_t original_size,
+                      uint32_t compression_mode,
                       const void* data);
 
   // Send |handle| to the client, to be used to establish a NodeChannel to us.
@@ -144,15 +152,18 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
                             size_t offset,
                             size_t sync_size,
                             size_t mapped_size,
+                            BrokerCompressionMode compression_mode = BrokerCompressionMode::ZLIB,
                             bool write_lock = true);
 
   void SyncSharedBufferImpl2d(const base::UnguessableToken& guid,
                               uint8_t* memory,
-                              size_t offset,
-                              size_t sync_size,
                               size_t mapped_size,
                               size_t width,
+                              size_t height,
+                              size_t bytes_per_pixel,
+                              size_t offset,
                               size_t stride,
+                              BrokerCompressionMode compression_mode = BrokerCompressionMode::WEBP,
                               bool write_lock = true);
 
   bool tcp_connection_ = false;

--- a/mojo/core/broker_messages.h
+++ b/mojo/core/broker_messages.h
@@ -51,6 +51,8 @@ struct BufferSyncData {
 #if defined(CASTANETS)
   uint32_t width;
   uint32_t stride;
+  uint32_t compression_mode;
+  uint32_t original_size;
 #endif
 };
 

--- a/mojo/core/core.cc
+++ b/mojo/core/core.cc
@@ -1194,11 +1194,12 @@ MojoResult Core::UnwrapPlatformSharedMemoryRegion(
 MojoResult Core::SyncPlatformSharedMemoryRegion(
     const MojoSharedBufferGuid* guid,
     size_t offset,
-    size_t sync_size) {
+    size_t sync_size,
+    BrokerCompressionMode compression_mode) {
   DCHECK(sync_size);
   const base::UnguessableToken& token =
       base::UnguessableToken::Deserialize(guid->high, guid->low);
-  if (!GetNodeController()->SyncSharedBuffer(token, offset, sync_size))
+  if (!GetNodeController()->SyncSharedBuffer(token, offset, sync_size, compression_mode))
       return MOJO_RESULT_UNKNOWN;
 
   return MOJO_RESULT_OK;
@@ -1206,15 +1207,16 @@ MojoResult Core::SyncPlatformSharedMemoryRegion(
 
 MojoResult Core::SyncPlatformSharedMemoryRegion2d(
     const MojoSharedBufferGuid* guid,
-    size_t offset,
-    size_t sync_size,
     size_t width,
-    size_t stride) {
-  DCHECK(sync_size);
+    size_t height,
+    size_t bytes_per_pixel,
+    size_t offset,
+    size_t stride,
+    BrokerCompressionMode compression_mode) {
   const base::UnguessableToken& token =
       base::UnguessableToken::Deserialize(guid->high, guid->low);
-  if (!GetNodeController()->SyncSharedBuffer2d(token, offset, sync_size, width,
-                                               stride))
+  if (!GetNodeController()->SyncSharedBuffer2d(token, width, height, bytes_per_pixel,
+                                               offset, stride, compression_mode))
     return MOJO_RESULT_UNKNOWN;
 
   return MOJO_RESULT_OK;

--- a/mojo/core/core.h
+++ b/mojo/core/core.h
@@ -30,6 +30,10 @@
 #include "mojo/public/c/system/trap.h"
 #include "mojo/public/c/system/types.h"
 
+#if defined(CASTANETS)
+#include "mojo/public/c/system/sync.h"
+#endif
+
 namespace base {
 class PortProvider;
 }
@@ -307,12 +311,15 @@ class MOJO_SYSTEM_IMPL_EXPORT Core {
   MojoResult SyncPlatformSharedMemoryRegion(
       const MojoSharedBufferGuid* guid,
       size_t offset,
-      size_t sync_size);
+      size_t sync_size,
+      BrokerCompressionMode compression_mode);
   MojoResult SyncPlatformSharedMemoryRegion2d(const MojoSharedBufferGuid* guid,
-                                              size_t offset,
-                                              size_t sync_size,
                                               size_t width,
-                                              size_t stride);
+                                              size_t height,
+                                              size_t bytes_per_pixel,
+                                              size_t offset,
+                                              size_t stride,
+                                              BrokerCompressionMode compression_mode);
   MojoResult WaitSyncPlatformSharedMemoryRegion(
       const MojoSharedBufferGuid* guid);
 #endif

--- a/mojo/core/entrypoints.cc
+++ b/mojo/core/entrypoints.cc
@@ -288,19 +288,22 @@ MojoResult MojoUnwrapPlatformSharedMemoryRegionImpl(
 MojoResult MojoSyncPlatformSharedMemoryRegionImpl(
     const MojoSharedBufferGuid* guid,
     size_t offset,
-    size_t sync_size) {
+    size_t sync_size,
+    BrokerCompressionMode compression_mode) {
   return g_core->SyncPlatformSharedMemoryRegion(
-      guid, offset, sync_size);
+      guid, offset, sync_size, compression_mode);
 }
 
 MojoResult MojoSyncPlatformSharedMemoryRegionImpl2d(
     const MojoSharedBufferGuid* guid,
-    size_t offset,
-    size_t sync_size,
     size_t width,
-    size_t stride) {
-  return g_core->SyncPlatformSharedMemoryRegion2d(guid, offset, sync_size,
-                                                  width, stride);
+    size_t height,
+    size_t bytes_per_pixel,
+    size_t offset,
+    size_t stride,
+    BrokerCompressionMode compression_mode) {
+  return g_core->SyncPlatformSharedMemoryRegion2d(guid, width, height, bytes_per_pixel,
+      offset, stride, compression_mode);
 }
 
 MojoResult MojoWaitSyncPlatformSharedMemoryRegionImpl(

--- a/mojo/core/node_controller.cc
+++ b/mojo/core/node_controller.cc
@@ -355,9 +355,10 @@ base::WritableSharedMemoryRegion NodeController::CreateSharedBuffer(
 bool NodeController::SyncSharedBuffer(
     const base::UnguessableToken& guid,
     size_t offset,
-    size_t sync_size) {
+    size_t sync_size,
+    BrokerCompressionMode compression_mode) {
   if (broker_)
-    return broker_->SyncSharedBuffer(guid, offset, sync_size);
+    return broker_->SyncSharedBuffer(guid, offset, sync_size, compression_mode);
 
   base::CastanetsMemorySyncer* syncer =
       base::SharedMemoryTracker::GetInstance()->GetSyncer(guid);
@@ -383,14 +384,17 @@ bool NodeController::SyncSharedBuffer(
 }
 
 bool NodeController::SyncSharedBuffer2d(const base::UnguessableToken& guid,
-                                        size_t offset,
-                                        size_t sync_size,
                                         size_t width,
-                                        size_t stride) {
+                                        size_t height,
+                                        size_t bytes_per_pixel,
+                                        size_t offset,
+                                        size_t stride,
+                                        BrokerCompressionMode compression_mode) {
   // If broker_ is null, it means the current process is a browser process.
   // The browser process isn't likely to send tile data.
   CHECK(broker_);
-  return broker_->SyncSharedBuffer2d(guid, offset, sync_size, width, stride);
+  return broker_->SyncSharedBuffer2d(
+      guid, width, height, bytes_per_pixel, offset, stride, compression_mode);
 }
 
 scoped_refptr<base::SyncDelegate> NodeController::GetSyncDelegate(

--- a/mojo/core/node_controller.h
+++ b/mojo/core/node_controller.h
@@ -31,6 +31,10 @@
 #include "mojo/core/system_impl_export.h"
 #include "mojo/public/cpp/platform/platform_handle.h"
 
+#if defined(CASTANETS)
+#include "mojo/public/c/system/sync.h"
+#endif
+
 namespace base {
 class PortProvider;
 #if defined(CASTANETS)
@@ -135,15 +139,18 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
 #if defined(CASTANETS)
   bool SyncSharedBuffer(const base::UnguessableToken& guid,
                         size_t offset,
-                        size_t sync_size);
+                        size_t sync_size,
+                        BrokerCompressionMode compression_mode);
   bool SyncSharedBuffer(base::WritableSharedMemoryMapping& mapping,
                         size_t offset,
                         size_t sync_size);
   bool SyncSharedBuffer2d(const base::UnguessableToken& guid,
-                          size_t offset,
-                          size_t sync_size,
                           size_t width,
-                          size_t stride);
+                          size_t height,
+                          size_t bytes_per_pixel,
+                          size_t offset,
+                          size_t stride,
+                          BrokerCompressionMode compression_mode);
 
   void WaitSyncSharedBuffer(const base::UnguessableToken& guid);
 

--- a/mojo/public/c/system/sync.h
+++ b/mojo/public/c/system/sync.h
@@ -14,17 +14,27 @@
 extern "C" {
 #endif
 
+enum BrokerCompressionMode : uint32_t {
+  NONE,
+  ZLIB,
+  WEBP
+};
+
 MOJO_SYSTEM_EXPORT MojoResult MojoSyncPlatformSharedMemoryRegion(
     const struct MojoSharedBufferGuid* guid,
     size_t offset,
-    size_t sync_size);
+    size_t sync_size,
+    BrokerCompressionMode compression_mode = BrokerCompressionMode::ZLIB);
 
 MOJO_SYSTEM_EXPORT MojoResult
-MojoSyncPlatformSharedMemoryRegion2d(const struct MojoSharedBufferGuid* guid,
-                                     size_t offset,
-                                     size_t sync_size,
-                                     size_t width,
-                                     size_t stride);
+MojoSyncPlatformSharedMemoryRegion2d(
+    const struct MojoSharedBufferGuid* guid,
+    size_t width,
+    size_t height,
+    size_t bytes_per_pixel,
+    size_t offset = 0,
+    size_t stride = 0,
+    BrokerCompressionMode compression_mode = BrokerCompressionMode::WEBP);
 
 MOJO_SYSTEM_EXPORT MojoResult MojoWaitSyncPlatformSharedMemoryRegion(
     const struct MojoSharedBufferGuid* guid);

--- a/mojo/public/c/system/thunks.cc
+++ b/mojo/public/c/system/thunks.cc
@@ -412,19 +412,22 @@ MojoResult MojoUnwrapPlatformSharedMemoryRegion(
 MojoResult MojoSyncPlatformSharedMemoryRegion(
     const struct MojoSharedBufferGuid* guid,
     size_t offset,
-    size_t sync_size) {
+    size_t sync_size,
+    BrokerCompressionMode compression_mode) {
   return INVOKE_THUNK(SyncPlatformSharedMemoryRegion,
-                      guid, offset, sync_size);
+                      guid, offset, sync_size, compression_mode);
 }
 
 MojoResult MojoSyncPlatformSharedMemoryRegion2d(
     const struct MojoSharedBufferGuid* guid,
-    size_t offset,
-    size_t sync_size,
     size_t width,
-    size_t stride) {
-  return INVOKE_THUNK(SyncPlatformSharedMemoryRegion2d, guid, offset, sync_size,
-                      width, stride);
+    size_t height,
+    size_t bytes_per_pixel,
+    size_t offset,
+    size_t stride,
+    BrokerCompressionMode compression_mode) {
+  return INVOKE_THUNK(SyncPlatformSharedMemoryRegion2d, guid, width, height,
+      bytes_per_pixel, offset, stride, compression_mode);
 }
 
 MojoResult MojoWaitSyncPlatformSharedMemoryRegion(

--- a/mojo/public/c/system/thunks.h
+++ b/mojo/public/c/system/thunks.h
@@ -188,13 +188,16 @@ struct MojoSystemThunks {
   MojoResult (*SyncPlatformSharedMemoryRegion)(
       const struct MojoSharedBufferGuid* guid,
       size_t offset,
-      size_t sync_size);
+      size_t sync_size,
+      BrokerCompressionMode compression_mode);
   MojoResult (*SyncPlatformSharedMemoryRegion2d)(
       const struct MojoSharedBufferGuid* guid,
-      size_t offset,
-      size_t sync_size,
       size_t width,
-      size_t stride);
+      size_t height,
+      size_t bytes_per_pixel,
+      size_t offset,
+      size_t stride,
+      BrokerCompressionMode compression_mode);
   MojoResult (*WaitSyncPlatformSharedMemoryRegion)(
       const struct MojoSharedBufferGuid* guid);
 #endif

--- a/mojo/public/cpp/system/sync.cc
+++ b/mojo/public/cpp/system/sync.cc
@@ -11,26 +11,29 @@ namespace mojo {
 
 MojoResult SyncSharedMemory(const base::UnguessableToken& guid,
                             size_t offset,
-                            size_t sync_size) {
+                            size_t sync_size,
+                            BrokerCompressionMode compression_mode) {
   MojoSharedBufferGuid mojo_guid;
   mojo_guid.high = guid.GetHighForSerialization();
   mojo_guid.low = guid.GetLowForSerialization();
 
   return MojoSyncPlatformSharedMemoryRegion(
-      &mojo_guid, offset, sync_size);
+      &mojo_guid, offset, sync_size, compression_mode);
 }
 
 MojoResult SyncSharedMemory2d(const base::UnguessableToken& guid,
-                              size_t offset,
-                              size_t sync_size,
                               size_t width,
-                              size_t stride) {
+                              size_t height,
+                              size_t bytes_per_pixel,
+                              size_t offset,
+                              size_t stride,
+                              BrokerCompressionMode compression_mode) {
   MojoSharedBufferGuid mojo_guid;
   mojo_guid.high = guid.GetHighForSerialization();
   mojo_guid.low = guid.GetLowForSerialization();
 
-  return MojoSyncPlatformSharedMemoryRegion2d(&mojo_guid, offset, sync_size,
-                                              width, stride);
+  return MojoSyncPlatformSharedMemoryRegion2d(&mojo_guid, width, height, bytes_per_pixel,
+                                              offset, stride, compression_mode);
 }
 
 MojoResult WaitSyncSharedMemory(const base::UnguessableToken& guid) {

--- a/mojo/public/cpp/system/sync.h
+++ b/mojo/public/cpp/system/sync.h
@@ -8,20 +8,24 @@
 #include "base/unguessable_token.h"
 #include "mojo/public/c/system/types.h"
 #include "mojo/public/cpp/system/system_export.h"
+#include "mojo/public/c/system/sync.h"
 
 namespace mojo {
 
 MOJO_CPP_SYSTEM_EXPORT MojoResult
 SyncSharedMemory(const base::UnguessableToken& guid,
                  size_t offset,
-                 size_t sync_size);
+                 size_t sync_size,
+                 BrokerCompressionMode compression_mode = BrokerCompressionMode::ZLIB);
 
 MOJO_CPP_SYSTEM_EXPORT MojoResult
 SyncSharedMemory2d(const base::UnguessableToken& guid,
-                   size_t offset,
-                   size_t sync_size,
                    size_t width,
-                   size_t stride);
+                   size_t height,
+                   size_t bytes_per_pixel,
+                   size_t offset = 0,
+                   size_t stride = 0,
+                   BrokerCompressionMode compression_mode = BrokerCompressionMode::WEBP);
 
 MOJO_CPP_SYSTEM_EXPORT MojoResult
 WaitSyncSharedMemory(const base::UnguessableToken& guid);


### PR DESCRIPTION
1. Default compression type is zlib.
2. Apply webp for 256*256 tiles.
3. If the sync size is less than 200 bytes, do not apply
   compression.