### PR TITLE
Apply zlib,webp based compression for sync data.

### DIFF
--- a/cc/raster/one_copy_raster_buffer_provider.cc
+++ b/cc/raster/one_copy_raster_buffer_provider.cc
@@ -352,9 +352,9 @@ void OneCopyRasterBufferProvider::PlaybackToStagingBuffer(
 #if defined(CASTANETS)
     if (std::string("renderer") ==
         base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
-      mojo::SyncSharedMemory(
-          buffer->CloneHandle().region.GetGUID(), 0,
-          staging_buffer->size.width() * staging_buffer->size.height() * 4);
+      mojo::SyncSharedMemory2d(
+          buffer->CloneHandle().region.GetGUID(), staging_buffer->size.width(),
+          staging_buffer->size.height(), buffer->stride(0)/staging_buffer->size.width());
     }
 #endif
     buffer->Unmap();

--- a/cc/tiles/tile_manager.cc
+++ b/cc/tiles/tile_manager.cc
@@ -144,18 +144,15 @@ class RasterTaskImpl : public TileTask {
           size_t offset_y =
               (invalid_content_rect_.y() - content_rect_.y()) * bytes_per_pixel;
           size_t linear_offset = offset_x + (offset_y * content_rect_.width());
-
           // Send bytes the size of invalid_content_rect.
-          for (int i = 0; i < invalid_content_rect_.height(); i++) {
-            mojo::SyncSharedMemory(
-                sw_backing->SharedMemoryGuid(), linear_offset,
-                invalid_content_rect_.width() * bytes_per_pixel);
-            linear_offset += content_rect_.width() * bytes_per_pixel;
-          }
+          mojo::SyncSharedMemory2d(
+              sw_backing->SharedMemoryGuid(), invalid_content_rect_.width(),
+              invalid_content_rect_.height(), bytes_per_pixel, linear_offset,
+              content_rect_.width() * bytes_per_pixel);
         } else {
-          mojo::SyncSharedMemory(
-              sw_backing->SharedMemoryGuid(), 0,
-              content_rect_.width() * content_rect_.height() * bytes_per_pixel);
+          mojo::SyncSharedMemory2d(
+              sw_backing->SharedMemoryGuid(),
+              content_rect_.width(), content_rect_.height(), bytes_per_pixel);
         }
       }
     }

--- a/mojo/core/BUILD.gn
+++ b/mojo/core/BUILD.gn
@@ -165,8 +165,12 @@ template("core_impl_source_set") {
       deps += [
         "//base:base_static",
         "//mojo/public/cpp/platform:platform",
+        "//third_party/libwebp:libwebp_dec",
+        "//third_party/libwebp:libwebp_enc",
+        "//third_party/zlib/google:compression_utils",
       ]
     }
+
     if (is_android) {
       deps += [ "//third_party/ashmem" ]
     }

--- a/mojo/core/broker_castanets.cc
+++ b/mojo/core/broker_castanets.cc
@@ -21,6 +21,12 @@
 #include "mojo/public/cpp/platform/socket_utils_posix.h"
 #include "mojo/public/cpp/platform/tcp_platform_handle_utils.h"
 
+#include "third_party/libwebp/src/webp/decode.h"
+#include "third_party/libwebp/src/webp/encode.h"
+#include "third_party/zlib/google/compression_utils.h"
+
+#define COMPRESSION_THRESHOLD_BYTES 200
+
 namespace mojo {
 namespace core {
 
@@ -200,13 +206,14 @@ void BrokerCastanets::SendSyncEvent(
   CHECK(tcp_connection_);
   SyncSharedBufferImpl(mapping_info->guid(),
                        static_cast<uint8_t*>(mapping_info->GetMemory()), offset,
-                       sync_size, mapping_info->mapped_size(), write_lock);
+                       sync_size, mapping_info->mapped_size(), BrokerCompressionMode::ZLIB, write_lock);
 }
 
 bool BrokerCastanets::SyncSharedBuffer(
     const base::UnguessableToken& guid,
     size_t offset,
-    size_t sync_size) {
+    size_t sync_size,
+    BrokerCompressionMode compression_mode) {
   if (!tcp_connection_)
     return true;
 
@@ -215,7 +222,7 @@ bool BrokerCastanets::SyncSharedBuffer(
   if (!mapping)
    return MOJO_RESULT_NOT_FOUND;
   SyncSharedBufferImpl(guid, static_cast<uint8_t*>(mapping->GetMemory()),
-                       offset, sync_size, mapping->mapped_size());
+                       offset, sync_size, mapping->mapped_size(), compression_mode);
   return true;
 }
 
@@ -227,15 +234,17 @@ bool BrokerCastanets::SyncSharedBuffer(
     return true;
 
   SyncSharedBufferImpl(mapping.guid(), static_cast<uint8_t*>(mapping.memory()),
-                       offset, sync_size, mapping.mapped_size());
+                       offset, sync_size, mapping.mapped_size(), BrokerCompressionMode::ZLIB);
   return true;
 }
 
 bool BrokerCastanets::SyncSharedBuffer2d(const base::UnguessableToken& guid,
-                                         size_t offset,
-                                         size_t sync_size,
                                          size_t width,
-                                         size_t stride) {
+                                         size_t height,
+                                         size_t bytes_per_pixel,
+                                         size_t offset,
+                                         size_t stride,
+                                         BrokerCompressionMode compression_mode) {
   if (!tcp_connection_)
     return true;
 
@@ -245,8 +254,8 @@ bool BrokerCastanets::SyncSharedBuffer2d(const base::UnguessableToken& guid,
     return MOJO_RESULT_NOT_FOUND;
 
   SyncSharedBufferImpl2d(guid, static_cast<uint8_t*>(mapping->GetMemory()),
-                         offset, sync_size, mapping->mapped_size(), width,
-                         stride);
+                         mapping->mapped_size(), width, height,
+                         bytes_per_pixel, offset, stride, compression_mode);
   return true;
 }
 
@@ -255,10 +264,38 @@ void BrokerCastanets::SyncSharedBufferImpl(const base::UnguessableToken& guid,
                                            size_t offset,
                                            size_t sync_size,
                                            size_t mapped_size,
+                                           BrokerCompressionMode compression_mode,
                                            bool write_lock) {
   CHECK_GE(mapped_size, offset + sync_size);
   BufferSyncData* buffer_sync = nullptr;
   void* extra_data = nullptr;
+  uint8_t* start_ptr = static_cast <uint8_t*>(memory + offset);
+  uint8_t* compressed_data = nullptr;
+  int original_sync_size = sync_size;
+  std::string compressed;
+  if (sync_size <= COMPRESSION_THRESHOLD_BYTES)
+    compression_mode = NONE;
+
+  switch (compression_mode) {
+    case BrokerCompressionMode::ZLIB: {
+      std::string raw(reinterpret_cast<const char*>(start_ptr), sync_size);
+      compression::GzipCompress(raw, &compressed);
+      VLOG(2) << "ZLIB Compression: Raw Size: " << raw.size()
+              << ", Compressed Size: " << compressed.size();
+      sync_size = compressed.size();
+      compressed_data = reinterpret_cast <uint8_t*>(&compressed[0]);
+      break;
+    }
+    case BrokerCompressionMode::WEBP: {
+      LOG(ERROR) << "Unsupported compression mode";
+      break;
+    }
+    case BrokerCompressionMode::NONE: {
+      compressed_data = static_cast <uint8_t*>(start_ptr);
+      break;
+    }
+  }
+
   Channel::MessagePtr out_message =
       CreateBrokerMessage(BrokerMessageType::BUFFER_SYNC, 0, sync_size,
                           &buffer_sync, &extra_data);
@@ -269,7 +306,9 @@ void BrokerCastanets::SyncSharedBufferImpl(const base::UnguessableToken& guid,
   buffer_sync->offset = offset;
   buffer_sync->sync_bytes = sync_size;
   buffer_sync->buffer_bytes = mapped_size;
-  memcpy(extra_data, memory + offset, sync_size);
+  buffer_sync->compression_mode = compression_mode;
+  memcpy(extra_data, compressed_data, sync_size);
+  buffer_sync->original_size = original_sync_size;
 
   base::AutoLock lock(sync_lock_);
 
@@ -283,13 +322,65 @@ void BrokerCastanets::SyncSharedBufferImpl(const base::UnguessableToken& guid,
 
 void BrokerCastanets::SyncSharedBufferImpl2d(const base::UnguessableToken& guid,
                                              uint8_t* memory,
-                                             size_t offset,
-                                             size_t sync_size,
                                              size_t mapped_size,
                                              size_t width,
+                                             size_t height,
+                                             size_t bytes_per_pixel,
+                                             size_t offset,
                                              size_t stride,
+                                             BrokerCompressionMode compression_mode,
                                              bool write_lock) {
+  size_t sync_size = width * height * bytes_per_pixel;
   CHECK_GE(mapped_size, offset + sync_size);
+  size_t put_bytes = 0;
+  size_t put_offset = offset;
+  uint32_t buffer_stride = width * bytes_per_pixel;
+  uint8_t* start_ptr = nullptr;
+
+  std::vector<uint8_t> bytes(sync_size);
+
+  uint8_t* compressed_data = nullptr;
+  size_t original_sync_size = sync_size;
+
+  switch (compression_mode) {
+    case BrokerCompressionMode::ZLIB: {
+      LOG(ERROR) << "Unsupported compression mode";
+      break;
+    }
+    case BrokerCompressionMode::WEBP: {
+      size_t webp_stride = stride ? stride : buffer_stride;
+      start_ptr = memory + offset;
+      size_t size;
+      size = WebPEncodeLosslessRGBA(start_ptr, width,
+          height, webp_stride, &compressed_data);
+      VLOG(2) << "WEBP Compression: Raw Size: " << sync_size
+              << ", Compressed Size: " << size
+              << ", Buffer width: " << width
+              << ", Buffer height: " << height
+              << ", Buffer stride: " << buffer_stride;
+      sync_size = size;
+      break;
+    }
+    case BrokerCompressionMode::NONE: {
+      if (offset == 0 && stride == 0) {
+        // Full tile
+        start_ptr = memory + offset;
+      } else {
+        // Partial tile
+        start_ptr = memory + offset;
+        while (put_bytes != sync_size) {
+          memcpy(static_cast<uint8_t*>(&bytes[0]) + put_bytes, memory + put_offset,
+                 buffer_stride);
+          put_offset += stride;
+          put_bytes += buffer_stride;
+        }
+        start_ptr = &bytes[0];
+      }
+      compressed_data = static_cast <uint8_t*>(start_ptr);
+      break;
+    }
+  }
+
   BufferSyncData* buffer_sync = nullptr;
   void* extra_data = nullptr;
   Channel::MessagePtr out_message =
@@ -303,18 +394,14 @@ void BrokerCastanets::SyncSharedBufferImpl2d(const base::UnguessableToken& guid,
   buffer_sync->offset = offset;
   buffer_sync->sync_bytes = sync_size;
   buffer_sync->buffer_bytes = mapped_size;
-  buffer_sync->width = width;
+  buffer_sync->width = buffer_stride;
   buffer_sync->stride = stride;
+  buffer_sync->compression_mode = compression_mode;
+  buffer_sync->original_size = original_sync_size;
+  memcpy(extra_data, compressed_data, sync_size);
 
-  size_t put_bytes = 0;
-  size_t put_offset = offset;
-
-  while (put_bytes != sync_size) {
-    memcpy(static_cast<uint8_t*>(extra_data) + put_bytes, memory + put_offset,
-           width);
-    put_offset += stride;
-    put_bytes += width;
-  }
+  if (compression_mode == BrokerCompressionMode::WEBP && compressed_data)
+    WebPFree (compressed_data);
 
   base::AutoLock lock(sync_lock_);
 
@@ -334,6 +421,8 @@ void BrokerCastanets::OnBufferSync(uint64_t guid_high,
                                    uint32_t offset,
                                    uint32_t sync_bytes,
                                    uint32_t buffer_bytes,
+                                   uint32_t original_size,
+                                   uint32_t compression_mode,
                                    const void* data) {
   CHECK(tcp_connection_);
   base::UnguessableToken guid =
@@ -344,17 +433,42 @@ void BrokerCastanets::OnBufferSync(uint64_t guid_high,
           << ", sync_size: " << sync_bytes
           << ", buffer_size: " << buffer_bytes
           << ", fence_id: " << fence_id;
+
+  void* uncompressed_data = nullptr;
+  std::string raw;
+
+  switch (compression_mode) {
+    case BrokerCompressionMode::ZLIB: {
+      std::string compressed (static_cast <const char*>(data), sync_bytes);
+      compression::GzipUncompress(compressed, &raw);
+      VLOG(2) << "ZLIB Decompression: Compressed Size: " << compressed.size()
+              << ", Raw Size: " << raw.size();
+      sync_bytes = raw.size();
+      uncompressed_data = &raw[0];
+      break;
+    }
+    case BrokerCompressionMode::WEBP: {
+      LOG(ERROR) << "Unsupported compression mode";
+      break;
+    }
+    case BrokerCompressionMode::NONE:
+    default: {
+      uncompressed_data = (void*) data;
+      break;
+    }
+  }
+
   scoped_refptr<base::CastanetsMemoryMapping> mapping =
       base::SharedMemoryTracker::GetInstance()->FindMappedMemory(guid);
+
   if (mapping) {
     CHECK_GE(mapping->mapped_size(), offset + sync_bytes);
-    memcpy(static_cast<uint8_t*>(mapping->GetMemory()) + offset,
-           data, sync_bytes);
+    memcpy(static_cast<uint8_t*>(mapping->GetMemory()) + offset, uncompressed_data,
+           sync_bytes);
 
     fence_queue_->RemoveFence(guid, fence_id);
     return;
   }
-
   base::SharedMemoryCreateOptions options;
   options.size = buffer_bytes;
   base::subtle::PlatformSharedMemoryRegion handle =
@@ -364,7 +478,7 @@ void BrokerCastanets::OnBufferSync(uint64_t guid_high,
   void* memory = mmap(NULL, sync_bytes + offset, PROT_READ | PROT_WRITE,
                       MAP_SHARED, handle.GetPlatformHandle().fd, 0);
   uint8_t* ptr = static_cast<uint8_t*>(memory);
-  memcpy(ptr + offset, data, sync_bytes);
+  memcpy(ptr + offset, uncompressed_data, sync_bytes);
   munmap(ptr, sync_bytes + offset);
 
   fence_queue_->RemoveFence(guid, fence_id);
@@ -378,6 +492,8 @@ void BrokerCastanets::OnBufferSync2d(uint64_t guid_high,
                                      uint32_t buffer_bytes,
                                      uint32_t width,
                                      uint32_t stride,
+                                     uint32_t original_size,
+                                     uint32_t compression_mode,
                                      const void* data) {
   CHECK(tcp_connection_);
   base::UnguessableToken guid =
@@ -390,19 +506,65 @@ void BrokerCastanets::OnBufferSync2d(uint64_t guid_high,
           << ", width: " << width << ", stride: " << stride
           << ", fence_id: " << fence_id;
 
+  void* uncompressed_data = nullptr;
+
   scoped_refptr<base::CastanetsMemoryMapping> mapping =
       base::SharedMemoryTracker::GetInstance()->FindMappedMemory(guid);
+  uint8_t* ptr = mapping ? static_cast<uint8_t*>(mapping->GetMemory()) : nullptr;
+  if (!ptr) {
+    base::SharedMemoryCreateOptions options;
+    options.size = buffer_bytes;
+    base::subtle::PlatformSharedMemoryRegion handle =
+        base::CreateAnonymousSharedMemoryIfNeeded(guid, options);
+    CHECK(handle.IsValid());
 
-  CHECK_GE(mapping->mapped_size(), offset + sync_bytes);
-  size_t put_bytes = 0;
-  size_t put_offset = offset;
-  while (put_bytes != sync_bytes) {
-    memcpy(static_cast<uint8_t*>(mapping->GetMemory()) + put_offset,
-           static_cast<const uint8_t*>(data) + put_bytes, width);
-    put_offset += stride;
-    put_bytes += width;
+    void* memory = mmap(NULL, original_size + offset, PROT_READ | PROT_WRITE,
+                        MAP_SHARED, handle.GetPlatformHandle().fd, 0);
+    ptr = static_cast<uint8_t*>(memory);
   }
 
+  switch (compression_mode) {
+    case BrokerCompressionMode::ZLIB: {
+      LOG(ERROR) << "Unsupported compression mode";
+      break;
+    }
+    case BrokerCompressionMode::WEBP: {
+      uint8_t * result = nullptr;
+      size_t output_stride = stride ? stride : width;
+      result = WebPDecodeRGBAInto(static_cast<const uint8_t*>(data), sync_bytes,
+                                  static_cast<uint8_t*>(ptr + offset), buffer_bytes, output_stride);
+      if (result == NULL)
+        LOG(ERROR) << "WEBP Decode failure";
+
+      VLOG(2) << "WEBP Decompression: Compressed Size: " << sync_bytes
+              << ", Raw Size: " << original_size;
+      uncompressed_data =  result;
+      sync_bytes = original_size;
+      break;
+    }
+    case BrokerCompressionMode::NONE:
+    default: {
+      size_t put_bytes = 0;
+      size_t put_offset = offset;
+      uncompressed_data = (void*) data;
+      if (offset == 0 && stride == 0) {
+        // Full tile
+        memcpy(ptr + offset, uncompressed_data, sync_bytes);
+      } else {
+        // Partial tile
+        while (put_bytes != sync_bytes) {
+          memcpy(static_cast<uint8_t*>(ptr + put_offset),
+                 static_cast<const uint8_t*>(uncompressed_data) + put_bytes, width);
+          put_offset += stride;
+          put_bytes += width;
+        }
+      }
+      break;
+    }
+  }
+
+  if (!mapping)
+    munmap(ptr, original_size + offset);
   fence_queue_->RemoveFence(guid, fence_id);
 }
 
@@ -633,7 +795,7 @@ void BrokerCastanets::OnChannelMessage(const void* payload,
           sizeof(BufferSyncData) + sync->sync_bytes)
         OnBufferSync(sync->guid_high, sync->guid_low, sync->fence_id,
                      sync->offset, sync->sync_bytes, sync->buffer_bytes,
-                     sync + 1);
+                     sync->original_size, sync->compression_mode, sync + 1);
       else
         LOG(WARNING) << "Wrong size for sync data";
       break;
@@ -646,7 +808,8 @@ void BrokerCastanets::OnChannelMessage(const void* payload,
                               sync->sync_bytes)
         OnBufferSync2d(sync->guid_high, sync->guid_low, sync->fence_id,
                        sync->offset, sync->sync_bytes, sync->buffer_bytes,
-                       sync->width, sync->stride, sync + 1);
+                       sync->width, sync->stride, sync->original_size,
+                       sync->compression_mode, sync + 1);
       else
         LOG(WARNING) << "Wrong size for sync data";
       break;

--- a/mojo/core/broker_castanets.h
+++ b/mojo/core/broker_castanets.h
@@ -12,6 +12,7 @@
 #include "mojo/core/embedder/process_error_callback.h"
 #include "mojo/core/platform_handle_in_transit.h"
 #include "mojo/public/cpp/platform/platform_channel_endpoint.h"
+#include "mojo/public/cpp/system/sync.h"
 
 namespace mojo {
 namespace core {
@@ -61,7 +62,8 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
 
   bool SyncSharedBuffer(const base::UnguessableToken& guid,
                         size_t offset,
-                        size_t sync_size);
+                        size_t sync_size,
+                        BrokerCompressionMode compression_mode);
 
   bool SyncSharedBuffer(base::WritableSharedMemoryMapping& mapping,
                         size_t offset,
@@ -73,16 +75,20 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
                     uint32_t offset,
                     uint32_t sync_bytes,
                     uint32_t buffer_bytes,
+                    uint32_t original_size,
+                    uint32_t compression_mode,
                     const void* data);
 
   void AddSyncFence(const base::UnguessableToken& guid, uint32_t fence_id);
 
   // Sync 2-dimensional memory for partial rasterization,
   bool SyncSharedBuffer2d(const base::UnguessableToken& guid,
-                          size_t offset,
-                          size_t sync_size,
                           size_t width,
-                          size_t stride);
+                          size_t height,
+                          size_t bytes_per_pixel,
+                          size_t offset,
+                          size_t stride,
+                          BrokerCompressionMode compression_mode);
 
   void OnBufferSync2d(uint64_t guid_high,
                       uint64_t guid_low,
@@ -92,6 +98,8 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
                       uint32_t buffer_bytes,
                       uint32_t width,
                       uint32_t stride,
+                      uint32_t original_size,
+                      uint32_t compression_mode,
                       const void* data);
 
   // Send InitData to the client for node channel connection.
@@ -140,15 +148,18 @@ class BrokerCastanets : public Channel::Delegate, public base::SyncDelegate {
                             size_t offset,
                             size_t sync_size,
                             size_t mapped_size,
+                            BrokerCompressionMode compression_mode = BrokerCompressionMode::ZLIB,
                             bool write_lock = true);
 
   void SyncSharedBufferImpl2d(const base::UnguessableToken& guid,
                               uint8_t* memory,
-                              size_t offset,
-                              size_t sync_size,
                               size_t mapped_size,
                               size_t width,
+                              size_t height,
+                              size_t bytes_per_pixel,
+                              size_t offset,
                               size_t stride,
+                              BrokerCompressionMode compression_mode = BrokerCompressionMode::WEBP,
                               bool write_lock = true);
 
   bool tcp_connection_ = false;

--- a/mojo/core/broker_messages.h
+++ b/mojo/core/broker_messages.h
@@ -48,6 +48,8 @@ struct BufferSyncData {
   uint32_t buffer_bytes;
   uint32_t width;
   uint32_t stride;
+  uint32_t compression_mode;
+  uint32_t original_size;
 };
 
 #if defined(OS_WIN) || defined(CASTANETS)

--- a/mojo/core/core.cc
+++ b/mojo/core/core.cc
@@ -1197,12 +1197,12 @@ MojoResult Core::UnwrapPlatformSharedMemoryRegion(
 MojoResult Core::SyncPlatformSharedMemoryRegion(
     const MojoSharedBufferGuid* guid,
     size_t offset,
-    size_t sync_size) {
+    size_t sync_size,
+    BrokerCompressionMode compression_mode) {
   DCHECK(sync_size);
   const base::UnguessableToken& token =
       base::UnguessableToken::Deserialize(guid->high, guid->low);
-
-  if (!GetNodeController()->SyncSharedBuffer(token, offset, sync_size))
+  if (!GetNodeController()->SyncSharedBuffer(token, offset, sync_size, compression_mode))
       return MOJO_RESULT_UNKNOWN;
 
   return MOJO_RESULT_OK;
@@ -1210,15 +1210,16 @@ MojoResult Core::SyncPlatformSharedMemoryRegion(
 
 MojoResult Core::SyncPlatformSharedMemoryRegion2d(
     const MojoSharedBufferGuid* guid,
-    size_t offset,
-    size_t sync_size,
     size_t width,
-    size_t stride) {
-  DCHECK(sync_size);
+    size_t height,
+    size_t bytes_per_pixel,
+    size_t offset,
+    size_t stride,
+    BrokerCompressionMode compression_mode) {
   const base::UnguessableToken& token =
       base::UnguessableToken::Deserialize(guid->high, guid->low);
-  if (!GetNodeController()->SyncSharedBuffer2d(token, offset, sync_size, width,
-                                               stride))
+  if (!GetNodeController()->SyncSharedBuffer2d(token, width, height, bytes_per_pixel,
+                                               offset, stride, compression_mode))
     return MOJO_RESULT_UNKNOWN;
 
   return MOJO_RESULT_OK;

--- a/mojo/core/core.h
+++ b/mojo/core/core.h
@@ -30,6 +30,10 @@
 #include "mojo/public/c/system/trap.h"
 #include "mojo/public/c/system/types.h"
 
+#if defined(CASTANETS)
+#include "mojo/public/c/system/sync.h"
+#endif
+
 namespace base {
 class PortProvider;
 }
@@ -308,12 +312,15 @@ class MOJO_SYSTEM_IMPL_EXPORT Core {
   MojoResult SyncPlatformSharedMemoryRegion(
       const MojoSharedBufferGuid* guid,
       size_t offset,
-      size_t sync_size);
+      size_t sync_size,
+      BrokerCompressionMode compression_mode);
   MojoResult SyncPlatformSharedMemoryRegion2d(const MojoSharedBufferGuid* guid,
-                                              size_t offset,
-                                              size_t sync_size,
                                               size_t width,
-                                              size_t stride);
+                                              size_t height,
+                                              size_t bytes_per_pixel,
+                                              size_t offset,
+                                              size_t stride,
+                                              BrokerCompressionMode compression_mode);
   MojoResult WaitSyncPlatformSharedMemoryRegion(
       const MojoSharedBufferGuid* guid);
 #endif

--- a/mojo/core/entrypoints.cc
+++ b/mojo/core/entrypoints.cc
@@ -288,19 +288,22 @@ MojoResult MojoUnwrapPlatformSharedMemoryRegionImpl(
 MojoResult MojoSyncPlatformSharedMemoryRegionImpl(
     const MojoSharedBufferGuid* guid,
     size_t offset,
-    size_t sync_size) {
+    size_t sync_size,
+    BrokerCompressionMode compression_mode) {
   return g_core->SyncPlatformSharedMemoryRegion(
-      guid, offset, sync_size);
+      guid, offset, sync_size, compression_mode);
 }
 
 MojoResult MojoSyncPlatformSharedMemoryRegionImpl2d(
     const MojoSharedBufferGuid* guid,
-    size_t offset,
-    size_t sync_size,
     size_t width,
-    size_t stride) {
-  return g_core->SyncPlatformSharedMemoryRegion2d(guid, offset, sync_size,
-                                                  width, stride);
+    size_t height,
+    size_t bytes_per_pixel,
+    size_t offset,
+    size_t stride,
+    BrokerCompressionMode compression_mode) {
+  return g_core->SyncPlatformSharedMemoryRegion2d(guid, width, height, bytes_per_pixel,
+      offset, stride, compression_mode);
 }
 
 MojoResult MojoWaitSyncPlatformSharedMemoryRegionImpl(

--- a/mojo/core/node_controller.cc
+++ b/mojo/core/node_controller.cc
@@ -351,9 +351,10 @@ base::WritableSharedMemoryRegion NodeController::CreateSharedBuffer(
 bool NodeController::SyncSharedBuffer(
     const base::UnguessableToken& guid,
     size_t offset,
-    size_t sync_size) {
+    size_t sync_size,
+    BrokerCompressionMode compression_mode) {
   if (broker_)
-    return broker_->SyncSharedBuffer(guid, offset, sync_size);
+    return broker_->SyncSharedBuffer(guid, offset, sync_size, compression_mode);
 
   base::CastanetsMemorySyncer* syncer =
       base::SharedMemoryTracker::GetInstance()->GetSyncer(guid);
@@ -381,14 +382,17 @@ bool NodeController::SyncSharedBuffer(
 }
 
 bool NodeController::SyncSharedBuffer2d(const base::UnguessableToken& guid,
-                                        size_t offset,
-                                        size_t sync_size,
                                         size_t width,
-                                        size_t stride) {
+                                        size_t height,
+                                        size_t bytes_per_pixel,
+                                        size_t offset,
+                                        size_t stride,
+                                        BrokerCompressionMode compression_mode) {
   // If broker_ is null, it means the current process is a browser process.
   // The browser process isn't likely to send tile data.
   CHECK(broker_);
-  return broker_->SyncSharedBuffer2d(guid, offset, sync_size, width, stride);
+  return broker_->SyncSharedBuffer2d(
+      guid, width, height, bytes_per_pixel, offset, stride, compression_mode);
 }
 
 scoped_refptr<base::SyncDelegate> NodeController::GetSyncDelegate(

--- a/mojo/core/node_controller.h
+++ b/mojo/core/node_controller.h
@@ -31,6 +31,10 @@
 #include "mojo/core/system_impl_export.h"
 #include "mojo/public/cpp/platform/platform_handle.h"
 
+#if defined(CASTANETS)
+#include "mojo/public/c/system/sync.h"
+#endif
+
 namespace base {
 class PortProvider;
 #if defined(CASTANETS)
@@ -136,15 +140,18 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
 #if defined(CASTANETS)
   bool SyncSharedBuffer(const base::UnguessableToken& guid,
                         size_t offset,
-                        size_t sync_size);
+                        size_t sync_size,
+                        BrokerCompressionMode compression_mode);
   bool SyncSharedBuffer(base::WritableSharedMemoryMapping& mapping,
                         size_t offset,
                         size_t sync_size);
   bool SyncSharedBuffer2d(const base::UnguessableToken& guid,
-                          size_t offset,
-                          size_t sync_size,
                           size_t width,
-                          size_t stride);
+                          size_t height,
+                          size_t bytes_per_pixel,
+                          size_t offset,
+                          size_t stride,
+                          BrokerCompressionMode compression_mode);
 
   void WaitSyncSharedBuffer(const base::UnguessableToken& guid);
 

--- a/mojo/public/c/system/sync.h
+++ b/mojo/public/c/system/sync.h
@@ -14,17 +14,27 @@
 extern "C" {
 #endif
 
+enum BrokerCompressionMode : uint32_t {
+  NONE,
+  ZLIB,
+  WEBP
+};
+
 MOJO_SYSTEM_EXPORT MojoResult MojoSyncPlatformSharedMemoryRegion(
     const struct MojoSharedBufferGuid* guid,
     size_t offset,
-    size_t sync_size);
+    size_t sync_size,
+    BrokerCompressionMode compression_mode = BrokerCompressionMode::ZLIB);
 
 MOJO_SYSTEM_EXPORT MojoResult
-MojoSyncPlatformSharedMemoryRegion2d(const struct MojoSharedBufferGuid* guid,
-                                     size_t offset,
-                                     size_t sync_size,
-                                     size_t width,
-                                     size_t stride);
+MojoSyncPlatformSharedMemoryRegion2d(
+    const struct MojoSharedBufferGuid* guid,
+    size_t width,
+    size_t height,
+    size_t bytes_per_pixel,
+    size_t offset = 0,
+    size_t stride = 0,
+    BrokerCompressionMode compression_mode = BrokerCompressionMode::WEBP);
 
 MOJO_SYSTEM_EXPORT MojoResult MojoWaitSyncPlatformSharedMemoryRegion(
     const struct MojoSharedBufferGuid* guid);

--- a/mojo/public/c/system/thunks.cc
+++ b/mojo/public/c/system/thunks.cc
@@ -427,19 +427,22 @@ MojoResult MojoUnwrapPlatformSharedMemoryRegion(
 MojoResult MojoSyncPlatformSharedMemoryRegion(
     const struct MojoSharedBufferGuid* guid,
     size_t offset,
-    size_t sync_size) {
+    size_t sync_size,
+    BrokerCompressionMode compression_mode) {
   return INVOKE_THUNK(SyncPlatformSharedMemoryRegion,
-                      guid, offset, sync_size);
+                      guid, offset, sync_size, compression_mode);
 }
 
 MojoResult MojoSyncPlatformSharedMemoryRegion2d(
     const struct MojoSharedBufferGuid* guid,
-    size_t offset,
-    size_t sync_size,
     size_t width,
-    size_t stride) {
-  return INVOKE_THUNK(SyncPlatformSharedMemoryRegion2d, guid, offset, sync_size,
-                      width, stride);
+    size_t height,
+    size_t bytes_per_pixel,
+    size_t offset,
+    size_t stride,
+    BrokerCompressionMode compression_mode) {
+  return INVOKE_THUNK(SyncPlatformSharedMemoryRegion2d, guid, width, height,
+      bytes_per_pixel, offset, stride, compression_mode);
 }
 
 MojoResult MojoWaitSyncPlatformSharedMemoryRegion(

--- a/mojo/public/c/system/thunks.h
+++ b/mojo/public/c/system/thunks.h
@@ -188,13 +188,16 @@ struct MojoSystemThunks {
   MojoResult (*SyncPlatformSharedMemoryRegion)(
       const struct MojoSharedBufferGuid* guid,
       size_t offset,
-      size_t sync_size);
+      size_t sync_size,
+      BrokerCompressionMode compression_mode);
   MojoResult (*SyncPlatformSharedMemoryRegion2d)(
       const struct MojoSharedBufferGuid* guid,
-      size_t offset,
-      size_t sync_size,
       size_t width,
-      size_t stride);
+      size_t height,
+      size_t bytes_per_pixel,
+      size_t offset,
+      size_t stride,
+      BrokerCompressionMode compression_mode);
   MojoResult (*WaitSyncPlatformSharedMemoryRegion)(
       const struct MojoSharedBufferGuid* guid);
 #endif

--- a/mojo/public/cpp/system/sync.cc
+++ b/mojo/public/cpp/system/sync.cc
@@ -11,26 +11,29 @@ namespace mojo {
 
 MojoResult SyncSharedMemory(const base::UnguessableToken& guid,
                             size_t offset,
-                            size_t sync_size) {
+                            size_t sync_size,
+                            BrokerCompressionMode compression_mode) {
   MojoSharedBufferGuid mojo_guid;
   mojo_guid.high = guid.GetHighForSerialization();
   mojo_guid.low = guid.GetLowForSerialization();
 
   return MojoSyncPlatformSharedMemoryRegion(
-      &mojo_guid, offset, sync_size);
+      &mojo_guid, offset, sync_size, compression_mode);
 }
 
 MojoResult SyncSharedMemory2d(const base::UnguessableToken& guid,
-                              size_t offset,
-                              size_t sync_size,
                               size_t width,
-                              size_t stride) {
+                              size_t height,
+                              size_t bytes_per_pixel,
+                              size_t offset,
+                              size_t stride,
+                              BrokerCompressionMode compression_mode) {
   MojoSharedBufferGuid mojo_guid;
   mojo_guid.high = guid.GetHighForSerialization();
   mojo_guid.low = guid.GetLowForSerialization();
 
-  return MojoSyncPlatformSharedMemoryRegion2d(&mojo_guid, offset, sync_size,
-                                              width, stride);
+  return MojoSyncPlatformSharedMemoryRegion2d(&mojo_guid, width, height, bytes_per_pixel,
+                                              offset, stride, compression_mode);
 }
 
 MojoResult WaitSyncSharedMemory(const base::UnguessableToken& guid) {

--- a/mojo/public/cpp/system/sync.h
+++ b/mojo/public/cpp/system/sync.h
@@ -8,20 +8,24 @@
 #include "base/unguessable_token.h"
 #include "mojo/public/c/system/types.h"
 #include "mojo/public/cpp/system/system_export.h"
+#include "mojo/public/c/system/sync.h"
 
 namespace mojo {
 
 MOJO_CPP_SYSTEM_EXPORT MojoResult
 SyncSharedMemory(const base::UnguessableToken& guid,
                  size_t offset,
-                 size_t sync_size);
+                 size_t sync_size,
+                 BrokerCompressionMode compression_mode = BrokerCompressionMode::ZLIB);
 
 MOJO_CPP_SYSTEM_EXPORT MojoResult
 SyncSharedMemory2d(const base::UnguessableToken& guid,
-                   size_t offset,
-                   size_t sync_size,
                    size_t width,
-                   size_t stride);
+                   size_t height,
+                   size_t bytes_per_pixel,
+                   size_t offset = 0,
+                   size_t stride = 0,
+                   BrokerCompressionMode compression_mode = BrokerCompressionMode::WEBP);
 
 MOJO_CPP_SYSTEM_EXPORT MojoResult
 WaitSyncSharedMemory(const base::UnguessableToken& guid);


### PR DESCRIPTION
1. Apply webp compression for tiles.
2. Default compression type is zlib for other sync datas.
3. If the sync size is less than 200 bytes, do not apply
   compression for zlib.

Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>