### PR TITLE
Add mising |title| field in PasswordForm mojom struct

### DIFF
--- a/components/autofill/core/common/mojom/BUILD.gn
+++ b/components/autofill/core/common/mojom/BUILD.gn
@@ -15,6 +15,11 @@ mojom("mojo_types") {
     "//url/mojom:url_mojom_gurl",
     "//url/mojom:url_mojom_origin",
   ]
+
+  enabled_features = []
+  if (enable_castanets) {
+    enabled_features += [ "is_castanets" ]
+  }
 }
 
 mojom("mojo_test_types") {

--- a/components/autofill/core/common/mojom/autofill_types.mojom
+++ b/components/autofill/core/common/mojom/autofill_types.mojom
@@ -281,6 +281,10 @@ struct PasswordForm {
   bool blacklisted_by_user;
   Type type;
   int32 times_used;
+
+  [EnableIf=is_castanets]
+  string title;
+
   FormData form_data;
   GenerationUploadStatus generation_upload_status;
   mojo_base.mojom.String16 display_name;

--- a/components/autofill/core/common/mojom/autofill_types_struct_traits.cc
+++ b/components/autofill/core/common/mojom/autofill_types_struct_traits.cc
@@ -543,6 +543,9 @@ bool StructTraits<
       !data.ReadAffiliatedWebRealm(&out->affiliated_web_realm) ||
       !data.ReadSubmitElement(&out->submit_element) ||
       !data.ReadUsernameElement(&out->username_element) ||
+#if defined(CASTANETS)
+      !data.ReadTitle(&out->title) ||
+#endif
       !data.ReadSubmissionEvent(&out->submission_event))
     return false;
 

--- a/components/autofill/core/common/mojom/autofill_types_struct_traits.h
+++ b/components/autofill/core/common/mojom/autofill_types_struct_traits.h
@@ -582,6 +582,12 @@ struct StructTraits<autofill::mojom::PasswordFormDataView,
     return r.times_used;
   }
 
+#if defined(CASTANETS)
+  static const std::string& title(const autofill::PasswordForm& r) {
+    return r.title;
+  }
+#endif
+
   static const autofill::FormData& form_data(const autofill::PasswordForm& r) {
     return r.form_data;
   }

--- a/components/autofill/core/common/password_form.h
+++ b/components/autofill/core/common/password_form.h
@@ -240,6 +240,10 @@ struct PasswordForm {
   // When parsing an HTML form, this is not used.
   int times_used = 0;
 
+#if defined(CASTANETS)
+  std::string title;
+#endif
+
   // Autofill representation of this form. Used to communicate with the
   // Autofill servers if necessary. Currently this is only used to help
   // determine forms where we can trigger password generation.


### PR DESCRIPTION
This commit makes PasswordForm same as the one in EFL port to fix
below mojo IPC related errors observed while loading tumblr.com.

E/CHROMIUM( 8166): [ERROR:validation_errors.cc(87)] Invalid
message: VALIDATION_ERROR_UNEXPECTED_STRUCT_HEADER
E/CHROMIUM( 8166): [ERROR:render_process_host_impl.cc(4778)]
Terminating render process for bad Mojo message: Received bad
user message: Validation failed for PasswordManagerDriver
RequestValidator [VALIDATION_ERROR_UNEXPECTED_STRUCT_HEADER
E/CHROMIUM( 8166): [ERROR:bad_message.cc(27)] Terminating
renderer for bad IPC message, reason 123

Signed-off-by: Chandan Padhi <c.padhi@samsung.com>