### PR TITLE
fixup! [DWE] Fixed SVACE and Coverity issues

### DIFF
--- a/third_party/meerkat/Component/mmSOCK/pTcpClient.cpp
+++ b/third_party/meerkat/Component/mmSOCK/pTcpClient.cpp
@@ -123,9 +123,6 @@ BOOL CpTcpClient::Stop(OSAL_Socket_Handle iSock) {
  * @remarks       this method is not used in this project
  */
 BOOL CpTcpClient::Close() {
-  __OSAL_Event_Destroy(&m_hTerminateEvent);
-  __OSAL_Mutex_Destroy(&m_hTerminateMutex);
-  __OSAL_Socket_DeInitEvent(m_hListenerEvent);
   return TRUE;
 }
 

--- a/third_party/meerkat/Component/mmSOCK/pTcpServer.cpp
+++ b/third_party/meerkat/Component/mmSOCK/pTcpServer.cpp
@@ -67,9 +67,6 @@ VOID CpAcceptSock::Activate(OSAL_Socket_Handle iSock,
 VOID CpAcceptSock::DeActivate() {
   __OSAL_Event_Send(&m_hTerminateEvent);
   CbTask::StopMainLoop();
-  __OSAL_Event_Destroy(&m_hTerminateEvent);
-  __OSAL_Mutex_Destroy(&m_hTerminateMutex);
-  __OSAL_Socket_DeInitEvent(m_hListenerEvent);
 }
 
 VOID CpAcceptSock::OnReceive(OSAL_Socket_Handle iEventSock,


### PR DESCRIPTION
All memeber of socket are will created or deleted only in ctor/dtor.
This patch removes redundant codes.

Signed-off-by: DongJun Kim <djmix.kim@samsung.com>