### PR TITLE
Adds variable for Castanets to AndroidManifest.

### DIFF
--- a/chrome/android/BUILD.gn
+++ b/chrome/android/BUILD.gn
@@ -78,6 +78,7 @@ jinja_template("chrome_public_android_manifest") {
   variables += [
     "min_sdk_version=19",
     "target_sdk_version=$android_sdk_version",
+    "enable_castanets=$enable_castanets",
     "enable_service_offloading=$enable_service_offloading",
     "enable_service_offloading_knox=$enable_service_offloading_knox",
   ]

--- a/chrome/android/java/AndroidManifest.xml
+++ b/chrome/android/java/AndroidManifest.xml
@@ -153,6 +153,8 @@ by a child template that "extends" this file.
         <meta-data android:name="com.samsung.android.sdk.multiwindow.enable"
             android:value="true" />
 
+        <!-- Castanets Support -->
+        <meta-data android:name="enable_castanets" android:value="{{ enable_castanets }}" />
         <!-- Service Offloading integration -->
         <meta-data android:name="enable_service_offloading" android:value="{{ enable_service_offloading }}" />
         <meta-data android:name="enable_service_offloading_knox" android:value="{{ enable_service_offloading_knox }}" />

--- a/chrome/android/java/src/org/chromium/chrome/browser/init/AsyncInitializationActivity.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/init/AsyncInitializationActivity.java
@@ -7,6 +7,9 @@ package org.chromium.chrome.browser.init;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
@@ -25,6 +28,7 @@ import android.view.ViewTreeObserver.OnPreDrawListener;
 import android.view.WindowManager;
 
 import org.chromium.base.ApiCompatibilityUtils;
+import org.chromium.base.ContextUtils;
 import org.chromium.base.StrictModeContext;
 import org.chromium.base.TraceEvent;
 import org.chromium.base.VisibleForTesting;
@@ -269,8 +273,18 @@ public abstract class AsyncInitializationActivity extends ChromeBaseAppCompatAct
     @Override
     @SuppressLint("MissingSuperCall")  // Called in onCreateInternal.
     protected final void onCreate(Bundle savedInstanceState) {
-        boolean runRenderer = true; // Toggle this when running browser process
-        if (runRenderer) {
+        boolean isCastanets = false; // Toggle this when running browser process
+
+        Context context = ContextUtils.getApplicationContext();
+        try {
+          ApplicationInfo info = context.getPackageManager().getApplicationInfo(context.getPackageName(),PackageManager.GET_META_DATA);
+          isCastanets = (Boolean)info.metaData.get("enable_castanets");
+        } catch (NameNotFoundException ex) {
+          // NameNotFoundExceptions occurs.
+        }
+
+        // Hide the activity if castanets is enabled and runs as renderer process,
+        if (isCastanets) {
             Intent startMain = new Intent(Intent.ACTION_MAIN);
             startMain.addCategory (Intent.CATEGORY_HOME);
             startMain.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);


### PR DESCRIPTION
Java codes for android need to know if Castanets is enabled.
enable_castanets is added to the manifest for this case.

It can be determined whether the activity is to be hidden for Castanets.