### PR TITLE
Allow the  node channel to connect using ssl

### DIFF
--- a/base/base_switches.cc
+++ b/base/base_switches.cc
@@ -143,6 +143,8 @@ const char kEnableForking[] = "enable-forking";
 const char kServerAddress[] = "server-address";
 
 const char kTcpLaunchTimeout[] = "tcp-launch-timeout";
+
+const char kSecureConnection[] = "secure-connection";
 #endif
 
 }  // namespace switches

--- a/base/base_switches.h
+++ b/base/base_switches.h
@@ -57,6 +57,7 @@ extern const char kEnableThreadInstructionCount[];
 extern const char kEnableForking[];
 extern const char kServerAddress[];
 extern const char kTcpLaunchTimeout[];
+extern const char kSecureConnection[];
 #endif
 
 }  // namespace switches

--- a/mojo/core/BUILD.gn
+++ b/mojo/core/BUILD.gn
@@ -162,7 +162,10 @@ template("core_impl_source_set") {
 
     deps = []
     if (enable_castanets) {
-      deps += ["//mojo/public/cpp/platform:platform"]
+      deps += [
+        "//base:base_static",
+        "//mojo/public/cpp/platform:platform",
+      ]
     }
     if (is_android) {
       deps += [ "//third_party/ashmem" ]

--- a/mojo/core/broker_castanets.h
+++ b/mojo/core/broker_castanets.h
@@ -94,8 +94,8 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
                       uint32_t stride,
                       const void* data);
 
-  // Send a port number to the client for TCP socket.
-  bool SendPortNumber(int port);
+  // Send InitData to the client for node channel connection.
+  bool SendBrokerInit(int port, bool secure_connection);
 
   // Send |handle| to the client, to be used to establish a NodeChannel to us.
   bool SendChannel(PlatformHandle handle);
@@ -112,6 +112,8 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
                         size_t payload_size,
                         std::vector<PlatformHandle> handles) override;
   void OnChannelError(Channel::Error error) override;
+
+  bool IsSecureConnection() const { return secure_connection_; }
 
   const ProcessErrorCallback process_error_callback_;
 
@@ -150,6 +152,7 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
                               bool write_lock = true);
 
   bool tcp_connection_ = false;
+  bool secure_connection_ = false;
 
   // Handle to the broker process, used for synchronous IPCs.
   PlatformHandle sync_channel_;

--- a/mojo/core/broker_messages.h
+++ b/mojo/core/broker_messages.h
@@ -60,6 +60,8 @@ struct InitData {
 #endif
 #if defined(CASTANETS)
   uint16_t port;
+  uint16_t secure_connection;  // bool
+  uint32_t padding;
 #endif
 };
 #endif

--- a/mojo/core/connection_params.h
+++ b/mojo/core/connection_params.h
@@ -36,6 +36,14 @@ class MOJO_SYSTEM_IMPL_EXPORT ConnectionParams {
     return std::move(server_endpoint_);
   }
 
+#if defined(CASTANETS)
+  bool is_secure() const { return secure_connection_; }
+  void SetSecure() { secure_connection_ = true; }
+
+ private:
+  bool secure_connection_ = false;
+#endif
+
  private:
   PlatformChannelEndpoint endpoint_;
   PlatformChannelServerEndpoint server_endpoint_;

--- a/mojo/core/node_controller.cc
+++ b/mojo/core/node_controller.cc
@@ -41,6 +41,7 @@
 #endif
 
 #if defined(CASTANETS)
+#include "base/base_switches.h"
 #include "base/memory/castanets_memory_mapping.h"
 #include "base/memory/castanets_memory_syncer.h"
 #include "base/memory/shared_memory_tracker.h"
@@ -491,13 +492,17 @@ void NodeController::SendBrokerClientInvitationOnIOThread(
     node_connection_params =
         ConnectionParams(mojo::PlatformChannelServerEndpoint(
             mojo::PlatformHandle(CreateTCPServerHandle(port, &port))));
+    if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+            switches::kSecureConnection))
+      node_connection_params.SetSecure();
 
     scoped_refptr<BrokerCastanets> broker_host =
         BrokerCastanets::CreateInBrowserProcess(target_process.get(),
                                                 std::move(connection_params),
                                                 process_error_callback,
                                                 fence_manager_.get());
-    channel_ok = broker_host->SendPortNumber(port);
+    channel_ok =
+        broker_host->SendBrokerInit(port, node_connection_params.is_secure());
     base::AutoLock lock(broker_hosts_lock_);
     broker_hosts_.emplace(target_process.get(), broker_host);
   }
@@ -602,6 +607,10 @@ void NodeController::AcceptBrokerClientInvitationOnIOThread(
     // At this point we don't know the inviter's name, so we can't yet insert it
     // into our |peers_| map. That will happen as soon as we receive an
     // AcceptInvitee message from them.
+#if defined(CASTANETS)
+    if (broker_->IsSecureConnection())
+      connection_params.SetSecure();
+#endif
     bootstrap_inviter_channel_ =
         NodeChannel::Create(this, std::move(connection_params),
                             Channel::HandlePolicy::kAcceptHandles,

--- a/mojo/public/cpp/platform/BUILD.gn
+++ b/mojo/public/cpp/platform/BUILD.gn
@@ -35,10 +35,20 @@ component("platform") {
     "//mojo/public/c/system:headers",
   ]
 
-  if(enable_castanets) {
-    public += [ "tcp_platform_handle_utils.h" ]
-    sources += [ "tcp_platform_handle_utils_posix.cc" ]
-    public_deps += [ "//base:base_static" ]
+  if (enable_castanets) {
+    public += [
+      "secure_socket_utils_posix.h",
+      "tcp_platform_handle_utils.h",
+    ]
+    sources += [
+      "secure_socket_utils_posix.cc",
+      "tcp_platform_handle_utils_posix.cc",
+    ]
+    public_deps += [
+      "//base:base_static",
+      "//crypto",
+      "//third_party/boringssl",
+    ]
   }
 
   if (is_posix && !is_nacl) {


### PR DESCRIPTION
This CL adds "--secure-connection" switch to allow the node
channel to connect securely by using BoringSSL.
Temporarily a self-signed certificate file is being used.

* Generate a self-signed certificate file.

Each time Castanets runs with the secure-connection switch, it
generates and uses a self-signed certificate file.

Signed-off-by: Uzair Jaleel <uzair.jaleel@samsung.com>