### PR TITLE
Modify TCP connection for the audio feature.

### DIFF
--- a/content/renderer/media/audio/mojo_audio_output_ipc.h
+++ b/content/renderer/media/audio/mojo_audio_output_ipc.h
@@ -18,6 +18,9 @@
 #include "media/audio/audio_output_ipc.h"
 #include "media/mojo/interfaces/audio_data_pipe.mojom.h"
 #include "mojo/public/cpp/bindings/binding.h"
+#if defined(CASTANETS)
+#include "mojo/public/cpp/system/platform_handle.h"
+#endif
 
 namespace content {
 
@@ -83,7 +86,10 @@ class CONTENT_EXPORT MojoAudioOutputIPC
 #if defined(CASTANETS)
   void RequestTCPConnectCallback(
       base::UnsafeSharedMemoryRegion shared_memory_region,
-      int32_t port);
+      mojo::PlatformHandle server_handle,
+      uint16_t assigned_port);
+
+  bool IsTCPServer();
 #endif
 
   const FactoryAccessorCB factory_accessor_;

--- a/media/mojo/interfaces/audio_output_stream.mojom
+++ b/media/mojo/interfaces/audio_output_stream.mojom
@@ -27,7 +27,7 @@ interface AudioOutputStream {
   [EnableIf=castanets]
   // CASTANETS: Request to create a TCP connection if the connection using
   // SyncSocket fails.
-  RequestTCPConnect() => (int32 port);
+  RequestTCPConnect(uint16 port) => (uint16 assigned_port);
 };
 
 // An AudioOutputStreamObserver gets notifications about events related to an

--- a/media/mojo/services/BUILD.gn
+++ b/media/mojo/services/BUILD.gn
@@ -81,6 +81,7 @@ component("services") {
 
   public_deps = [
     "//base",
+    "//base:base_static",
     "//media",
     "//media/gpu",
     "//media/gpu/ipc/common",

--- a/media/mojo/services/mojo_audio_output_stream.h
+++ b/media/mojo/services/mojo_audio_output_stream.h
@@ -48,7 +48,8 @@ class MEDIA_MOJO_EXPORT MojoAudioOutputStream
   void Pause() override;
   void SetVolume(double volume) override;
 #if defined(CASTANETS)
-  void RequestTCPConnect(RequestTCPConnectCallback callback) override;
+  void RequestTCPConnect(uint16_t assigned_port,
+                         RequestTCPConnectCallback callback) override;
 #endif
 
   // AudioOutputDelegate::EventHandler implementation.

--- a/services/audio/output_stream.h
+++ b/services/audio/output_stream.h
@@ -63,7 +63,8 @@ class OutputStream final : public media::mojom::AudioOutputStream,
   void Pause() final;
   void SetVolume(double volume) final;
 #if defined(CASTANETS)
-  void RequestTCPConnect(RequestTCPConnectCallback callback) final {}
+  void RequestTCPConnect(uint16_t assigned_port,
+                         RequestTCPConnectCallback callback) final {}
 #endif
 
   // OutputController::EventHandler implementation.


### PR DESCRIPTION
Renderer process can be TCP server since the below patch.
"Support both server and client TCP sockets on all processes"

So the audio feature also supports both server and client TCP sockets
on all processes.

Signed-off-by: Sunwoo Nam <sunny.nam@samsung.com>