### PR TITLE
Enable GpuCompositing on android.

### DIFF
--- a/chrome/browser/android/vr/arcore_device/ar_image_transport.cc
+++ b/chrome/browser/android/vr/arcore_device/ar_image_transport.cc
@@ -70,6 +70,7 @@ GLuint ArImageTransport::GetCameraTextureId() {
 
 void ArImageTransport::ResizeSharedBuffer(const gfx::Size& size,
                                           vr::WebXrSharedBuffer* buffer) {
+#if !defined(CASTANETS)
   DCHECK(IsOnGlThread());
 
   if (buffer->size == size)
@@ -123,6 +124,7 @@ void ArImageTransport::ResizeSharedBuffer(const gfx::Size& size,
   DVLOG(1) << __FUNCTION__ << ": resized to " << size.width() << "x"
            << size.height();
   buffer->size = size;
+#endif
 }
 
 std::unique_ptr<vr::WebXrSharedBuffer> ArImageTransport::CreateBuffer() {

--- a/chrome/browser/android/vr/gvr_scheduler_delegate.cc
+++ b/chrome/browser/android/vr/gvr_scheduler_delegate.cc
@@ -991,6 +991,7 @@ void GvrSchedulerDelegate::WebXrPrepareSharedBuffer() {
 void GvrSchedulerDelegate::WebXrCreateOrResizeSharedBufferImage(
     WebXrSharedBuffer* buffer,
     const gfx::Size& size) {
+#if !defined(CASTANETS)
   TRACE_EVENT0("gpu", __func__);
   // Unbind previous image (if any).
   if (!buffer->mailbox_holder.mailbox.IsZero()) {
@@ -1037,6 +1038,7 @@ void GvrSchedulerDelegate::WebXrCreateOrResizeSharedBufferImage(
   glBindTexture(GL_TEXTURE_EXTERNAL_OES, buffer->local_texture);
   img->BindTexImage(GL_TEXTURE_EXTERNAL_OES);
   buffer->local_glimage = std::move(img);
+#endif
 }
 
 base::TimeDelta GvrSchedulerDelegate::GetPredictedFrameTime() {

--- a/content/app/content_main_runner_impl.cc
+++ b/content/app/content_main_runner_impl.cc
@@ -79,6 +79,7 @@
 #include "ui/gfx/switches.h"
 
 #if defined(CASTANETS)
+#include "gpu/config/gpu_switches.h"
 #include "ui/gl/gl_switches.h"
 #endif
 
@@ -696,7 +697,8 @@ int ContentMainRunnerImpl::Initialize(const ContentMainParams& params) {
                                                             "en-US");
   base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
       switches::kNumRasterThreads, "4");
-
+  base::CommandLine::ForCurrentProcess()->AppendSwitch(
+      switches::kIgnoreGpuBlacklist);
   base::CommandLine::ForCurrentProcess()->AppendSwitch(
       switches::kDisallowNonExactResourceReuse);
 

--- a/content/browser/android/content_startup_flags.cc
+++ b/content/browser/android/content_startup_flags.cc
@@ -36,12 +36,12 @@ void SetContentCommandLineFlags(bool single_process) {
   base::CommandLine::ForCurrentProcess()->AppendSwitch(
       service_manager::switches::kNoSandbox);
   base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoZygote);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      switches::kDisableGpuCompositing);
   base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
       switches::kNumRasterThreads, "4");
   base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
       switches::kLang, "en-US");
+  base::CommandLine::ForCurrentProcess()->AppendSwitch(
+      switches::kIgnoreGpuBlacklist);
 #endif
   if (single_process) {
     // Need to ensure the command line flag is consistent as a lot of chrome

--- a/gpu/ipc/common/BUILD.gn
+++ b/gpu/ipc/common/BUILD.gn
@@ -109,6 +109,12 @@ source_set("ipc_common_sources") {
       "gpu_memory_buffer_impl_android_hardware_buffer.cc",
       "gpu_memory_buffer_impl_android_hardware_buffer.h",
     ]
+    if (enable_castanets) {
+      sources -= [
+        "gpu_memory_buffer_impl_android_hardware_buffer.cc",
+        "gpu_memory_buffer_impl_android_hardware_buffer.h",
+      ]
+    }
     visibility += [ "//media/gpu:gpu" ]
   }
 

--- a/gpu/ipc/common/gpu_memory_buffer_support.cc
+++ b/gpu/ipc/common/gpu_memory_buffer_support.cc
@@ -52,7 +52,7 @@ gfx::GpuMemoryBufferType
 GpuMemoryBufferSupport::GetNativeGpuMemoryBufferType() {
 #if defined(OS_MACOSX)
   return gfx::IO_SURFACE_BUFFER;
-#elif defined(OS_ANDROID)
+#elif defined(OS_ANDROID) && !defined(CASTANETS)
   return gfx::ANDROID_HARDWARE_BUFFER;
 #elif defined(OS_LINUX) || defined(USE_OZONE)
   return gfx::NATIVE_PIXMAP;
@@ -178,7 +178,7 @@ GpuMemoryBufferSupport::CreateGpuMemoryBufferImplFromHandle(
       return GpuMemoryBufferImplDXGI::CreateFromHandle(
           std::move(handle), size, format, usage, std::move(callback));
 #endif
-#if defined(OS_ANDROID)
+#if defined(OS_ANDROID)  && !defined(CASTANETS)
     case gfx::ANDROID_HARDWARE_BUFFER:
       return GpuMemoryBufferImplAndroidHardwareBuffer::CreateFromHandle(
           std::move(handle), size, format, usage, std::move(callback));

--- a/gpu/ipc/common/surface_handle.h
+++ b/gpu/ipc/common/surface_handle.h
@@ -31,8 +31,13 @@ namespace gpu {
 //
 // TODO(fuchsia): Figure out the right approach for Fuchsia.
 #if defined(GPU_SURFACE_HANDLE_IS_ACCELERATED_WINDOW)
+#if defined(CASTANETS)
+using SurfaceHandle = int32_t;
+constexpr SurfaceHandle kNullSurfaceHandle = 0;
+#else
 using SurfaceHandle = gfx::AcceleratedWidget;
 constexpr SurfaceHandle kNullSurfaceHandle = gfx::kNullAcceleratedWidget;
+#endif
 #elif defined(OS_ANDROID) || defined(OS_NACL) || defined(OS_FUCHSIA)
 using SurfaceHandle = int32_t;
 constexpr SurfaceHandle kNullSurfaceHandle = 0;

--- a/gpu/ipc/service/BUILD.gn
+++ b/gpu/ipc/service/BUILD.gn
@@ -111,6 +111,12 @@ jumbo_component("service") {
       "stream_texture_android.cc",
       "stream_texture_android.h",
     ]
+    if (enable_castanets) {
+      sources -= [
+        "gpu_memory_buffer_factory_android_hardware_buffer.cc",
+        "gpu_memory_buffer_factory_android_hardware_buffer.h",
+      ]
+    }
     libs += [ "android" ]
   }
   if (is_linux) {

--- a/gpu/ipc/service/gpu_memory_buffer_factory.cc
+++ b/gpu/ipc/service/gpu_memory_buffer_factory.cc
@@ -32,7 +32,7 @@ GpuMemoryBufferFactory::CreateNativeType(
     viz::VulkanContextProvider* vulkan_context_provider) {
 #if defined(OS_MACOSX)
   return std::make_unique<GpuMemoryBufferFactoryIOSurface>();
-#elif defined(OS_ANDROID)
+#elif defined(OS_ANDROID) && !defined(CASTANETS)
   return std::make_unique<GpuMemoryBufferFactoryAndroidHardwareBuffer>();
 #elif defined(OS_LINUX) || defined(OS_FUCHSIA)
   return std::make_unique<GpuMemoryBufferFactoryNativePixmap>(

--- a/ui/gfx/BUILD.gn
+++ b/ui/gfx/BUILD.gn
@@ -567,7 +567,7 @@ jumbo_source_set("memory_buffer_sources") {
     public_deps += [ "//ipc:message_support" ]
   }
 
-  if ((is_linux || use_ozone) && !is_nacl) {
+  if ((is_linux || use_ozone || enable_castanets) && !is_nacl) {
     sources += [
       "native_pixmap_handle.cc",
       "native_pixmap_handle.h",

--- a/ui/gfx/gpu_memory_buffer.h
+++ b/ui/gfx/gpu_memory_buffer.h
@@ -16,7 +16,7 @@
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/gfx_export.h"
 
-#if defined(USE_OZONE) || defined(OS_LINUX)
+#if defined(USE_OZONE) || defined(OS_LINUX) || defined(CASTANETS)
 #include "ui/gfx/native_pixmap_handle.h"
 #elif defined(OS_MACOSX) && !defined(OS_IOS)
 #include "ui/gfx/mac/io_surface.h"
@@ -65,7 +65,7 @@ struct GFX_EXPORT GpuMemoryBufferHandle {
   base::UnsafeSharedMemoryRegion region;
   uint32_t offset;
   int32_t stride;
-#if defined(OS_LINUX) || defined(OS_FUCHSIA)
+#if defined(OS_LINUX) || defined(OS_FUCHSIA) || defined(CASTANETS)
   NativePixmapHandle native_pixmap_handle;
 #elif defined(OS_MACOSX) && !defined(OS_IOS)
   ScopedRefCountedIOSurfaceMachPort mach_port;

--- a/ui/gfx/ipc/gfx_param_traits_macros.h
+++ b/ui/gfx/ipc/gfx_param_traits_macros.h
@@ -18,7 +18,7 @@
 #include "ui/gfx/selection_bound.h"
 #include "ui/gfx/swap_result.h"
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(CASTANETS)
 #include "ui/gfx/native_pixmap_handle.h"
 #endif
 
@@ -51,7 +51,7 @@ IPC_STRUCT_TRAITS_BEGIN(gfx::GpuMemoryBufferHandle)
   IPC_STRUCT_TRAITS_MEMBER(region)
   IPC_STRUCT_TRAITS_MEMBER(offset)
   IPC_STRUCT_TRAITS_MEMBER(stride)
-#if defined(OS_LINUX) || defined(OS_FUCHSIA)
+#if defined(OS_LINUX) || defined(OS_FUCHSIA) || defined(CASTANETS)
   IPC_STRUCT_TRAITS_MEMBER(native_pixmap_handle)
 #elif defined(OS_MACOSX)
   IPC_STRUCT_TRAITS_MEMBER(mach_port)
@@ -66,7 +66,7 @@ IPC_STRUCT_TRAITS_BEGIN(gfx::GpuMemoryBufferId)
   IPC_STRUCT_TRAITS_MEMBER(id)
 IPC_STRUCT_TRAITS_END()
 
-#if defined(OS_LINUX) || defined(OS_FUCHSIA)
+#if defined(OS_LINUX) || defined(OS_FUCHSIA) || defined(CASTANETS)
 IPC_STRUCT_TRAITS_BEGIN(gfx::NativePixmapPlane)
   IPC_STRUCT_TRAITS_MEMBER(stride)
   IPC_STRUCT_TRAITS_MEMBER(offset)

--- a/ui/gfx/mojo/BUILD.gn
+++ b/ui/gfx/mojo/BUILD.gn
@@ -28,6 +28,9 @@ mojom("mojo") {
   if (is_linux || use_ozone) {
     enabled_features = [ "supports_native_pixmap" ]
   }
+  if (is_android && !enable_castanets) {
+    enabled_features += [ "use_android_buffer" ]
+  }
 }
 
 mojom("test_interfaces") {

--- a/ui/gfx/mojo/buffer_types.mojom
+++ b/ui/gfx/mojo/buffer_types.mojom
@@ -70,7 +70,7 @@ struct NativePixmapHandle {
   uint32 buffer_index;
 };
 
-[EnableIf=is_android]
+[EnableIf=use_android_buffer]
 struct AHardwareBufferHandle {
   // The actual file descriptor used to wrap the AHardwareBuffer object for
   // serialization.
@@ -96,7 +96,7 @@ union GpuMemoryBufferPlatformHandle {
   [EnableIf=is_win]
   handle dxgi_handle;
 
-  [EnableIf=is_android]
+  [EnableIf=use_android_buffer]
   AHardwareBufferHandle android_hardware_buffer_handle;
 };
 

--- a/ui/gfx/mojo/buffer_types_struct_traits.cc
+++ b/ui/gfx/mojo/buffer_types_struct_traits.cc
@@ -106,7 +106,7 @@ gfx::mojom::GpuMemoryBufferPlatformHandlePtr StructTraits<
       break;
 #endif
     case gfx::ANDROID_HARDWARE_BUFFER: {
-#if defined(OS_ANDROID)
+#if defined(OS_ANDROID) && !defined(CASTANETS)
       // We must keep a ref to the AHardwareBuffer alive until the receiver has
       // acquired its own reference. We do this by sending a message pipe handle
       // along with the buffer. When the receiver deserializes (or even if they
@@ -189,7 +189,7 @@ bool StructTraits<gfx::mojom::GpuMemoryBufferHandleDataView,
       out->dxgi_handle = IPC::PlatformFileForTransit(handle);
       return true;
     }
-#elif defined(OS_ANDROID)
+#elif defined(OS_ANDROID) && !defined(CASTANETS)
     case gfx::mojom::GpuMemoryBufferPlatformHandleDataView::Tag::
         ANDROID_HARDWARE_BUFFER_HANDLE: {
       out->type = gfx::ANDROID_HARDWARE_BUFFER;

--- a/ui/gfx/native_pixmap_handle.cc
+++ b/ui/gfx/native_pixmap_handle.cc
@@ -31,7 +31,7 @@ NativePixmapPlane::NativePixmapPlane() : stride(0), offset(0), size(0) {}
 NativePixmapPlane::NativePixmapPlane(int stride,
                                      int offset,
                                      uint64_t size
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(CASTANETS)
                                      ,
                                      base::ScopedFD fd
 #elif defined(OS_FUCHSIA)
@@ -42,7 +42,7 @@ NativePixmapPlane::NativePixmapPlane(int stride,
     : stride(stride),
       offset(offset),
       size(size)
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(CASTANETS)
       ,
       fd(std::move(fd))
 #elif defined(OS_FUCHSIA)
@@ -70,7 +70,7 @@ NativePixmapHandle& NativePixmapHandle::operator=(NativePixmapHandle&& other) =
 NativePixmapHandle CloneHandleForIPC(const NativePixmapHandle& handle) {
   NativePixmapHandle clone;
   for (auto& plane : handle.planes) {
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(CASTANETS)
     DCHECK(plane.fd.is_valid());
     base::ScopedFD fd_dup(HANDLE_EINTR(dup(plane.fd.get())));
     if (!fd_dup.is_valid()) {

--- a/ui/gfx/native_pixmap_handle.h
+++ b/ui/gfx/native_pixmap_handle.h
@@ -15,7 +15,7 @@
 #include "build/build_config.h"
 #include "ui/gfx/gfx_export.h"
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(CASTANETS)
 #include "base/files/scoped_file.h"
 #endif
 
@@ -32,7 +32,7 @@ struct GFX_EXPORT NativePixmapPlane {
   NativePixmapPlane(int stride,
                     int offset,
                     uint64_t size
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(CASTANETS)
                     ,
                     base::ScopedFD fd
 #elif defined(OS_FUCHSIA)
@@ -53,7 +53,7 @@ struct GFX_EXPORT NativePixmapPlane {
   // This is necessary to map the buffers.
   uint64_t size;
 
-#if defined(OS_LINUX)
+#if defined(OS_LINUX) || defined(CASTANETS)
   // File descriptor for the underlying memory object (usually dmabuf).
   base::ScopedFD fd;
 #elif defined(OS_FUCHSIA)


### PR DESCRIPTION
1. GpuMemoryBufferHandle: Do not use AHardwareBufferHandle for castanets.
2. Ignore GpuBlackList, this causes serialization error as the list
   quantity is different between linux, android.
3. Unify datatypes for SurfaceHandle in linux, android.

Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>