### PR TITLE
Enable scrambled message IDs for castanets.

### DIFF
--- a/mojo/public/tools/bindings/mojom.gni
+++ b/mojo/public/tools/bindings/mojom.gni
@@ -14,11 +14,11 @@ import("//ui/webui/webui_features.gni")
 # flipped elsewhere though.
 import("//build/config/chrome_build.gni")
 import("//build/config/chromecast_build.gni")
+import("//build/config/features.gni")
 import("//build/config/nacl/config.gni")
 import("//components/nacl/features.gni")
 import("//third_party/jinja2/jinja2.gni")
 import("//tools/ipc_fuzzer/ipc_fuzzer.gni")
-import("//build/config/features.gni")
 
 declare_args() {
   # Indicates whether typemapping should be supported in this build
@@ -62,7 +62,8 @@ declare_args() {
 # check |target_os| explicitly, as it's consistent across all toolchains.
 enable_scrambled_message_ids =
     enable_mojom_message_id_scrambling &&
-    (is_mac || is_win || (is_linux && !is_chromeos && !is_chromecast && !enable_castanets) ||
+    (is_mac || is_win || enable_castanets ||
+     (is_linux && !is_chromeos && !is_chromecast) ||
      ((enable_nacl || is_nacl || is_nacl_nonsfi) && target_os != "chromeos"))
 
 mojom_generator_root = "//mojo/public/tools/bindings"


### PR DESCRIPTION
Mojo message scrambling was initially disabled for castanets in order
to match the IDs between desktop and android, as in android the feature
is disabled. Nacl depends on message scrambling and scrambling enhances
security. So we enable it for castanets too.

Reference:
https://codereview.chromium.org/2794743002/

Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>