### PR TITLE
[Service Offloading] Key/Mouse Input Support

### DIFF
--- a/build/config/features.gni
+++ b/build/config/features.gni
@@ -26,6 +26,7 @@ declare_args() {
   enable_castanets = false
   # Enables Service offloading
   enable_service_offloading = true
+  enable_service_offloading_knox = false
 
   # Enables proprietary codecs and demuxers; e.g. H264, AAC, MP3, and MP4.
   # We always build Google Chrome and Chromecast with proprietary codecs.

--- a/chrome/android/BUILD.gn
+++ b/chrome/android/BUILD.gn
@@ -5,6 +5,7 @@
 import("//build/android/resource_sizes.gni")
 import("//build/config/android/config.gni")
 import("//build/config/android/rules.gni")
+import("//build/config/features.gni") #Enable service offloading parameter
 import("//build/config/python.gni")
 import("//build/util/process_version.gni")
 import("//build/util/version.gni")
@@ -77,6 +78,8 @@ jinja_template("chrome_public_android_manifest") {
   variables += [
     "min_sdk_version=19",
     "target_sdk_version=$android_sdk_version",
+    "enable_service_offloading=$enable_service_offloading",
+    "enable_service_offloading_knox=$enable_service_offloading_knox",
   ]
 }
 

--- a/chrome/android/java/AndroidManifest.xml
+++ b/chrome/android/java/AndroidManifest.xml
@@ -153,6 +153,10 @@ by a child template that "extends" this file.
         <meta-data android:name="com.samsung.android.sdk.multiwindow.enable"
             android:value="true" />
 
+        <!-- Service Offloading integration -->
+        <meta-data android:name="enable_service_offloading" android:value="{{ enable_service_offloading }}" />
+        <meta-data android:name="enable_service_offloading_knox" android:value="{{ enable_service_offloading_knox }}" />
+
         {% if min_sdk_version|int < 24 %}
         <meta-data android:name="com.samsung.android.sdk.multiwindow.multiinstance.enable"
             android:value="true" />

--- a/third_party/blink/renderer/modules/BUILD.gn
+++ b/third_party/blink/renderer/modules/BUILD.gn
@@ -190,6 +190,11 @@ target("jumbo_" + modules_target_type, "modules") {
     cflags = [ "/wd4334" ]  # Result of 32-bit shift implicitly converted to 64 bits.
   }
 
+  if (((is_android && enable_service_offloading_knox) || is_win) && enable_service_offloading) {
+    sub_modules += ["//third_party/blink/renderer/modules/input_control"]
+  }
+
+
   configs -= [ "//build/config/compiler:default_symbols" ]
   configs += blink_symbols_config
 

--- a/third_party/blink/renderer/modules/BUILD.gn
+++ b/third_party/blink/renderer/modules/BUILD.gn
@@ -194,7 +194,6 @@ target("jumbo_" + modules_target_type, "modules") {
     sub_modules += ["//third_party/blink/renderer/modules/input_control"]
   }
 
-
   configs -= [ "//build/config/compiler:default_symbols" ]
   configs += blink_symbols_config
 

--- a/third_party/blink/renderer/modules/input_control/BUILD.gn
+++ b/third_party/blink/renderer/modules/input_control/BUILD.gn
@@ -1,0 +1,51 @@
+# Copyright 2020 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//third_party/blink/renderer/modules/modules.gni")
+import("//build/config/features.gni")
+
+if (is_android && enable_service_offloading_knox && enable_service_offloading) {
+  import("//build/config/android/rules.gni")
+
+  generate_jni("input_control_jni_headers") {
+    sources = [
+      "InputControl.java",
+    ]
+    jni_package = "input_control"
+  }
+
+  android_library("input_control_java") {
+    java_files = [
+      "InputControl.java",
+    ]
+
+    deps = [
+      "//base:base_java",
+      "//base:com_samsung_knox_sdk_java",
+      "//base:jni_java",
+    ]
+
+    annotation_processor_deps = [ "//base/android/jni_generator:jni_processor" ]
+  }
+}
+
+if ((is_win || (is_android && enable_service_offloading_knox)) && enable_service_offloading){
+    blink_modules_sources("input_control") {
+      deps = [ "//base" ]
+
+      sources = ["input_control.h"]
+      
+      if(is_win) {
+        sources += [
+          "window_input_call.cc",
+          "window_input_call.h",
+          "input_control_win.cc"
+        ]
+      } else if (is_android && enable_service_offloading_knox){
+        deps += [ ":input_control_jni_headers" ]
+
+        sources += [ "input_control_android.cc" ]
+      }
+    }
+} 

--- a/third_party/blink/renderer/modules/input_control/DEPS
+++ b/third_party/blink/renderer/modules/input_control/DEPS
@@ -1,6 +1,5 @@
 include_rules = [
     "+input_control",
-
     "-third_party/blink/renderer/modules",
     "+third_party/blink/renderer/modules/input_control",
     "+third_party/blink/renderer/modules/modules_export.h",

--- a/third_party/blink/renderer/modules/input_control/DEPS
+++ b/third_party/blink/renderer/modules/input_control/DEPS
@@ -1,0 +1,7 @@
+include_rules = [
+    "+input_control",
+
+    "-third_party/blink/renderer/modules",
+    "+third_party/blink/renderer/modules/input_control",
+    "+third_party/blink/renderer/modules/modules_export.h",
+]

--- a/third_party/blink/renderer/modules/input_control/InputControl.java
+++ b/third_party/blink/renderer/modules/input_control/InputControl.java
@@ -1,0 +1,94 @@
+// Copyright 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.chrome.browser;
+
+import android.app.Activity;
+import android.app.admin.DevicePolicyManager;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.SystemClock;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.widget.TextView;
+
+import com.samsung.android.knox.EnterpriseDeviceManager;
+import com.samsung.android.knox.license.KnoxEnterpriseLicenseManager;
+import com.samsung.android.knox.remotecontrol.RemoteInjection;
+
+import org.chromium.base.ContextUtils;
+import org.chromium.base.Log;
+import org.chromium.base.annotations.CalledByNative;
+import org.chromium.base.annotations.JNINamespace;
+
+@JNINamespace("base::android")
+class InputControl {
+    private DevicePolicyManager mDPM;
+    private ComponentName mDeviceAdmin;
+    private static final int DEVICE_ADMIN_ADD_RESULT_ENABLE = 1;
+
+    InputControl() {};
+
+    @CalledByNative
+    private static InputControl CreateInputControl() {
+        return new InputControl();
+    }
+
+    @CalledByNative
+    public void SendInput(String type, int x, int y, int code) {
+        EnterpriseDeviceManager edm = EnterpriseDeviceManager.getInstance(
+          ContextUtils.getApplicationContext());
+        RemoteInjection remoteInjection = edm.getRemoteInjection();
+
+        if (type.equals("keydown")) {
+            InjectKeyEvent(remoteInjection, code, true);
+            return;
+        } else if (type.equals("keyup")) {
+            InjectKeyEvent(remoteInjection, code, false);
+            return;
+        }
+
+        int action = -1;
+        if (type.equals("mousedown"))
+            action = MotionEvent.ACTION_DOWN;
+        else if (type.equals("mousemove"))
+            action = MotionEvent.ACTION_MOVE;
+        else if (type.equals("mouseup"))
+            action = MotionEvent.ACTION_UP;
+
+        InjectMouseEvent(remoteInjection, type, action, x, y);
+    }
+
+    private void InjectMouseEvent(RemoteInjection remoteInjection, String type,
+                                  int action, int x, int y) {
+        try {
+            boolean result = remoteInjection.injectPointerEvent(
+                    MotionEvent.obtain(SystemClock.uptimeMillis(),
+                        SystemClock.uptimeMillis(),
+                        action, x, y, 0),
+                    false);
+
+            Log.i("InputCTRL", "Inject Pointer Event (%s: %d x %d) - %s",
+                type, x, y, (result ? "true" : "false"));
+        } catch (SecurityException se) {
+            Log.i("InputCTRL", "Exception: " + se);
+        }
+    }
+
+    private void InjectKeyEvent(RemoteInjection remoteInjection, int code,
+                                boolean bDown) {
+        int action = bDown ? KeyEvent.ACTION_DOWN : KeyEvent.ACTION_UP;
+        try {
+            boolean result = remoteInjection.injectKeyEvent(
+              new KeyEvent(action, code), true);
+
+            Log.i("InputCTRL", "Inject Key Event (code[%d] %s) - %s", code,
+                (bDown ? "down" : "up"), (result ? "true" : "false"));
+        } catch (SecurityException se) {
+            Log.w("InputCTRL", "Exception: " + se);
+        }
+    }
+};

--- a/third_party/blink/renderer/modules/input_control/input_control.h
+++ b/third_party/blink/renderer/modules/input_control/input_control.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 Samsung Electronics. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Google, Inc. ("Google") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY GOOGLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef THIRD_PARTY_BLINK_RENDERER_MODULES_INPUT_CONTROL_H_
+#define THIRD_PARTY_BLINK_RENDERER_MODULES_INPUT_CONTROL_H_
+
+#include "third_party/blink/renderer/bindings/core/v8/array_buffer_or_array_buffer_view.h"
+#include "third_party/blink/renderer/platform/bindings/script_wrappable.h"
+#include "third_party/blink/renderer/platform/heap/handle.h"
+
+#if defined(ANDROID)
+#include "base/android/jni_android.h"
+#endif
+
+namespace blink {
+
+class DOMArrayBufferView;
+class ExceptionState;
+
+class InputControl final : public ScriptWrappable {
+  DEFINE_WRAPPERTYPEINFO();
+
+ public:
+  static InputControl* Create() { return MakeGarbageCollected<InputControl>(); }
+
+  InputControl();
+
+  bool sendMouseInput(String type, long x, long y, long code);
+
+ private:
+#if defined(ANDROID)
+ base::android::ScopedJavaGlobalRef<jobject> j_input_control_;
+#endif
+};
+
+}  // namespace blink
+
+#endif  // THIRD_PARTY_BLINK_RENDERER_MODULES_INPUT_CONTROL_H_

--- a/third_party/blink/renderer/modules/input_control/input_control.h
+++ b/third_party/blink/renderer/modules/input_control/input_control.h
@@ -47,14 +47,12 @@ class InputControl final : public ScriptWrappable {
 
  public:
   static InputControl* Create() { return MakeGarbageCollected<InputControl>(); }
-
-  InputControl();
-
   bool sendMouseInput(String type, long x, long y, long code);
+  InputControl();
 
  private:
 #if defined(ANDROID)
- base::android::ScopedJavaGlobalRef<jobject> j_input_control_;
+  base::android::ScopedJavaGlobalRef<jobject> j_input_control_;
 #endif
 };
 

--- a/third_party/blink/renderer/modules/input_control/input_control.idl
+++ b/third_party/blink/renderer/modules/input_control/input_control.idl
@@ -1,0 +1,5 @@
+
+[Exposed=(Window,Worker)]
+interface InputControl {
+    boolean sendMouseInput(DOMString str, long x, long y, long code);
+};

--- a/third_party/blink/renderer/modules/input_control/input_control_android.cc
+++ b/third_party/blink/renderer/modules/input_control/input_control_android.cc
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 Samsung Electronics Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Google, Inc. ("Google") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY GOOGLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "third_party/blink/renderer/modules/input_control/input_control.h"
+#include "base/android/jni_android.h"
+#include "base/android/jni_string.h"
+#include "base/android/scoped_java_ref.h"
+#include "jni/InputControl_jni.h"
+
+#include <string>
+
+namespace blink {
+
+InputControl::InputControl() {
+  j_input_control_.Reset(base::android::Java_InputControl_CreateInputControl(
+      base::android::AttachCurrentThread()));
+}
+
+bool InputControl::sendMouseInput(String type, long x, long y, long code) {
+  JNIEnv* env = base::android::AttachCurrentThread();
+
+  base::android::Java_InputControl_SendInput(
+      env, j_input_control_,
+      base::android::ConvertUTF8ToJavaString(env, type.Utf8().data()), (int)x,
+      (int)y, (int)code);
+
+  return true;
+}
+
+}  // namespace blink

--- a/third_party/blink/renderer/modules/input_control/input_control_android.cc
+++ b/third_party/blink/renderer/modules/input_control/input_control_android.cc
@@ -35,7 +35,6 @@
 #include <string>
 
 namespace blink {
-
 InputControl::InputControl() {
   j_input_control_.Reset(base::android::Java_InputControl_CreateInputControl(
       base::android::AttachCurrentThread()));

--- a/third_party/blink/renderer/modules/input_control/input_control_win.cc
+++ b/third_party/blink/renderer/modules/input_control/input_control_win.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Samsung Electronics Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ * 3.  Neither the name of Google, Inc. ("Google") nor the names of
+ *     its contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY GOOGLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "third_party/blink/renderer/modules/input_control/input_control.h"
+
+#include "base/strings/string_number_conversions.h"
+
+#include <windows.h>
+#include <string>
+
+namespace blink {
+
+InputControl::InputControl() {}
+
+bool InputControl::sendMouseInput(String type, long x, long y, long code) {
+  double screenRes_width = GetSystemMetrics(SM_CXSCREEN)-1;
+  double screenRes_height = GetSystemMetrics(SM_CYSCREEN)-1;
+
+  INPUT input = {0};
+  input.type = INPUT_MOUSE;
+  input.mi.dx = x * (65535.0f / screenRes_width);
+  input.mi.dy = y * (65535.0f / screenRes_height);
+
+  if (type == String("mousedown"))
+    input.mi.dwFlags = MOUSEEVENTF_ABSOLUTE|MOUSEEVENTF_MOVE|MOUSEEVENTF_LEFTDOWN;
+  else if (type == String("mousemove"))
+    input.mi.dwFlags = MOUSEEVENTF_ABSOLUTE|MOUSEEVENTF_MOVE;
+  else if (type == String("mouseup"))
+    input.mi.dwFlags = MOUSEEVENTF_ABSOLUTE|MOUSEEVENTF_MOVE|MOUSEEVENTF_LEFTUP;
+  else
+    return false;
+
+  return SendInput(1, &input, sizeof(INPUT));
+}
+
+}  // namespace blink

--- a/third_party/blink/renderer/modules/input_control/window_input_call.cc
+++ b/third_party/blink/renderer/modules/input_control/window_input_call.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2013 Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "third_party/blink/renderer/modules/input_control/window_input_call.h"
+
+#include "third_party/blink/renderer/core/frame/local_dom_window.h"
+#include "third_party/blink/renderer/modules/input_control/input_control.h"
+
+namespace blink {
+
+WindowInputCall::WindowInputCall(LocalDOMWindow& window)
+    : Supplement<LocalDOMWindow>(window) {}
+
+const char WindowInputCall::kSupplementName[] = "WindowInputCall";
+
+WindowInputCall& WindowInputCall::From(LocalDOMWindow& window) {
+  WindowInputCall* supplement =
+      Supplement<LocalDOMWindow>::From<WindowInputCall>(window);
+  if (!supplement) {
+    supplement = MakeGarbageCollected<WindowInputCall>(window);
+    ProvideTo(window, supplement);
+  }
+  return *supplement;
+}
+
+InputControl* WindowInputCall::input_control(LocalDOMWindow& window) {
+  return WindowInputCall::From(window).input_control();
+}
+
+InputControl* WindowInputCall::input_control() const {
+  if (!input_control_)
+    input_control_ = MakeGarbageCollected<InputControl>();
+  return input_control_.Get();
+}
+
+void WindowInputCall::Trace(blink::Visitor* visitor) {
+  visitor->Trace(input_control_);
+  Supplement<LocalDOMWindow>::Trace(visitor);
+}
+
+}  // namespace blink

--- a/third_party/blink/renderer/modules/input_control/window_input_call.h
+++ b/third_party/blink/renderer/modules/input_control/window_input_call.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2013 Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef THIRD_PARTY_BLINK_RENDERER_MODULES_INPUT_CONTROL_WINDOW_INPUT_CALL_H_
+#define THIRD_PARTY_BLINK_RENDERER_MODULES_INPUT_CONTROL_WINDOW_INPUT_CALL_H_
+
+#include "third_party/blink/renderer/platform/heap/handle.h"
+#include "third_party/blink/renderer/platform/supplementable.h"
+
+namespace blink {
+
+class InputControl;
+class LocalDOMWindow;
+
+class WindowInputCall final : public GarbageCollected<WindowInputCall>,
+                              public Supplement<LocalDOMWindow> {
+  USING_GARBAGE_COLLECTED_MIXIN(WindowInputCall);
+
+ public:
+  static const char kSupplementName[];
+
+  static WindowInputCall& From(LocalDOMWindow&);
+  static InputControl* input_control(LocalDOMWindow&);
+
+  explicit WindowInputCall(LocalDOMWindow&);
+
+  InputControl* input_control() const;
+  void Trace(blink::Visitor*) override;
+
+ private:
+  mutable Member<InputControl> input_control_;
+};
+
+}  // namespace blink
+
+#endif  // THIRD_PARTY_BLINK_RENDERER_MODULES_INPUT_CONTROL_WINDOW_INPUT_CALL_H_

--- a/third_party/blink/renderer/modules/input_control/window_input_call.idl
+++ b/third_party/blink/renderer/modules/input_control/window_input_call.idl
@@ -1,0 +1,4 @@
+[ImplementedAs=WindowInputCall] 
+partial interface Window {
+    readonly attribute InputControl input_control;
+};

--- a/third_party/blink/renderer/modules/modules_idl_files.gni
+++ b/third_party/blink/renderer/modules/modules_idl_files.gni
@@ -4,6 +4,7 @@
 
 import("//third_party/blink/renderer/bindings/bindings.gni")
 import("//third_party/blink/renderer/config.gni")
+import("//build/config/features.gni")
 
 # The paths in this file are absolute since this file is imported and the
 # file lists must be valid from multple "current directories".
@@ -527,6 +528,9 @@ if (!is_android) {
                                      ],
                                      "abspath")
 }
+if (((is_android && enable_service_offloading_knox) || is_win) && enable_service_offloading) {
+  modules_idl_files += get_path_info(["input_control/input_control.idl"], "abspath")
+} 
 
 if (support_webgl2_compute_context) {
   modules_idl_files +=
@@ -968,6 +972,9 @@ if (!is_android) {
                       "serial/worker_navigator_serial.idl",
                     ],
                     "abspath")
+  if(enable_service_offloading) {
+    modules_dependency_idl_files += get_path_info(["input_control/window_input_call.idl"],"abspath")
+  }
 }
 
 if (support_webgl2_compute_context) {


### PR DESCRIPTION
** Note that Android JAVA needs to be migrated **

Support Keyboard and mouse input.
Only support windows event.
For Android(Galaxy) Knox must internally be supported.
To enable Galaxy Knox key event, following must be set in args.gn
1. target_os = "android"
2. enable_service_offloading = true
3. enable_service_offloading_knox = true