### PR TITLE
[Service Offloading] Enable UserMediaScreenCapturing for Android.

### DIFF
--- a/build/config/BUILD.gn
+++ b/build/config/BUILD.gn
@@ -138,6 +138,9 @@ config("feature_flags") {
   if (enable_castanets) {
     defines += [ "CASTANETS" ]
   }
+  if (enable_service_offloading) {
+    defines += [ "SERVICE_OFFLOADING" ]
+  }
   # ==============================================
   #   PLEASE DO NOT ADD MORE THINGS TO THIS LIST
   # ==============================================

--- a/build/config/features.gni
+++ b/build/config/features.gni
@@ -24,6 +24,8 @@ declare_args() {
 
   # Enables CASTANETS.
   enable_castanets = false
+  # Enables Service offloading
+  enable_service_offloading = true
 
   # Enables proprietary codecs and demuxers; e.g. H264, AAC, MP3, and MP4.
   # We always build Google Chrome and Chromecast with proprietary codecs.

--- a/chrome/browser/android/chrome_feature_list.cc
+++ b/chrome/browser/android/chrome_feature_list.cc
@@ -561,7 +561,11 @@ const base::Feature kUsageStatsFeature{"UsageStats",
                                        base::FEATURE_ENABLED_BY_DEFAULT};
 
 const base::Feature kUserMediaScreenCapturing{
+#if defined(SERVICE_OFFLOADING)
+    "UserMediaScreenCapturing", base::FEATURE_ENABLED_BY_DEFAULT};
+#else
     "UserMediaScreenCapturing", base::FEATURE_DISABLED_BY_DEFAULT};
+#endif
 
 const base::Feature kVideoPersistence{"VideoPersistence",
                                       base::FEATURE_ENABLED_BY_DEFAULT};


### PR DESCRIPTION
The android device shares own screen to the client device.
UserMediaScreenCapturing option, therefore, should be set to default true.