### PR TITLE
fixup! Fix build errors in android with castanets disabled.

### DIFF
--- a/services/viz/public/interfaces/BUILD.gn
+++ b/services/viz/public/interfaces/BUILD.gn
@@ -47,8 +47,13 @@ mojom("interfaces") {
     "//ui/latency/mojo:interfaces",
   ]
 
+  enabled_features = []
   if (enable_castanets) {
-    enabled_features = [ "is_castanets" ]
+    enabled_features += [ "is_castanets" ]
+  }
+
+  if (is_android || enable_castanets) {
+    enabled_features += [ "is_android_or_castanets" ]
   }
 }
 

--- a/services/viz/public/interfaces/compositing/compositor_frame_metadata.mojom
+++ b/services/viz/public/interfaces/compositing/compositor_frame_metadata.mojom
@@ -33,22 +33,13 @@ struct CompositorFrameMetadata {
 
   float min_page_scale_factor;
 
-  [EnableIf=is_android]
+  [EnableIf=is_android_or_castanets]
   float max_page_scale_factor;
 
-  [EnableIf=is_android]
+  [EnableIf=is_android_or_castanets]
   gfx.mojom.SizeF root_layer_size;
 
-  [EnableIf=is_android]
-  bool root_overflow_y_hidden;
-
-  [EnableIf=is_linux, is_castanets]
-  float max_page_scale_factor;
-
-  [EnableIf=is_linux, is_castanets]
-  gfx.mojom.SizeF root_layer_size;
-
-  [EnableIf=is_linux, is_castanets]
+  [EnableIf=is_android_or_castanets]
   bool root_overflow_y_hidden;
 
   float top_controls_height;
@@ -63,22 +54,13 @@ struct CompositorFrameMetadata {
   // the client can animate at the maximum frame rate supported by the Display.
   mojo_base.mojom.TimeDelta? preferred_frame_interval;
 
-  [EnableIf=is_android]
+  [EnableIf=is_android_or_castanets]
   float bottom_controls_height;
 
-  [EnableIf=is_android]
+  [EnableIf=is_android_or_castanets]
   float bottom_controls_shown_ratio;
 
-  [EnableIf=is_android]
-  Selection selection;
-
-  [EnableIf=is_linux, is_castanets]
-  float bottom_controls_height;
-
-  [EnableIf=is_linux, is_castanets]
-  float bottom_controls_shown_ratio;
-
-  [EnableIf=is_linux, is_castanets]
+  [EnableIf=is_android_or_castanets]
   Selection selection;
 
   [EnableIf=is_castanets]


### PR DESCRIPTION
This change fixes the build error on desktop with castanets disabled.

build is verified with below config,
linux desktop: with, without castanets build option.
android: with, without castanets build option.