### PR TITLE
Fix DidFirstVisuallyNonEmptyPaint not received on browser

### DIFF
--- a/content/renderer/render_widget.cc
+++ b/content/renderer/render_widget.cc
@@ -1663,7 +1663,11 @@ void RenderWidget::IntrinsicSizingInfoChanged(
 
 void RenderWidget::DidMeaningfulLayout(blink::WebMeaningfulLayout layout_type) {
   if (layout_type == blink::WebMeaningfulLayout::kVisuallyNonEmpty) {
+#if defined(CASTANETS)
+    Send(new WidgetHostMsg_DidFirstVisuallyNonEmptyPaint(routing_id_));
+#else
     QueueMessage(new WidgetHostMsg_DidFirstVisuallyNonEmptyPaint(routing_id_));
+#endif
   }
 
   for (auto& observer : render_frames_)


### PR DESCRIPTION
With DidFirstVisuallyNonEmptyPaint renderer informs the browser
that first layout has happened and helps browser to take a decision
as to when to show pixels on screen. Currently for all websites
DidFirstVisuallyNonEmptyPaint callback is not received on browser
side. Using Send method for sending IPC in this case helps and
similar changes present in tizen as well.

Signed-off-by: Uzair Jaleel <uzair.jaleel@samsung.com>