### PR TITLE
Fix loading of JS resources.

### DIFF
--- a/base/memory/castanets_memory_mapping.h
+++ b/base/memory/castanets_memory_mapping.h
@@ -22,6 +22,9 @@ class BASE_EXPORT CastanetsMemoryMapping
   void AddMapping(void* address);
   void RemoveMapping(void* address);
 
+  void UpdateCurrentSize(size_t size) { current_size_ += size; }
+  size_t current_size() { return current_size_; }
+
   UnguessableToken guid() const { return guid_; }
   size_t mapped_size() const { return mapped_size_; }
   void* GetMemory();
@@ -39,6 +42,7 @@ class BASE_EXPORT CastanetsMemoryMapping
 
   UnguessableToken guid_;
   size_t mapped_size_ = 0;
+  size_t current_size_ = 0;
 
   std::vector<void*> addresses_;
 

--- a/mojo/core/broker_castanets.cc
+++ b/mojo/core/broker_castanets.cc
@@ -531,6 +531,8 @@ void BrokerCastanets::OnBufferSync(uint64_t guid_high,
     memcpy(static_cast<uint8_t*>(mapping->GetMemory()) + offset, uncompressed_data,
            sync_bytes);
 
+    // Update currently received size in mapping.
+    mapping->UpdateCurrentSize(sync_bytes);
     fence_queue_->RemoveFence(guid, fence_id);
     return;
   }
@@ -545,6 +547,11 @@ void BrokerCastanets::OnBufferSync(uint64_t guid_high,
   uint8_t* ptr = static_cast<uint8_t*>(memory);
   memcpy(ptr + offset, uncompressed_data, sync_bytes);
   munmap(ptr, sync_bytes + offset);
+
+  // Update currently received size in mapping.
+  mapping = base::SharedMemoryTracker::GetInstance()->FindMappedMemory(guid);
+  if (mapping)
+    mapping->UpdateCurrentSize(sync_bytes);
 
   fence_queue_->RemoveFence(guid, fence_id);
 }

--- a/mojo/core/data_pipe_consumer_dispatcher.cc
+++ b/mojo/core/data_pipe_consumer_dispatcher.cc
@@ -23,6 +23,7 @@
 #include "mojo/public/c/system/data_pipe.h"
 
 #if defined(CASTANETS)
+#include "base/memory/castanets_memory_mapping.h"
 #include "base/memory/shared_memory_helper.h"
 #include "base/memory/shared_memory_tracker.h"
 #endif
@@ -185,6 +186,9 @@ MojoResult DataPipeConsumerDispatcher::ReadData(
   bool peek = !!(options.flags & MOJO_READ_DATA_FLAG_PEEK);
   if (discard || !peek) {
     read_offset_ = (read_offset_ + bytes_to_read) % options_.capacity_num_bytes;
+#if defined(CASTANETS)
+    unrolled_read_offset_ += bytes_to_read;
+#endif
     bytes_available_ -= bytes_to_read;
 
     base::AutoUnlock unlock(lock_);
@@ -225,6 +229,21 @@ MojoResult DataPipeConsumerDispatcher::BeginReadData(
   uint32_t bytes_to_read =
       std::min(bytes_available_, options_.capacity_num_bytes - read_offset_);
 
+#if defined(CASTANETS)
+  scoped_refptr<base::CastanetsMemoryMapping> mapping =
+      base::SharedMemoryTracker::GetInstance()->FindMappedMemory(
+          ring_buffer_mapping_.guid());
+  if (mapping && mapping->current_size() &&
+      mapping->current_size() < (unrolled_read_offset_ + bytes_to_read)) {
+    VLOG(2) << ring_buffer_mapping_.guid()
+            << " is not fully received, received size: "
+            << mapping->current_size()
+            << ", but trying to read: " << bytes_to_read
+            << " bytes from offset: " << unrolled_read_offset_;
+    return MOJO_RESULT_SHOULD_WAIT;
+  }
+#endif
+
   CHECK(ring_buffer_mapping_.IsValid());
   uint8_t* data = static_cast<uint8_t*>(ring_buffer_mapping_.memory());
   CHECK(data);
@@ -258,6 +277,9 @@ MojoResult DataPipeConsumerDispatcher::EndReadData(uint32_t num_bytes_read) {
     rv = MOJO_RESULT_OK;
     read_offset_ =
         (read_offset_ + num_bytes_read) % options_.capacity_num_bytes;
+#if defined(CASTANETS)
+    unrolled_read_offset_ += num_bytes_read;
+#endif
 
     DCHECK_GE(bytes_available_, num_bytes_read);
     bytes_available_ -= num_bytes_read;
@@ -437,6 +459,9 @@ DataPipeConsumerDispatcher::Deserialize(const void* data,
   {
     base::AutoLock lock(dispatcher->lock_);
     dispatcher->read_offset_ = state->read_offset;
+#if defined(CASTANETS)
+    dispatcher->unrolled_read_offset_ = state->read_offset;
+#endif
     dispatcher->bytes_available_ = state->bytes_available;
     dispatcher->new_data_available_ = state->bytes_available > 0;
     dispatcher->peer_closed_ = state->flags & kFlagPeerClosed;

--- a/mojo/core/data_pipe_consumer_dispatcher.h
+++ b/mojo/core/data_pipe_consumer_dispatcher.h
@@ -114,6 +114,12 @@ class MOJO_SYSTEM_IMPL_EXPORT DataPipeConsumerDispatcher final
   bool transferred_ = false;
 
   uint32_t read_offset_ = 0;
+#if defined(CASTANETS)
+  // If read_offset_ exceeds data pipe size, it re-starts from 0 and reuses same
+  // data pipe. We need exact read_offset_ to compare it against the current
+  // size of ring buffer mapping to avoid sync issues.
+  uint32_t unrolled_read_offset_ = 0;
+#endif
   uint32_t bytes_available_ = 0;
 
   // Indicates whether any new data is available since the last read attempt.

--- a/third_party/blink/renderer/core/loader/resource/script_resource.cc
+++ b/third_party/blink/renderer/core/loader/resource/script_resource.cc
@@ -312,6 +312,15 @@ void ScriptResource::OnDataPipeReadable(MojoResult result,
   MojoReadDataFlags flags_to_pass = MOJO_READ_DATA_FLAG_NONE;
   MojoResult begin_read_result =
       data_pipe_->BeginReadData(&data, &data_size, flags_to_pass);
+
+#if defined(CASTANETS)
+  // When JS resources are sent in chunks from browser, there are chances,
+  // we may attempt to read more data than received from data pipe.
+  if (begin_read_result == MOJO_RESULT_SHOULD_WAIT) {
+    watcher_->ArmOrNotify();
+    return;
+  }
+#endif
   // There should be data, so this read should succeed.
   CHECK_EQ(begin_read_result, MOJO_RESULT_OK);
 


### PR DESCRIPTION
When JS resources are sent in chunks from browser, there are chances
we may attempt to read more than data received from datapipe.

Scenario, During JS resource loading.
Browser:
1. writes 4 chunks in same guid -> sends 4 BUFER_SYNC with 4 fence ids.
2. Notifies renderer that it wrote all 4 chunks.
Renderer:
1. Receives only 2 chunks, WaitSync() will wait for only two fence ids.
2. May attempt to read more bytes than received 2, which will result in
   js error.

Fix:
1. Store the received chunk size in CastanetsMapping, check against it
   when attempting to read.
2. Send Mojo wait signal to retry read during
   the above scenario.

Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>