### PR TITLE
fixup! Support both server and client TCP sockets on all processes.

### DIFF
--- a/mojo/public/cpp/system/invitation.cc
+++ b/mojo/public/cpp/system/invitation.cc
@@ -102,6 +102,7 @@ void SendInvitation(ScopedInvitationHandle invitation,
   options.tcp_address_length = static_cast<uint32_t>(tcp_address.size());
   options.tcp_port = tcp_port;
   options.secure_connection = secure_connection;
+  endpoint.secure_connection = secure_connection;
   MojoResult result = MojoSendInvitation(
       invitation.get().value(), &process_handle, &endpoint, error_handler,
       error_handler_context, &options, tcp_success_callback);


### PR DESCRIPTION
Need to mark transport endpoint's secure_connection to true when ssl
based connection is used for correct behavior of --secure-connection
runtime flag.

Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>