### PR TITLE
Process broker messages in a new thread.

### DIFF
--- a/mojo/core/broker_castanets.cc
+++ b/mojo/core/broker_castanets.cc
@@ -129,8 +129,8 @@ void BrokerCastanets::StartChannelOnIOThread(ConnectionParams connection_params,
 
   // Do not apply secure connection for Broker Channel.
   connection_params.SetSecure(false);
-  channel_ = Channel::Create(this, std::move(connection_params),
-                             base::ThreadTaskRunnerHandle::Get());
+  channel_ = Channel::CreateForCastanets(this, std::move(connection_params),
+                                         base::ThreadTaskRunnerHandle::Get());
   channel_->Start();
 
   if (server_endpoint) {

--- a/mojo/core/castanets_fence.cc
+++ b/mojo/core/castanets_fence.cc
@@ -72,6 +72,7 @@ CastanetsFenceQueue::~CastanetsFenceQueue() {
 
 void CastanetsFenceQueue::AddFence(const base::UnguessableToken& guid,
                                    FenceId fence_id) {
+  base::AutoLock lock(lock_);
   if (complete_queue_.empty()) {
     scoped_refptr<CastanetsFence> new_fence =
         CastanetsFence::Create(guid, fence_id);
@@ -87,6 +88,7 @@ void CastanetsFenceQueue::AddFence(const base::UnguessableToken& guid,
 
 void CastanetsFenceQueue::RemoveFence(const base::UnguessableToken& guid,
                                       FenceId fence_id) {
+  base::AutoLock lock(lock_);
   if (fence_queue_.empty()) {
     complete_queue_.push(fence_id);
     return;

--- a/mojo/core/castanets_fence.h
+++ b/mojo/core/castanets_fence.h
@@ -83,6 +83,7 @@ class CastanetsFenceQueue {
   void RemoveFence(const base::UnguessableToken& guid, FenceId fence_id);
 
  private:
+  base::Lock lock_;
   FenceQueue fence_queue_;
   base::queue<FenceId> complete_queue_;
 

--- a/mojo/core/channel.h
+++ b/mojo/core/channel.h
@@ -280,6 +280,11 @@ class MOJO_SYSTEM_IMPL_EXPORT Channel
   }
   const ScopedProcessHandle& remote_process() const { return remote_process_; }
 #if defined(CASTANETS)
+  static scoped_refptr<Channel> CreateForCastanets(
+      Delegate* delegate,
+      ConnectionParams connection_params,
+      scoped_refptr<base::TaskRunner> io_task_runner);
+
   virtual void SetSocket(ConnectionParams connection_params) {}
   virtual void ClearOutgoingMessages() {}
 #endif

--- a/mojo/core/channel_posix.cc
+++ b/mojo/core/channel_posix.cc
@@ -27,6 +27,7 @@
 #if defined(CASTANETS)
 #include "base/memory/castanets_memory_syncer.h"
 #include "base/memory/shared_memory_tracker.h"
+#include "base/task_scheduler/post_task.h"
 #include "mojo/public/cpp/platform/secure_socket_utils_posix.h"
 #include "mojo/public/cpp/platform/tcp_platform_handle_utils.h"
 #include "third_party/boringssl/src/include/openssl/ssl.h"
@@ -348,6 +349,9 @@ class ChannelPosix : public Channel,
   }
 
  private:
+ #if defined(CASTANETS)
+ protected:
+ #endif
   ~ChannelPosix() override {
     DCHECK(!read_watcher_);
     DCHECK(!write_watcher_);
@@ -865,6 +869,95 @@ class ChannelPosix : public Channel,
   DISALLOW_COPY_AND_ASSIGN(ChannelPosix);
 };
 
+#if defined(CASTANETS)
+class ChannelCastanets : public ChannelPosix {
+ public:
+  ChannelCastanets(Delegate* delegate,
+                   ConnectionParams connection_params,
+                   scoped_refptr<base::TaskRunner> io_task_runner)
+      : ChannelPosix(delegate, std::move(connection_params), io_task_runner),
+        broker_runner_(base::CreateSingleThreadTaskRunnerWithTraits(
+            {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+            base::SingleThreadTaskRunnerThreadMode::DEDICATED)) {}
+
+ private:
+  ~ChannelCastanets() override {};
+
+  void OnFileCanReadWithoutBlocking(int fd) override {
+    if (server_.is_valid()) {
+      CHECK_EQ(fd, server_.platform_handle().GetFD().get());
+#if !defined(OS_NACL)
+      read_watcher_.reset();
+      base::MessageLoopCurrent::Get()->RemoveDestructionObserver(this);
+
+      TCPServerAcceptConnection(server_.platform_handle().GetFD().get(),
+                                &socket_);
+
+      ignore_result(server_.TakePlatformHandle());
+      if (!socket_.is_valid()) {
+        OnError(Error::kConnectionFailed);
+        return;
+      }
+      StartOnIOThread();
+#else
+      NOTREACHED();
+#endif
+      return;
+    }
+    CHECK_EQ(fd, socket_.get());
+
+    broker_runner_->PostTask(
+        FROM_HERE,
+        base::BindOnce(&ChannelCastanets::ReadFDWithoutBlocking, this));
+  }
+
+  void ReadFDWithoutBlocking() {
+    bool validation_error = false;
+    bool read_error = false;
+    size_t next_read_size = 0;
+    size_t buffer_capacity = 0;
+    size_t total_bytes_read = 0;
+    size_t bytes_read = 0;
+    do {
+      buffer_capacity = next_read_size;
+      char* buffer = GetReadBuffer(&buffer_capacity);
+      DCHECK_GT(buffer_capacity, 0u);
+
+      std::vector<base::ScopedFD> incoming_fds;
+      ssize_t read_result = 0;
+      read_result = SocketRecvmsg(socket_.get(), buffer, buffer_capacity,
+                                  &incoming_fds);
+      for (auto& fd : incoming_fds)
+        incoming_fds_.emplace_back(std::move(fd));
+
+      if (read_result > 0) {
+        bytes_read = static_cast<size_t>(read_result);
+        total_bytes_read += bytes_read;
+        if (!OnReadComplete(bytes_read, &next_read_size)) {
+          read_error = true;
+          validation_error = true;
+          break;
+        }
+      } else if (read_result == 0 ||
+                 (errno != EAGAIN && errno != EWOULDBLOCK)) {
+        read_error = true;
+        break;
+      }
+    } while (bytes_read == buffer_capacity &&
+             total_bytes_read < kMaxBatchReadCapacity && next_read_size > 0);
+    if (read_error) {
+      // Stop receiving read notifications.
+      read_watcher_.reset();
+      if (validation_error)
+        OnError(Error::kReceivedMalformedData);
+      else
+        OnError(Error::kDisconnected);
+    }
+  }
+
+  scoped_refptr<base::SingleThreadTaskRunner> broker_runner_;
+};
+#endif
 }  // namespace
 
 // static
@@ -875,6 +968,16 @@ scoped_refptr<Channel> Channel::Create(
   return new ChannelPosix(delegate, std::move(connection_params),
                           io_task_runner);
 }
+
+#if defined(CASTANETS)
+scoped_refptr<Channel> Channel::CreateForCastanets(
+    Delegate* delegate,
+    ConnectionParams connection_params,
+    scoped_refptr<base::TaskRunner> io_task_runner) {
+  return new ChannelCastanets(delegate, std::move(connection_params),
+                              io_task_runner);
+}
+#endif
 
 }  // namespace core
 }  // namespace mojo


### PR DESCRIPTION
Castanets has read messages from broker channels and handled time-consuming tasks like BUFFER_SYNC in the IO thread. This PR allows broker channel messages to be processed in a separate thread to improve performance.