### PR TITLE
Add support of run time flags for enable Castanets

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -2011,6 +2011,14 @@ jumbo_component("base") {
   }
   set_sources_assignment_filter(sources_assignment_filter)
 
+  # Distributed chromium
+  if (enable_castanets) {
+    sources += [
+      "distributed_chromium_util.cc",
+      "distributed_chromium_util.h",
+    ]
+  }
+
   if (!use_glib) {
     sources -= [
       "message_loop/message_pump_glib.cc",
@@ -3300,7 +3308,8 @@ if (is_android) {
     }
 
     if (enable_service_offloading) {
-      java_files += [ "android/java/src/org/chromium/base/AudioRecordBridge.java", ]
+      java_files +=
+          [ "android/java/src/org/chromium/base/AudioRecordBridge.java" ]
     }
   }
 

--- a/base/base_switches.cc
+++ b/base/base_switches.cc
@@ -137,10 +137,8 @@ const char kEnableThreadInstructionCount[] = "enable-thread-instruction-count";
 #endif
 
 #if defined(CASTANETS)
-const char kEnableForking[] = "enable-forking";
-
-// Specify distributed chrome server address.
-const char kServerAddress[] = "server-address";
+// Enable features for distributed chromium.
+const char kEnableCastanets[] = "enable-castanets";
 
 const char kTcpLaunchTimeout[] = "tcp-launch-timeout";
 

--- a/base/base_switches.h
+++ b/base/base_switches.h
@@ -54,8 +54,7 @@ extern const char kEnableThreadInstructionCount[];
 #endif
 
 #if defined(CASTANETS)
-extern const char kEnableForking[];
-extern const char kServerAddress[];
+extern const char kEnableCastanets[];
 extern const char kTcpLaunchTimeout[];
 extern const char kSecureConnection[];
 #endif

--- a/base/distributed_chromium_util.cc
+++ b/base/distributed_chromium_util.cc
@@ -1,0 +1,30 @@
+// Copyright 2020 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/distributed_chromium_util.h"
+
+#include "base/base_switches.h"
+#include "base/command_line.h"
+
+namespace base {
+
+bool Castanets::IsEnabled() {
+  return (CommandLine::ForCurrentProcess()->HasSwitch(
+             switches::kEnableCastanets))
+             ? true
+             : false;
+}
+
+std::string Castanets::ServerAddress() {
+  std::string server_address;
+  base::CommandLine* command_line = CommandLine::ForCurrentProcess();
+  if (command_line->HasSwitch(switches::kEnableCastanets)) {
+    server_address =
+        command_line->GetSwitchValueASCII(switches::kEnableCastanets);
+  }
+
+  return server_address;
+}
+
+}  // namespace base

--- a/base/distributed_chromium_util.h
+++ b/base/distributed_chromium_util.h
@@ -1,0 +1,22 @@
+// Copyright 2020 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef BASE_DISTRIBUTED_CHROMIUM_H_
+#define BASE_DISTRIBUTED_CHROMIUM_H_
+
+#include <stddef.h>
+#include <string>
+
+#include "base/base_export.h"
+
+namespace base {
+class BASE_EXPORT Castanets {
+ public:
+  static bool IsEnabled();
+  static std::string ServerAddress();
+};
+
+}  // namespace base
+
+#endif  // BASE_DISTRIBUTED_CHROMIUM_H_

--- a/base/memory/shared_memory_posix.cc
+++ b/base/memory/shared_memory_posix.cc
@@ -39,6 +39,7 @@
 #if defined(CASTANETS)
 #include "base/base_switches.h"
 #include "base/command_line.h"
+#include "base/distributed_chromium_util.h"
 #endif
 
 namespace base {
@@ -50,8 +51,7 @@ SharedMemory::SharedMemory(const SharedMemoryHandle& handle, bool read_only)
 #if defined(CASTANETS)
   // Always make SharedMemory as writable memory to sync memory from remote for
   // Castanets.
-  if (read_only_ && !base::CommandLine::ForCurrentProcess()->HasSwitch(
-                        switches::kEnableForking))
+  if (base::Castanets::IsEnabled() && read_only_)
     read_only_ = false;
 #endif
 }

--- a/base/process/kill_posix.cc
+++ b/base/process/kill_posix.cc
@@ -20,6 +20,10 @@
 #include "base/threading/platform_thread.h"
 #include "build/build_config.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace base {
 
 namespace {
@@ -29,7 +33,7 @@ TerminationStatus GetTerminationStatusImpl(ProcessHandle handle,
                                            int* exit_code) {
   DCHECK(exit_code);
 #if defined(CASTANETS)
-  if (handle == kCastanetsProcessHandle) {
+  if (base::Castanets::IsEnabled() && (handle == kCastanetsProcessHandle)) {
     *exit_code = 0;
     return TERMINATION_STATUS_NORMAL_TERMINATION;
   }
@@ -99,7 +103,7 @@ TerminationStatus GetTerminationStatus(ProcessHandle handle, int* exit_code) {
 TerminationStatus GetKnownDeadTerminationStatus(ProcessHandle handle,
                                                 int* exit_code) {
 #if defined(CASTANETS)
-  if (handle == kCastanetsProcessHandle)
+  if (base::Castanets::IsEnabled() && (handle == kCastanetsProcessHandle))
     return GetTerminationStatusImpl(handle, true /* can_block */, exit_code);
 #endif
 

--- a/base/process/process_posix.cc
+++ b/base/process/process_posix.cc
@@ -24,6 +24,10 @@
 #include <sys/event.h>
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace {
 
 #if !defined(OS_NACL_NONSFI)
@@ -184,7 +188,8 @@ bool WaitForExitWithTimeoutImpl(base::ProcessHandle handle,
                                 int* exit_code,
                                 base::TimeDelta timeout) {
 #if defined(CASTANETS)
-  if (handle < base::kCastanetsProcessHandle) {
+  if (base::Castanets::IsEnabled() &&
+      (handle < base::kCastanetsProcessHandle)) {
     *exit_code = -1;
     return true;
   }
@@ -288,7 +293,7 @@ void Process::TerminateCurrentProcessImmediately(int exit_code) {
 
 bool Process::IsValid() const {
 #if defined(CASTANETS)
-  if (process_ < kCastanetsProcessHandle)
+  if (base::Castanets::IsEnabled() && (process_ < kCastanetsProcessHandle))
     return true;
 #endif
   return process_ != kNullProcessHandle;
@@ -307,7 +312,7 @@ Process Process::Duplicate() const {
 
 ProcessId Process::Pid() const {
 #if defined(CASTANETS)
-  if (process_ < kCastanetsProcessHandle)
+  if (base::Castanets::IsEnabled() && (process_ < kCastanetsProcessHandle))
     return kCastanetsProcessId;
 #endif
   DCHECK(IsValid());
@@ -328,7 +333,7 @@ void Process::Close() {
 #if !defined(OS_NACL_NONSFI)
 bool Process::Terminate(int exit_code, bool wait) const {
 #if defined(CASTANETS)
-  if (process_ < kCastanetsProcessHandle) {
+  if (base::Castanets::IsEnabled() && (process_ < kCastanetsProcessHandle)) {
     // TODO(hw1008.kim): We have to send exit_code to the remote child process?
     return true;
   }
@@ -398,8 +403,8 @@ bool Process::SetProcessBackgrounded(bool value) {
 
 int Process::GetPriority() const {
 #if defined(CASTANETS)
-  if (process_ < kCastanetsProcessHandle)
-    return  0; // The default priority is 0
+  if (base::Castanets::IsEnabled() && (process_ < kCastanetsProcessHandle))
+    return 0;  // The default priority is 0
 #endif
   DCHECK(IsValid());
   return getpriority(PRIO_PROCESS, process_);

--- a/cc/raster/one_copy_raster_buffer_provider.cc
+++ b/cc/raster/one_copy_raster_buffer_provider.cc
@@ -34,6 +34,7 @@
 
 #if defined(CASTANETS)
 #include "base/command_line.h"
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -350,11 +351,13 @@ void OneCopyRasterBufferProvider::PlaybackToStagingBuffer(
         raster_source, raster_full_rect, playback_rect, transform,
         dst_color_space, /*gpu_compositing=*/true, playback_settings);
 #if defined(CASTANETS)
-    if (std::string("renderer") ==
-        base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
+    if (base::Castanets::IsEnabled() &&
+        (std::string("renderer") ==
+         base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type"))) {
       mojo::SyncSharedMemory2d(
           buffer->CloneHandle().region.GetGUID(), staging_buffer->size.width(),
-          staging_buffer->size.height(), buffer->stride(0)/staging_buffer->size.width());
+          staging_buffer->size.height(),
+          buffer->stride(0) / staging_buffer->size.width());
     }
 #endif
     buffer->Unmap();

--- a/cc/raster/staging_buffer_pool.cc
+++ b/cc/raster/staging_buffer_pool.cc
@@ -20,6 +20,10 @@
 #include "third_party/khronos/GLES2/gl2ext.h"
 #include "ui/gfx/gpu_memory_buffer.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 using base::trace_event::MemoryAllocatorDump;
 using base::trace_event::MemoryAllocatorDumpGuid;
 using base::trace_event::MemoryDumpLevelOfDetail;
@@ -51,7 +55,8 @@ void WaitForQueryResult(gpu::raster::RasterInterface* ri, GLuint query_id) {
 #if defined(CASTANETS)
   // FIXME: Skip this region because shared memory of query result
   // is not being syncronized.
-  return;
+  if (base::Castanets::IsEnabled())
+    return;
 #endif
 
   int attempts_left = kMaxCheckForQueryResultAvailableAttempts;
@@ -261,14 +266,17 @@ std::unique_ptr<StagingBuffer> StagingBufferPool::AcquireStagingBuffer(
   while (!busy_buffers_.empty()) {
 #if defined(CASTANETS)
     //  FIXME: Fall-back to glFinish because QueryResult isnt handled.
-    ri->Finish();
-#else
-    // Early out if query isn't used, or if query isn't complete yet.  Query is
-    // created in OneCopyRasterBufferProvider::CopyOnWorkerThread().
-    if (!busy_buffers_.front()->query_id ||
-        !CheckForQueryResult(ri, busy_buffers_.front()->query_id))
-      break;
+    if (base::Castanets::IsEnabled()) {
+      ri->Finish();
+    } else
 #endif
+    {
+      // Early out if query isn't used, or if query isn't complete yet.  Query
+      // is created in OneCopyRasterBufferProvider::CopyOnWorkerThread().
+      if (!busy_buffers_.front()->query_id ||
+          !CheckForQueryResult(ri, busy_buffers_.front()->query_id))
+        break;
+    }
 
     MarkStagingBufferAsFree(busy_buffers_.front().get());
     free_buffers_.push_back(PopFront(&busy_buffers_));

--- a/cc/tiles/tile_manager.cc
+++ b/cc/tiles/tile_manager.cc
@@ -35,6 +35,7 @@
 
 #if defined(CASTANETS)
 #include "base/command_line.h"
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif // defined(CASTANETS)
 
@@ -133,8 +134,9 @@ class RasterTaskImpl : public TileTask {
                              raster_transform_, playback_settings_, url_);
 
 #if defined(CASTANETS)
-    if (std::string("renderer") ==
-        base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
+    if (base::Castanets::IsEnabled() &&
+        (std::string("renderer") ==
+         base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type"))) {
       ResourcePool::SoftwareBacking* sw_backing = resource_.software_backing();
       if (sw_backing) {
         int bytes_per_pixel = BitsPerPixel(resource_.format()) / 8;

--- a/cc/trees/layer_tree_host_impl.cc
+++ b/cc/trees/layer_tree_host_impl.cc
@@ -118,6 +118,7 @@
 #include "ui/gfx/skia_util.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -5499,9 +5500,11 @@ void LayerTreeHostImpl::CreateUIResource(UIResourceId uid,
     transferable.format = format;
   } else {
 #if defined(CASTANETS)
-    mojo::SyncSharedMemory(
-        mapped_region.region.GetGUID(), 0,
-        upload_size.width() * upload_size.height() * BitsPerPixel(format) / 8);
+    if (base::Castanets::IsEnabled()) {
+      mojo::SyncSharedMemory(mapped_region.region.GetGUID(), 0,
+                             upload_size.width() * upload_size.height() *
+                                 BitsPerPixel(format) / 8);
+    }
 #endif
     layer_tree_frame_sink_->DidAllocateSharedBitmap(
         viz::bitmap_allocation::ToMojoHandle(std::move(mapped_region.region)),

--- a/components/services/font/public/cpp/font_service_thread.cc
+++ b/components/services/font/public/cpp/font_service_thread.cc
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include "base/distributed_chromium_util.h"
 #endif
 
 #include "base/bind.h"
@@ -45,24 +46,23 @@ bool FontServiceThread::MatchFamilyName(
   // This proxies to the other thread, which proxies to mojo. Only on the reply
   // from mojo do we return from this.
 #if defined(CASTANETS)
-  SkFontConfigInterface* fc =
-      SkFontConfigInterface::GetSingletonDirectInterface();
-  out_valid =
-      fc->matchFamilyName(family_name,
-                          requested_style,
-                          out_font_identity,
-                          out_family_name,
-                          out_style);
-#else
-  base::WaitableEvent done_event;
-  task_runner_->PostTask(
-      FROM_HERE,
-      base::BindOnce(&FontServiceThread::MatchFamilyNameImpl, this, &done_event,
-                     family_name, requested_style, &out_valid,
-                     out_font_identity, out_family_name, out_style));
-  done_event.Wait();
+  if (base::Castanets::IsEnabled()) {
+    SkFontConfigInterface* fc =
+        SkFontConfigInterface::GetSingletonDirectInterface();
+    out_valid =
+        fc->matchFamilyName(family_name, requested_style, out_font_identity,
+                            out_family_name, out_style);
+  } else
 #endif
-
+  {
+    base::WaitableEvent done_event;
+    task_runner_->PostTask(
+        FROM_HERE,
+        base::BindOnce(&FontServiceThread::MatchFamilyNameImpl, this,
+                       &done_event, family_name, requested_style, &out_valid,
+                       out_font_identity, out_family_name, out_style));
+    done_event.Wait();
+  }
   return out_valid;
 }
 
@@ -143,24 +143,28 @@ scoped_refptr<MappedFontFile> FontServiceThread::OpenStream(
     const SkFontConfigInterface::FontIdentity& identity) {
   DCHECK(!task_runner_->RunsTasksInCurrentSequence());
 
-#if defined(CASTANETS)
-  int result_fd = open(identity.fString.c_str(), O_RDONLY);
-  base::File stream_file(result_fd);
-#else
   base::File stream_file;
-  // This proxies to the other thread, which proxies to mojo. Only on the
-  // reply from mojo do we return from this.
-  base::WaitableEvent done_event;
-  task_runner_->PostTask(
-      FROM_HERE, base::BindOnce(&FontServiceThread::OpenStreamImpl, this,
-                                &done_event, &stream_file, identity.fID));
-  done_event.Wait();
-
-  if (!stream_file.IsValid()) {
-    // The font-service may have been killed.
-    return nullptr;
-  }
+#if defined(CASTANETS)
+  if (base::Castanets::IsEnabled()) {
+    int result_fd = open(identity.fString.c_str(), O_RDONLY);
+    base::File local_file(result_fd);
+    stream_file = std::move(local_file);
+  } else
 #endif
+  {
+    // This proxies to the other thread, which proxies to mojo. Only on the
+    // reply from mojo do we return from this.
+    base::WaitableEvent done_event;
+    task_runner_->PostTask(
+        FROM_HERE, base::BindOnce(&FontServiceThread::OpenStreamImpl, this,
+                                  &done_event, &stream_file, identity.fID));
+    done_event.Wait();
+
+    if (!stream_file.IsValid()) {
+      // The font-service may have been killed.
+      return nullptr;
+    }
+  }
 
   // Converts the file to out internal type.
   scoped_refptr<MappedFontFile> mapped_font_file =

--- a/components/subresource_filter/content/renderer/unverified_ruleset_dealer.cc
+++ b/components/subresource_filter/content/renderer/unverified_ruleset_dealer.cc
@@ -7,6 +7,10 @@
 #include "components/subresource_filter/content/common/subresource_filter_messages.h"
 #include "ipc/ipc_message_macros.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace subresource_filter {
 
 UnverifiedRulesetDealer::UnverifiedRulesetDealer() = default;
@@ -26,8 +30,10 @@ bool UnverifiedRulesetDealer::OnControlMessageReceived(
 void UnverifiedRulesetDealer::OnSetRulesetForProcess(
     const IPC::PlatformFileForTransit& platform_file) {
 #if defined(CASTANETS)
-  LOG(INFO) << "SKIP!!!!! UnverifiedRulesetDealer::OnSetRulesetForProcess";
-  return;
+  if (base::Castanets::IsEnabled()) {
+    LOG(INFO) << "SKIP!!!!! UnverifiedRulesetDealer::OnSetRulesetForProcess";
+    return;
+  }
 #endif
   SetRulesetFile(IPC::PlatformFileForTransitToFile(platform_file));
 }

--- a/components/visitedlink/renderer/visitedlink_slave.cc
+++ b/components/visitedlink/renderer/visitedlink_slave.cc
@@ -11,6 +11,10 @@
 #include "base/logging.h"
 #include "third_party/blink/public/web/web_view.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 using blink::WebView;
 
 namespace visitedlink {
@@ -33,8 +37,10 @@ void VisitedLinkSlave::UpdateVisitedLinks(
   // Since this function may be called again to change the table, we may need
   // to free old objects.
 #if defined(CASTANETS)
-  LOG(INFO) << "SKIP!!!!! VisitedLinkSlave::UpdateVisitedLinks";
-  return;
+  if (base::Castanets::IsEnabled()) {
+    LOG(INFO) << "SKIP!!!!! VisitedLinkSlave::UpdateVisitedLinks";
+    return;
+  }
 #endif
 
   FreeTable();
@@ -69,8 +75,10 @@ void VisitedLinkSlave::UpdateVisitedLinks(
 void VisitedLinkSlave::AddVisitedLinks(
     const std::vector<VisitedLinkSlave::Fingerprint>& fingerprints) {
 #if defined(CASTANETS)
-  LOG(INFO) << "SKIP!!!!! VisitedLinkSlave::AddVisitedLinks";
-  return;
+  if (base::Castanets::IsEnabled()) {
+    LOG(INFO) << "SKIP!!!!! VisitedLinkSlave::AddVisitedLinks";
+    return;
+  }
 #endif
   for (size_t i = 0; i < fingerprints.size(); ++i)
     WebView::UpdateVisitedLinkState(fingerprints[i]);

--- a/components/viz/common/features.cc
+++ b/components/viz/common/features.cc
@@ -20,18 +20,14 @@ constexpr char kDrawQuad[] = "draw_quad";
 constexpr char kSurfaceLayer[] = "surface_layer";
 
 const base::Feature kEnableSurfaceSynchronization{
-#if defined(CASTANETS)
-    "SurfaceSynchronization", base::FEATURE_DISABLED_BY_DEFAULT};
-#else
     "SurfaceSynchronization", base::FEATURE_ENABLED_BY_DEFAULT};
-#endif
 
 // Enables running the display compositor as part of the viz service in the GPU
 // process. This is also referred to as out-of-process display compositor
 // (OOP-D).
 // TODO(dnicoara): Look at enabling Chromecast support when ChromeOS support is
 // ready.
-#if defined(OS_CHROMEOS) || defined(IS_CHROMECAST) || (defined(CASTANETS) && defined(OS_ANDROID))
+#if defined(OS_CHROMEOS) || defined(IS_CHROMECAST)
 const base::Feature kVizDisplayCompositor{"VizDisplayCompositor",
                                           base::FEATURE_DISABLED_BY_DEFAULT};
 #else

--- a/components/viz/service/display_embedder/server_shared_bitmap_manager.cc
+++ b/components/viz/service/display_embedder/server_shared_bitmap_manager.cc
@@ -23,6 +23,7 @@
 #include "ui/gfx/geometry/size.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -96,7 +97,8 @@ std::unique_ptr<SharedBitmap> ServerSharedBitmapManager::GetSharedBitmapFromId(
   }
 
 #if defined(CASTANETS)
-  mojo::WaitSyncSharedMemory(data->mapped_id());
+  if (base::Castanets::IsEnabled())
+    mojo::WaitSyncSharedMemory(data->mapped_id());
 #endif
 
   if (!data->memory()) {

--- a/content/browser/android/content_startup_flags.cc
+++ b/content/browser/android/content_startup_flags.cc
@@ -16,6 +16,7 @@
 #include "ui/base/ui_base_switches.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "components/viz/common/switches.h"
 #include "services/service_manager/sandbox/switches.h"
 #include "ui/gl/gl_switches.h"
@@ -38,19 +39,33 @@ void SetContentCommandLineFlags(bool single_process) {
       base::CommandLine::ForCurrentProcess();
 
 #if defined(CASTANETS)
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      service_manager::switches::kNoSandbox);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoZygote);
-  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
-      switches::kNumRasterThreads, "4");
-  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
-      switches::kLang, "en-US");
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      switches::kIgnoreGpuBlacklist);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      switches::kDisableGpuDriverBugWorkarounds);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      switches::kDisableFrameRateLimit);
+  if (base::Castanets::IsEnabled()) {
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        service_manager::switches::kNoSandbox);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoZygote);
+    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
+        switches::kNumRasterThreads, "4");
+    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kLang,
+                                                              "en-US");
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        switches::kIgnoreGpuBlacklist);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        switches::kDisableGpuDriverBugWorkarounds);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        switches::kDisableFrameRateLimit);
+    std::string disabled_features =
+        base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(
+            switches::kDisableFeatures);
+    std::string features_to_disable =
+        "NetworkService,NetworkServiceInProcess,SpareRendererForSitePerProcess,\
+        SurfaceSynchronization,VizDisplayCompositor";
+    if (!disabled_features.empty())
+      disabled_features = disabled_features + "," + features_to_disable;
+    else
+      disabled_features = features_to_disable;
+    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
+        switches::kDisableFeatures, disabled_features);
+  }
 #endif
   if (single_process) {
     // Need to ensure the command line flag is consistent as a lot of chrome

--- a/content/browser/browser_child_process_host_impl.cc
+++ b/content/browser/browser_child_process_host_impl.cc
@@ -58,6 +58,10 @@
 #include "content/browser/mach_broker_mac.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 namespace {
 
@@ -588,8 +592,11 @@ void BrowserChildProcessHostImpl::CreateMetricsAllocator() {
 
 void BrowserChildProcessHostImpl::ShareMetricsAllocatorToProcess() {
 #if defined(CASTANETS)
-  LOG(INFO) << "SKIP!!!!! BrowserChildProcessHostImpl::ShareMetricsAllocatorToProcess";
-  return;
+  if (base::Castanets::IsEnabled()) {
+    LOG(INFO) << "SKIP!!!!! "
+                 "BrowserChildProcessHostImpl::ShareMetricsAllocatorToProcess";
+    return;
+  }
 #endif
   if (metrics_allocator_) {
     HistogramController::GetInstance()->SetHistogramMemory<ChildProcessHost>(

--- a/content/browser/child_process_launcher_helper.cc
+++ b/content/browser/child_process_launcher_helper.cc
@@ -26,6 +26,7 @@
 
 #if defined(CASTANETS)
 #include "base/base_switches.h"
+#include "base/distributed_chromium_util.h"
 #include "base/strings/string_number_conversions.h"
 #include "content/browser/renderer_host/input/timeout_monitor.h"
 
@@ -104,8 +105,7 @@ ChildProcessLauncherHelper::ChildProcessLauncherHelper(
   tcp_success_callback_ = base::BindRepeating(
       &ChildProcessLauncherHelper::OnCastanetsRendererLaunchedViaTcp,
       base::Unretained(this));
-  remote_process_ = !base::CommandLine::ForCurrentProcess()->HasSwitch(
-      switches::kEnableForking);
+  remote_process_ = base::Castanets::IsEnabled();
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
           switches::kTcpLaunchTimeout)) {
     relaunch_renderer_process_monitor_timeout_.reset(new TimeoutMonitor(
@@ -252,12 +252,6 @@ void ChildProcessLauncherHelper::PostLaunchOnLauncherThread(
         uint16_t port = (GetProcessType() == switches::kRendererProcess)
                             ? mojo::kCastanetsRendererPort
                             : mojo::kCastanetsUtilityPort;
-        std::string address =
-            base::CommandLine::ForCurrentProcess()->HasSwitch(
-                switches::kServerAddress)
-                ? base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(
-                      switches::kServerAddress)
-                : std::string();
         // Reset IPC socket
         mojo_channel_->TakeLocalEndpoint().reset();
 
@@ -265,7 +259,8 @@ void ChildProcessLauncherHelper::PostLaunchOnLauncherThread(
         mojo::OutgoingInvitation::SendTcpSocket(
             std::move(invitation), process.process.Handle(),
             mojo::CreateTCPSocketHandle(), process_error_callback_,
-            tcp_success_callback_, false, address, port);
+            tcp_success_callback_, false, base::Castanets::ServerAddress(),
+            port);
 
       } else {
         // Send OutgoingInvitation to IPC socket

--- a/content/browser/child_process_launcher_helper_android.cc
+++ b/content/browser/child_process_launcher_helper_android.cc
@@ -28,6 +28,7 @@
 
 #if defined(CASTANETS)
 #include "base/base_switches.h"
+#include "base/distributed_chromium_util.h"
 #endif
 
 using base::android::AttachCurrentThread;
@@ -74,9 +75,7 @@ ChildProcessLauncherHelper::CreateNamedPlatformChannelOnClientThread() {
   if (!remote_process_)
     return base::nullopt;
 
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  if (!command_line->HasSwitch(switches::kServerAddress) ||
-      command_line->GetSwitchValueASCII(switches::kServerAddress).empty()) {
+  if (base::Castanets::ServerAddress().empty()) {
     mojo::NamedPlatformChannel::Options options;
     options.port = (GetProcessType() == switches::kRendererProcess)
                        ? mojo::kCastanetsRendererPort
@@ -131,7 +130,7 @@ ChildProcessLauncherHelper::LaunchProcessOnLauncherThread(
     bool* is_synchronous_launch,
     int* launch_result) {
 #if defined(CASTANETS)
-  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kEnableForking)) {
+  if (base::Castanets::IsEnabled()) {
     Process castanets_process;
     // Positive: normal process
     // 0: kNullProcessHandle
@@ -270,7 +269,8 @@ void ChildProcessLauncherHelper::SetProcessPriorityOnLauncherThread(
     base::Process process,
     const ChildProcessLauncherPriority& priority) {
 #if defined(CASTANETS)
-  return;
+  if (base::Castanets::IsEnabled())
+    return;
 #endif
   JNIEnv* env = AttachCurrentThread();
   DCHECK(env);

--- a/content/browser/child_process_security_policy_impl.cc
+++ b/content/browser/child_process_security_policy_impl.cc
@@ -46,6 +46,10 @@
 #include "url/url_canon.h"
 #include "url/url_constants.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 
 namespace {
@@ -320,7 +324,8 @@ class ChildProcessSecurityPolicyImpl::SecurityState {
 #if defined(CASTANETS)
     // TODO BeginNavigation mojo IPC are blocked in castanets mode.
     // The below change is a workaround.
-    return true;
+    if (base::Castanets::IsEnabled())
+      return true;
 #endif
 
     if (origin_lock_.is_empty())

--- a/content/browser/frame_host/frame_tree_node.cc
+++ b/content/browser/frame_host/frame_tree_node.cc
@@ -30,6 +30,9 @@
 #include "third_party/blink/public/common/frame/sandbox_flags.h"
 #include "third_party/blink/public/common/frame/user_activation_update_type.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
 namespace content {
 
 namespace {
@@ -397,7 +400,7 @@ bool FrameTreeNode::CommitPendingFramePolicy() {
 void FrameTreeNode::TransferNavigationRequestOwnership(
     RenderFrameHostImpl* render_frame_host) {
 #if defined(CASTANETS)
-  if (!navigation_request_) {
+  if (base::Castanets::IsEnabled() && !navigation_request_) {
     LOG(WARNING)<< "NavigationRequest is null";
     return;
   }

--- a/content/browser/frame_host/render_frame_host_manager.cc
+++ b/content/browser/frame_host/render_frame_host_manager.cc
@@ -62,6 +62,10 @@
 #include "ui/gfx/mac/scoped_cocoa_disable_screen_updates.h"
 #endif  // defined(OS_MACOSX)
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 
 namespace {
@@ -601,7 +605,7 @@ RenderFrameHostImpl* RenderFrameHostManager::GetFrameHostForNavigation(
 #if defined(CASTANETS)
   // FIXME: Currently once use_current_rfh is false, browser seem to be creating
   // new channel for renderer ignoring the already connected renderer.
-  if (1 || use_current_rfh) {
+  if (base::Castanets::IsEnabled() || use_current_rfh) {
 #else
   if (use_current_rfh) {
 #endif

--- a/content/browser/renderer_host/render_process_host_impl.cc
+++ b/content/browser/renderer_host/render_process_host_impl.cc
@@ -277,6 +277,10 @@
 #define NumberToStringType base::NumberToString
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 
 namespace {
@@ -3105,7 +3109,7 @@ void RenderProcessHostImpl::PropagateBrowserCommandLineToRenderer(
     switches::kIpcFuzzerTestcase,
 #endif
 #if defined(CASTANETS)
-    switches::kServerAddress,
+    switches::kEnableCastanets,
 #endif
   };
   renderer_cmd->CopySwitchesFrom(browser_cmd, kSwitchNames,
@@ -4096,8 +4100,12 @@ RenderProcessHost* RenderProcessHostImpl::GetProcessHostForSiteInstance(
 
 void RenderProcessHostImpl::CreateSharedRendererHistogramAllocator() {
 #if defined(CASTANETS)
-  LOG(INFO) << "SKIP!!!!! RenderProcessHostImpl::CreateSharedRendererHistogramAllocator";
-  return;
+  if (base::Castanets::IsEnabled()) {
+    LOG(INFO)
+        << "SKIP!!!!! "
+           "RenderProcessHostImpl::CreateSharedRendererHistogramAllocator";
+    return;
+  }
 #endif
   // Create a persistent memory segment for renderer histograms only if
   // they're active in the browser.

--- a/content/child/child_process_sandbox_support_impl_linux.cc
+++ b/content/child/child_process_sandbox_support_impl_linux.cc
@@ -19,6 +19,7 @@
 #include "third_party/blink/public/platform/web_vector.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "ui/gfx/font_fallback_linux.h"
 #include "ui/gfx/font_render_params.h"
 #endif
@@ -47,45 +48,50 @@ void WebSandboxSupportLinux::GetFallbackFontForCharacter(
   }
 
 #if defined(CASTANETS)
-  auto fallback_font_ = gfx::GetFallbackFontForChar(character, preferred_locale);
+  if (base::Castanets::IsEnabled()) {
+    auto fallback_font_ =
+        gfx::GetFallbackFontForChar(character, preferred_locale);
 
-  font_service::mojom::FontIdentityPtr identity(font_service::mojom::FontIdentity::New());
-  identity->id = 0;
-  identity->ttc_index = fallback_font_.ttc_index;
-  identity->str_representation = fallback_font_.filename;
+    font_service::mojom::FontIdentityPtr identity(
+        font_service::mojom::FontIdentity::New());
+    identity->id = 0;
+    identity->ttc_index = fallback_font_.ttc_index;
+    identity->str_representation = fallback_font_.filename;
 
-  std::string family_name = fallback_font_.name;
-  fallback_font->name =
-      blink::WebString::FromUTF8(family_name.c_str(), family_name.length());
-  fallback_font->fontconfig_interface_id = 0;
-  fallback_font->filename.Assign(identity->str_representation.c_str(),
-                                 identity->str_representation.length());
-  fallback_font->ttc_index = fallback_font_.ttc_index;
-  fallback_font->is_bold = fallback_font_.is_bold;
-  fallback_font->is_italic = fallback_font_.is_italic;
-#else
-  font_service::mojom::FontIdentityPtr font_identity;
-  bool is_bold = false;
-  bool is_italic = false;
-  std::string family_name;
-  if (!font_loader_->FallbackFontForCharacter(character, preferred_locale,
-                                              &font_identity, &family_name,
-                                              &is_bold, &is_italic)) {
-    LOG(ERROR) << "FontService fallback request does not receive a response.";
-    return;
-  }
-
-  // TODO(drott): Perhaps take OutOfProcessFont out of the picture here and pass
-  // mojo FontIdentityPtr directly?
-  fallback_font->name =
-      blink::WebString::FromUTF8(family_name.c_str(), family_name.length());
-  fallback_font->fontconfig_interface_id = font_identity->id;
-  fallback_font->filename.Assign(font_identity->str_representation.c_str(),
-                                 font_identity->str_representation.length());
-  fallback_font->ttc_index = font_identity->ttc_index;
-  fallback_font->is_bold = is_bold;
-  fallback_font->is_italic = is_italic;
+    std::string family_name = fallback_font_.name;
+    fallback_font->name =
+        blink::WebString::FromUTF8(family_name.c_str(), family_name.length());
+    fallback_font->fontconfig_interface_id = 0;
+    fallback_font->filename.Assign(identity->str_representation.c_str(),
+                                   identity->str_representation.length());
+    fallback_font->ttc_index = fallback_font_.ttc_index;
+    fallback_font->is_bold = fallback_font_.is_bold;
+    fallback_font->is_italic = fallback_font_.is_italic;
+  } else
 #endif
+  {
+    font_service::mojom::FontIdentityPtr font_identity;
+    bool is_bold = false;
+    bool is_italic = false;
+    std::string family_name;
+    if (!font_loader_->FallbackFontForCharacter(character, preferred_locale,
+                                                &font_identity, &family_name,
+                                                &is_bold, &is_italic)) {
+      LOG(ERROR) << "FontService fallback request does not receive a response.";
+      return;
+    }
+
+    // TODO(drott): Perhaps take OutOfProcessFont out of the picture here and
+    // pass mojo FontIdentityPtr directly?
+    fallback_font->name =
+        blink::WebString::FromUTF8(family_name.c_str(), family_name.length());
+    fallback_font->fontconfig_interface_id = font_identity->id;
+    fallback_font->filename.Assign(font_identity->str_representation.c_str(),
+                                   font_identity->str_representation.length());
+    fallback_font->ttc_index = font_identity->ttc_index;
+    fallback_font->is_bold = is_bold;
+    fallback_font->is_italic = is_italic;
+  }
 
   base::AutoLock lock(lock_);
   unicode_font_families_.emplace(character, *fallback_font);

--- a/content/common/service_manager/child_connection.cc
+++ b/content/common/service_manager/child_connection.cc
@@ -20,6 +20,10 @@
 #include "services/service_manager/public/cpp/identity.h"
 #include "services/service_manager/public/mojom/service.mojom.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 
 class ChildConnection::IOThreadContext
@@ -136,10 +140,14 @@ ChildConnection::ChildConnection(
       child_identity_(child_identity),
       weak_factory_(this) {
 #if defined(CASTANETS)
-if (child_identity.name() == "content_utility")
-    service_token_ = "castanets_service_utility_request";
-  else
-    service_token_ = "castanets_service_request";
+  if (base::Castanets::IsEnabled()) {
+    if (child_identity.name() == "content_utility")
+      service_token_ = "castanets_service_utility_request";
+    else
+      service_token_ = "castanets_service_request";
+  } else {
+    service_token_ = base::NumberToString(base::RandUint64());
+  }
 #else
   service_token_ = base::NumberToString(base::RandUint64());
 #endif

--- a/content/public/browser/content_browser_client.cc
+++ b/content/public/browser/content_browser_client.cc
@@ -43,6 +43,10 @@
 #include "url/gurl.h"
 #include "url/origin.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 
 void OverrideOnBindInterface(const service_manager::BindSourceInfo& remote_info,
@@ -244,9 +248,13 @@ ContentBrowserClient::GetOriginsRequiringDedicatedProcess() {
 }
 
 bool ContentBrowserClient::ShouldEnableStrictSiteIsolation() {
-#if defined(OS_ANDROID) || defined(CASTANETS)
+#if defined(OS_ANDROID)
   return false;
 #else
+#if defined(CASTANETS)
+  if (base::Castanets::IsEnabled())
+    return false;
+#endif
   return true;
 #endif
 }

--- a/content/public/common/content_features.cc
+++ b/content/public/common/content_features.cc
@@ -275,7 +275,7 @@ const base::Feature kMojoVideoCaptureSecondary{
 // If the network service is enabled, runs it in process.
 const base::Feature kNetworkServiceInProcess {
   "NetworkServiceInProcess",
-#if defined(OS_ANDROID) && !defined(CASTANETS)
+#if defined(OS_ANDROID)
       base::FEATURE_ENABLED_BY_DEFAULT
 #else
       base::FEATURE_DISABLED_BY_DEFAULT
@@ -481,11 +481,7 @@ const base::Feature kSmsReceiver{"SmsReceiver",
 // spare renderer process around for the most recently requested BrowserContext.
 // This feature is only consulted in site-per-process mode.
 const base::Feature kSpareRendererForSitePerProcess{
-#if defined(CASTANETS)
-    "SpareRendererForSitePerProcess", base::FEATURE_DISABLED_BY_DEFAULT};
-#else
     "SpareRendererForSitePerProcess", base::FEATURE_ENABLED_BY_DEFAULT};
-#endif
 
 // Enables StaleWhileRevalidate support.
 // https://www.chromestatus.com/features/5050913014153216

--- a/content/public/common/use_zoom_for_dsf_policy.cc
+++ b/content/public/common/use_zoom_for_dsf_policy.cc
@@ -12,6 +12,10 @@
 #include "base/feature_list.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace {
 
 #if defined(OS_WIN)
@@ -19,15 +23,17 @@ const base::Feature kUseZoomForDsfEnabledByDefault{
     "use-zoom-for-dsf enabled by default", base::FEATURE_ENABLED_BY_DEFAULT};
 #endif
 
-#if defined(OS_ANDROID) && !defined(CASTANETS)
+#if defined(OS_ANDROID)
 const base::Feature kUseZoomForDsfEnabledByDefault{
     "use-zoom-for-dsf enabled by default", base::FEATURE_ENABLED_BY_DEFAULT};
 #endif
 
 bool IsUseZoomForDSFEnabledByDefault() {
 #if defined(CASTANETS)
-  return false;
-#elif defined(OS_LINUX) || defined(OS_FUCHSIA)
+  if (base::Castanets::IsEnabled())
+    return false;
+#endif
+#if defined(OS_LINUX) || defined(OS_FUCHSIA)
   return true;
 #elif defined(OS_WIN) || defined(OS_ANDROID)
   return base::FeatureList::IsEnabled(kUseZoomForDsfEnabledByDefault);

--- a/content/renderer/input/render_widget_input_handler.cc
+++ b/content/renderer/input/render_widget_input_handler.cc
@@ -50,6 +50,7 @@
 #endif
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "content/common/widget_messages.h"
 #endif
 
@@ -428,18 +429,20 @@ void RenderWidgetInputHandler::HandleInputEvent(
   }
 
 #if defined(CASTANETS)
-  // TODO(youngsoo): To avoid IPC,
-  // remove this after http://107.108.218.239/bugzilla/show_bug.cgi?id=9406
-  if (WebInputEvent::IsKeyboardEventType(input_event.GetType())) {
-    // This message is called for every IME key input.
-    // The current status of processing the input event is used to
-    // properly manage 'CommitQueue' or 'PreeditQueue' on impl side:
-    // If the event is not processed, 'ConfirmComposition' or 'SetComposition'
-    // is called for IME composition, and then pops event queue.
-    // If the event is processed instead, impl side just pops the queue.
-    widget_->Send(new WidgetHostMsg_DidHandleKeyEvent(
-        widget_->routing_id(), &input_event,
-        processed != WebInputEventResult::kNotHandled));
+  if (base::Castanets::IsEnabled()) {
+    // TODO(youngsoo): To avoid IPC,
+    // remove this after http://107.108.218.239/bugzilla/show_bug.cgi?id=9406
+    if (WebInputEvent::IsKeyboardEventType(input_event.GetType())) {
+      // This message is called for every IME key input.
+      // The current status of processing the input event is used to
+      // properly manage 'CommitQueue' or 'PreeditQueue' on impl side:
+      // If the event is not processed, 'ConfirmComposition' or 'SetComposition'
+      // is called for IME composition, and then pops event queue.
+      // If the event is processed instead, impl side just pops the queue.
+      widget_->Send(new WidgetHostMsg_DidHandleKeyEvent(
+          widget_->routing_id(), &input_event,
+          processed != WebInputEventResult::kNotHandled));
+    }
   }
 #endif
 

--- a/content/renderer/media/audio/mojo_audio_output_ipc.cc
+++ b/content/renderer/media/audio/mojo_audio_output_ipc.cc
@@ -16,6 +16,7 @@
 #if defined(CASTANETS)
 #include "base/base_switches.h"
 #include "base/command_line.h"
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/platform/tcp_platform_handle_utils.h"
 #endif
 
@@ -251,7 +252,7 @@ void MojoAudioOutputIPC::Created(
 
 #if defined(CASTANETS)
   // If socket_handle is invalid.
-  if (socket_handle < 0) {
+  if (base::Castanets::IsEnabled() && (socket_handle < 0)) {
     uint16_t port = 0;
     mojo::PlatformHandle server_handle;
 
@@ -289,11 +290,8 @@ void MojoAudioOutputIPC::RequestTCPConnectCallback(
                                     &socket_handle);
   } else {
     // Create a TCP client socket.
-    base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-    std::string server_address =
-        command_line->GetSwitchValueASCII(switches::kServerAddress);
-    mojo::PlatformHandle tcp_client_handle =
-        mojo::CreateTCPClientHandle(assigned_port, server_address);
+    mojo::PlatformHandle tcp_client_handle = mojo::CreateTCPClientHandle(
+        assigned_port, base::Castanets::ServerAddress());
     if (!tcp_client_handle.is_valid()) {
       LOG(ERROR) << __func__ << " tcp_client_handle is not valid.";
       return;
@@ -313,10 +311,7 @@ void MojoAudioOutputIPC::RequestTCPConnectCallback(
 
 bool MojoAudioOutputIPC::IsTCPServer() {
   // Check if the TCP client or the TCP server using kSeverAddress.
-  bool is_server = base::CommandLine::ForCurrentProcess()->HasSwitch(
-                       switches::kServerAddress)
-                       ? false
-                       : true;
+  bool is_server = base::Castanets::ServerAddress().empty() ? false : true;
   return is_server;
 }
 #endif

--- a/content/renderer/render_widget.cc
+++ b/content/renderer/render_widget.cc
@@ -134,6 +134,10 @@
 #include "content/renderer/text_input_client_observer.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 using blink::WebImeTextSpan;
 using blink::WebCursorInfo;
 using blink::WebDeviceEmulationParams;
@@ -1664,10 +1668,12 @@ void RenderWidget::IntrinsicSizingInfoChanged(
 void RenderWidget::DidMeaningfulLayout(blink::WebMeaningfulLayout layout_type) {
   if (layout_type == blink::WebMeaningfulLayout::kVisuallyNonEmpty) {
 #if defined(CASTANETS)
-    Send(new WidgetHostMsg_DidFirstVisuallyNonEmptyPaint(routing_id_));
-#else
-    QueueMessage(new WidgetHostMsg_DidFirstVisuallyNonEmptyPaint(routing_id_));
+    if (base::Castanets::IsEnabled())
+      Send(new WidgetHostMsg_DidFirstVisuallyNonEmptyPaint(routing_id_));
+    else
 #endif
+      QueueMessage(
+          new WidgetHostMsg_DidFirstVisuallyNonEmptyPaint(routing_id_));
   }
 
   for (auto& observer : render_frames_)

--- a/content/test/test_render_frame.cc
+++ b/content/test/test_render_frame.cc
@@ -182,7 +182,7 @@ class MockFrameHost : public mojom::FrameHost {
                             int error_code,
                             const base::string16& error_description) override {}
 
-#if defined(OS_ANDROID)
+#if defined(OS_ANDROID) || defined(CASTANETS)
   void UpdateUserGestureCarryoverInfo() override {}
 #endif
 

--- a/gpu/command_buffer/client/cmd_buffer_helper.cc
+++ b/gpu/command_buffer/client/cmd_buffer_helper.cc
@@ -23,6 +23,7 @@
 
 #if defined(CASTANETS)
 #include "base/command_line.h"
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -206,7 +207,8 @@ void CommandBufferHelper::Flush() {
 
   if (HaveRingBuffer()) {
 #if defined(CASTANETS)
-    SyncSharedMemoryForCommands();
+    if (base::Castanets::IsEnabled())
+      SyncSharedMemoryForCommands();
 #endif
     last_flush_time_ = base::TimeTicks::Now();
     last_flush_put_ = put_;
@@ -230,7 +232,8 @@ void CommandBufferHelper::OrderingBarrier() {
 
   if (HaveRingBuffer()) {
 #if defined(CASTANETS)
-    SyncSharedMemoryForCommands();
+    if (base::Castanets::IsEnabled())
+      SyncSharedMemoryForCommands();
 #endif
     last_ordering_barrier_put_ = put_;
     command_buffer_->OrderingBarrier(put_);

--- a/gpu/command_buffer/client/mapped_memory.h
+++ b/gpu/command_buffer/client/mapped_memory.h
@@ -20,6 +20,7 @@
 
 #if defined(CASTANETS)
 #include "base/command_line.h"
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -87,10 +88,10 @@ class GPU_EXPORT MemoryChunk {
   void FreePendingToken(void* pointer, uint32_t token) {
     allocator_.FreePendingToken(pointer, token);
 #if defined(CASTANETS)
-    if (std::string("renderer") ==
-        base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
-      mojo::SyncSharedMemory(shm_->backing()->GetGUID(),
-                             GetOffset(pointer),
+    if (base::Castanets::IsEnabled() &&
+        (std::string("renderer") ==
+         base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type"))) {
+      mojo::SyncSharedMemory(shm_->backing()->GetGUID(), GetOffset(pointer),
                              allocator_.GetBlockSize(pointer));
     }
 #endif

--- a/gpu/command_buffer/client/transfer_buffer.cc
+++ b/gpu/command_buffer/client/transfer_buffer.cc
@@ -16,6 +16,7 @@
 
 #if defined(CASTANETS)
 #include "base/command_line.h"
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -93,8 +94,9 @@ void TransferBuffer::DiscardBlock(void* p) {
 void TransferBuffer::FreePendingToken(void* p, unsigned int token) {
   ring_buffer_->FreePendingToken(p, token);
 #if defined(CASTANETS)
-  if (std::string("renderer") ==
-      base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
+  if (base::Castanets::IsEnabled() &&
+      (std::string("renderer") ==
+       base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type"))) {
     mojo::SyncSharedMemory(shared_memory_guid(), GetOffset(p),
                            ring_buffer_->GetBlockSize(p));
   }

--- a/gpu/command_buffer/service/command_buffer_service.cc
+++ b/gpu/command_buffer/service/command_buffer_service.cc
@@ -17,6 +17,7 @@
 #include "gpu/command_buffer/service/transfer_buffer_manager.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -65,7 +66,7 @@ void CommandBufferService::Flush(int32_t put_offset,
   }
 
 #if defined(CASTANETS)
-  if (ring_buffer_ && ring_buffer_->backing())
+  if (base::Castanets::IsEnabled() && ring_buffer_ && ring_buffer_->backing())
     mojo::WaitSyncSharedMemory(ring_buffer_->backing()->GetGUID());
 #endif
 

--- a/gpu/command_buffer/service/common_decoder.cc
+++ b/gpu/command_buffer/service/common_decoder.cc
@@ -15,6 +15,7 @@
 #include "gpu/command_buffer/service/decoder_client.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -344,10 +345,12 @@ error::Error CommonDecoder::HandleGetBucketStart(
     memcpy(data, bucket->GetData(0, size), size);
   }
 #if defined(CASTANETS)
-  scoped_refptr<gpu::Buffer> buffer =
-      command_buffer_service_->GetTransferBuffer(data_memory_id);
-  mojo::SyncSharedMemory(buffer->backing()->GetGUID(), data_memory_offset,
-                         data_memory_size);
+  if (base::Castanets::IsEnabled()) {
+    scoped_refptr<gpu::Buffer> buffer =
+        command_buffer_service_->GetTransferBuffer(data_memory_id);
+    mojo::SyncSharedMemory(buffer->backing()->GetGUID(), data_memory_offset,
+                           data_memory_size);
+  }
 #endif
   return error::kNoError;
 }
@@ -374,9 +377,11 @@ error::Error CommonDecoder::HandleGetBucketData(uint32_t immediate_data_size,
   }
   memcpy(data, src, size);
 #if defined(CASTANETS)
-  scoped_refptr<gpu::Buffer> buffer =
-      command_buffer_service_->GetTransferBuffer(args.shared_memory_id);
-  mojo::SyncSharedMemory(buffer->backing()->GetGUID(), offset, size);
+  if (base::Castanets::IsEnabled()) {
+    scoped_refptr<gpu::Buffer> buffer =
+        command_buffer_service_->GetTransferBuffer(args.shared_memory_id);
+    mojo::SyncSharedMemory(buffer->backing()->GetGUID(), offset, size);
+  }
 #endif
   return error::kNoError;
 }

--- a/gpu/ipc/common/gpu_memory_buffer_support.cc
+++ b/gpu/ipc/common/gpu_memory_buffer_support.cc
@@ -178,7 +178,7 @@ GpuMemoryBufferSupport::CreateGpuMemoryBufferImplFromHandle(
       return GpuMemoryBufferImplDXGI::CreateFromHandle(
           std::move(handle), size, format, usage, std::move(callback));
 #endif
-#if defined(OS_ANDROID)  && !defined(CASTANETS)
+#if defined(OS_ANDROID) && !defined(CASTANETS)
     case gfx::ANDROID_HARDWARE_BUFFER:
       return GpuMemoryBufferImplAndroidHardwareBuffer::CreateFromHandle(
           std::move(handle), size, format, usage, std::move(callback));

--- a/media/audio/audio_output_device_thread_callback.cc
+++ b/media/audio/audio_output_device_thread_callback.cc
@@ -10,6 +10,7 @@
 #include "base/trace_event/trace_event.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -84,7 +85,8 @@ void AudioOutputDeviceThreadCallback::Process(uint32_t control_signal) {
   callback_num_++;
 
 #if defined(CASTANETS)
-  mojo::WaitSyncSharedMemory(shared_memory_region_.GetGUID());
+  if (base::Castanets::IsEnabled())
+    mojo::WaitSyncSharedMemory(shared_memory_region_.GetGUID());
 #endif
   // Read and reset the number of frames skipped.
   media::AudioOutputBuffer* buffer =
@@ -129,8 +131,10 @@ void AudioOutputDeviceThreadCallback::Process(uint32_t control_signal) {
   }
 
 #if defined(CASTANETS)
-  mojo::SyncSharedMemory(shared_memory_region_.GetGUID(), 0,
-                         shared_memory_region_.GetSize());
+  if (base::Castanets::IsEnabled()) {
+    mojo::SyncSharedMemory(shared_memory_region_.GetGUID(), 0,
+                           shared_memory_region_.GetSize());
+  }
 #endif
 
   TRACE_EVENT_END2("audio", "AudioOutputDevice::FireRenderCallback",

--- a/media/audio/audio_sync_reader.cc
+++ b/media/audio/audio_sync_reader.cc
@@ -22,6 +22,7 @@
 #include "media/base/media_switches.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -173,8 +174,10 @@ void AudioSyncReader::RequestMoreData(base::TimeDelta delay,
   output_bus_->Zero();
 
 #if defined(CASTANETS)
-  mojo::SyncSharedMemory(shared_memory_region_.GetGUID(), 0,
-                         shared_memory_region_.GetSize());
+  if (base::Castanets::IsEnabled()) {
+    mojo::SyncSharedMemory(shared_memory_region_.GetGUID(), 0,
+                           shared_memory_region_.GetSize());
+  }
 #endif
 
   uint32_t control_signal = 0;
@@ -223,7 +226,8 @@ void AudioSyncReader::Read(AudioBus* dest) {
   trailing_renderer_missed_callback_count_ = 0;
 
 #if defined(CASTANETS)
-  mojo::WaitSyncSharedMemory(shared_memory_region_.GetGUID());
+  if (base::Castanets::IsEnabled())
+    mojo::WaitSyncSharedMemory(shared_memory_region_.GetGUID());
 #endif
 
   // Zeroed buffers may be discarded immediately when outputing compressed

--- a/media/mojo/services/mojo_audio_output_stream.cc
+++ b/media/mojo/services/mojo_audio_output_stream.cc
@@ -17,6 +17,7 @@
 #if defined(CASTANETS)
 #include "base/base_switches.h"
 #include "base/command_line.h"
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/platform/tcp_platform_handle_utils.h"
 #endif
 
@@ -94,13 +95,9 @@ void MojoAudioOutputStream::RequestTCPConnect(
                                     &socket_handle);
   } else {
     std::move(callback).Run(assigned_port);
-
-    std::string server_address =
-        base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(
-            switches::kServerAddress);
     // Create a TCP client socket.
-    mojo::PlatformHandle tcp_client_handle =
-        mojo::CreateTCPClientHandle(assigned_port, server_address);
+    mojo::PlatformHandle tcp_client_handle = mojo::CreateTCPClientHandle(
+        assigned_port, base::Castanets::ServerAddress());
     if (!tcp_client_handle.is_valid()) {
       LOG(ERROR) << __func__ << " tcp_client_handle is not valid.";
       return;

--- a/media/renderers/video_resource_updater.cc
+++ b/media/renderers/video_resource_updater.cc
@@ -53,6 +53,7 @@
 #include "ui/gl/trace_util.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -990,10 +991,12 @@ VideoFrameExternalResources VideoResourceUpdater::CreateForSoftwarePlanes(
         video_renderer_->Copy(video_frame, &canvas, nullptr);
 #if defined(CASTANETS)
         // Compute the memory size with a RGBA_8888 format.
-        size_t memory_bytes = software_resource->resource_size().width() *
-                              software_resource->resource_size().height() * 4;
-        mojo::SyncSharedMemory(software_resource->GetSharedMemoryGuid(),
-                               0, memory_bytes);
+        if (base::Castanets::IsEnabled()) {
+          size_t memory_bytes = software_resource->resource_size().width() *
+                                software_resource->resource_size().height() * 4;
+          mojo::SyncSharedMemory(software_resource->GetSharedMemoryGuid(), 0,
+                                 memory_bytes);
+        }
 #endif
 
       } else {

--- a/media/video/gpu_memory_buffer_video_frame_pool.cc
+++ b/media/video/gpu_memory_buffer_video_frame_pool.cc
@@ -39,6 +39,7 @@
 #include "ui/gl/trace_util.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -725,9 +726,11 @@ void GpuMemoryBufferVideoFramePool::PoolImpl::OnCopiesDone(
   for (const auto& plane_resource : frame_resources->plane_resources) {
     if (plane_resource.gpu_memory_buffer) {
 #if defined(CASTANETS)
-      gfx::GpuMemoryBuffer* buffer = plane_resource.gpu_memory_buffer.get();
-      mojo::SyncSharedMemory(buffer->CloneHandle().region.GetGUID(), 0,
-                             buffer->CloneHandle().region.GetSize());
+      if (base::Castanets::IsEnabled()) {
+        gfx::GpuMemoryBuffer* buffer = plane_resource.gpu_memory_buffer.get();
+        mojo::SyncSharedMemory(buffer->CloneHandle().region.GetGUID(), 0,
+                               buffer->CloneHandle().region.GetSize());
+      }
 #endif
       plane_resource.gpu_memory_buffer->Unmap();
       plane_resource.gpu_memory_buffer->SetColorSpace(

--- a/mojo/core/broker_host.cc
+++ b/mojo/core/broker_host.cc
@@ -18,6 +18,10 @@
 #include <windows.h>
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace mojo {
 namespace core {
 
@@ -73,15 +77,15 @@ bool BrokerHost::SendChannel(PlatformHandle handle) {
       CreateBrokerMessage(BrokerMessageType::INIT, 1, 0, &data);
   data->pipe_name_length = 0;
 #else
+  Channel::MessagePtr message;
 #if defined(CASTANETS)
-  InitData* data;
-  Channel::MessagePtr message =
-      CreateBrokerMessage(BrokerMessageType::INIT, 1, 0, &data);
-  data->port = -1;
-#else
-  Channel::MessagePtr message =
-      CreateBrokerMessage(BrokerMessageType::INIT, 1, nullptr);
+  if (base::Castanets::IsEnabled()) {
+    InitData* data;
+    message = CreateBrokerMessage(BrokerMessageType::INIT, 1, 0, &data);
+    data->port = -1;
+  } else
 #endif
+    message = CreateBrokerMessage(BrokerMessageType::INIT, 1, nullptr);
 #endif
   std::vector<PlatformHandleInTransit> handles(1);
   handles[0] = PlatformHandleInTransit(std::move(handle));

--- a/mojo/core/broker_posix.cc
+++ b/mojo/core/broker_posix.cc
@@ -111,7 +111,7 @@ base::WritableSharedMemoryRegion Broker::GetWritableSharedMemoryRegion(
     return base::WritableSharedMemoryRegion();
   }
 
-#if !defined(OS_POSIX) || defined(OS_ANDROID) || \
+#if !defined(OS_POSIX) || (defined(OS_ANDROID) && !defined(CASTANETS)) || \
     (defined(OS_MACOSX) && !defined(OS_IOS))
   // Non-POSIX systems, as well as Android, and non-iOS Mac, only use a single
   // handle to represent a writable region.

--- a/mojo/core/channel_posix.cc
+++ b/mojo/core/channel_posix.cc
@@ -26,6 +26,7 @@
 #include "mojo/public/cpp/platform/socket_utils_posix.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "base/memory/castanets_memory_syncer.h"
 #include "base/memory/shared_memory_tracker.h"
 #include "base/task/post_task.h"
@@ -336,7 +337,8 @@ class ChannelPosix : public Channel,
       handles->at(i) = handles_in_transit[i].TakeHandle();
 #else
 #if defined(CASTANETS)
-    if (num_handles && incoming_fds_.size() < num_handles) {
+    if (base::Castanets::IsEnabled() && num_handles &&
+        incoming_fds_.size() < num_handles) {
       handles->clear();
       handles->resize(num_handles);
       for (size_t i = 0; i < num_handles; ++i)
@@ -504,17 +506,20 @@ class ChannelPosix : public Channel,
       read_watcher_.reset();
       base::MessageLoopCurrent::Get()->RemoveDestructionObserver(this);
 #if defined(CASTANETS)
-      TCPServerAcceptConnection(server_.platform_handle().GetFD().get(),
-                                &socket_);
-      if (secure_connection_) {
-        ssl_.reset(AcceptSSLConnection(socket_.get()));
-        CHECK(ssl_);
-        LOG(INFO) << "SSL Server Connection Success - socket: "
-                  << socket_.get();
-      }
-#else
-      AcceptSocketConnection(server_.platform_handle().GetFD().get(), &socket_);
+      if (base::Castanets::IsEnabled()) {
+        TCPServerAcceptConnection(server_.platform_handle().GetFD().get(),
+                                  &socket_);
+        if (secure_connection_) {
+          ssl_.reset(AcceptSSLConnection(socket_.get()));
+          CHECK(ssl_);
+          LOG(INFO) << "SSL Server Connection Success - socket: "
+                    << socket_.get();
+        }
+      } else
 #endif
+        AcceptSocketConnection(server_.platform_handle().GetFD().get(),
+                               &socket_);
+
       ignore_result(server_.TakePlatformHandle());
       if (!socket_.is_valid()) {
         OnError(Error::kConnectionFailed);
@@ -622,17 +627,20 @@ class ChannelPosix : public Channel,
         std::vector<base::ScopedFD> fds(num_handles_to_send);
         for (size_t i = 0; i < num_handles_to_send; ++i)
           fds[i] = handles[i + handles_written].TakeHandle().TakeFD();
+
 #if defined(CASTANETS)
-        scoped_refptr<base::SyncDelegate> delegate =
-            Core::Get()->GetNodeController()->GetSyncDelegate(
-                remote_process().get());
-        for (size_t i = 0; i < fds.size(); ++i) {
-          if (delegate)
-            base::SharedMemoryTracker::GetInstance()->MapExternalMemory(
-                fds[i].get(), delegate);
-          else
-            base::SharedMemoryTracker::GetInstance()->MapInternalMemory(
-                fds[i].get());
+        if (base::Castanets::IsEnabled()) {
+          scoped_refptr<base::SyncDelegate> delegate =
+              Core::Get()->GetNodeController()->GetSyncDelegate(
+                  remote_process().get());
+          for (size_t i = 0; i < fds.size(); ++i) {
+            if (delegate)
+              base::SharedMemoryTracker::GetInstance()->MapExternalMemory(
+                  fds[i].get(), delegate);
+            else
+              base::SharedMemoryTracker::GetInstance()->MapInternalMemory(
+                  fds[i].get());
+          }
         }
         if (secure_connection_)
           result = SecureSocketWrite(ssl_.get(), message_view.data(),

--- a/mojo/core/core.cc
+++ b/mojo/core/core.cc
@@ -43,6 +43,7 @@
 #include "mojo/core/watcher_dispatcher.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "base/memory/shared_memory_tracker.h"
 #endif // defined(CASTANETS)
 
@@ -1443,15 +1444,17 @@ MojoResult Core::SendInvitation(
                                          connection_name);
   } else {
 #if defined(CASTANETS)
-    if (transport_endpoint->type ==
-        MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_TCP_CLIENT) {
-      connection_params.SetTcpClient(
-          std::string(options->tcp_address, options->tcp_address_length),
-          options->tcp_port);
-    } else if (transport_endpoint->type ==
-               MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER) {
-      if (transport_endpoint->secure_connection)
-        connection_params.SetSecure();
+    if (base::Castanets::IsEnabled()) {
+      if (transport_endpoint->type ==
+          MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_TCP_CLIENT) {
+        connection_params.SetTcpClient(
+            std::string(options->tcp_address, options->tcp_address_length),
+            options->tcp_port);
+      } else if (transport_endpoint->type ==
+                 MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER) {
+        if (transport_endpoint->secure_connection)
+          connection_params.SetSecure();
+      }
     }
 #endif
     GetNodeController()->SendBrokerClientInvitation(
@@ -1519,16 +1522,18 @@ MojoResult Core::AcceptInvitation(
         ConnectionParams(PlatformChannelEndpoint(std::move(endpoint)));
   }
 #if defined(CASTANETS)
-  if (transport_endpoint->type ==
-      MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_TCP_CLIENT) {
-    connection_params.SetTcpClient(
-        std::string(transport_endpoint->tcp_address,
-                    transport_endpoint->tcp_address_length),
-        transport_endpoint->tcp_port);
-  } else if (transport_endpoint->type ==
-             MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER) {
-    if (transport_endpoint->secure_connection)
-      connection_params.SetSecure();
+  if (base::Castanets::IsEnabled()) {
+    if (transport_endpoint->type ==
+        MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_TCP_CLIENT) {
+      connection_params.SetTcpClient(
+          std::string(transport_endpoint->tcp_address,
+                      transport_endpoint->tcp_address_length),
+          transport_endpoint->tcp_port);
+    } else if (transport_endpoint->type ==
+               MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER) {
+      if (transport_endpoint->secure_connection)
+        connection_params.SetSecure();
+    }
   }
 #endif
 

--- a/mojo/core/data_pipe_producer_dispatcher.cc
+++ b/mojo/core/data_pipe_producer_dispatcher.cc
@@ -21,6 +21,10 @@
 #include "mojo/core/user_message_impl.h"
 #include "mojo/public/c/system/data_pipe.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace mojo {
 namespace core {
 
@@ -239,7 +243,8 @@ MojoResult DataPipeProducerDispatcher::EndWriteData(
         (write_offset_ + num_bytes_written) % options_.capacity_num_bytes;
 
 #if defined(CASTANETS)
-    SyncData(num_bytes_written);
+    if (base::Castanets::IsEnabled())
+      SyncData(num_bytes_written);
 #endif
     base::AutoUnlock unlock(lock_);
     NotifyWrite(num_bytes_written);

--- a/mojo/core/node_controller.h
+++ b/mojo/core/node_controller.h
@@ -389,7 +389,8 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
 #if !defined(OS_MACOSX) && !defined(OS_NACL_SFI) && !defined(OS_FUCHSIA)
   // Broker for sync shared buffer creation on behalf of broker clients.
 #if defined(CASTANETS)
-  scoped_refptr<BrokerCastanets> broker_;
+  scoped_refptr<BrokerCastanets> broker_castanets_;
+  std::unique_ptr<Broker> broker_;
   base::Lock broker_hosts_lock_;
   std::unordered_map<base::ProcessHandle, scoped_refptr<BrokerCastanets>>
       broker_hosts_;

--- a/mojo/core/shared_buffer_dispatcher.cc
+++ b/mojo/core/shared_buffer_dispatcher.cc
@@ -22,6 +22,7 @@
 #include "mojo/public/c/system/platform_handle.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "base/memory/shared_memory_helper.h"
 #include "base/memory/shared_memory_tracker.h"
 #endif // defined(CASTANETS)
@@ -188,19 +189,15 @@ scoped_refptr<SharedBufferDispatcher> SharedBufferDispatcher::Deserialize(
       mode, static_cast<size_t>(serialized_state->num_bytes), guid);
 
 #if defined(CASTANETS)
-  if (!region.IsValid()) {
-    base::SharedMemoryCreateOptions options;
-    options.size = static_cast<size_t>(serialized_state->num_bytes);
-    // TODO: Check why read only mode crashes
-#if 0
-    if (mode == base::subtle::PlatformSharedMemoryRegion::Mode::kReadOnly) {
-      options.share_read_only = true;
+  if (base::Castanets::IsEnabled()) {
+    if (!region.IsValid()) {
+      base::SharedMemoryCreateOptions options;
+      options.size = static_cast<size_t>(serialized_state->num_bytes);
+      region = base::CreateAnonymousSharedMemoryIfNeeded(guid, options);
+    } else {
+      base::SharedMemoryTracker::GetInstance()->MapInternalMemory(
+          region.GetPlatformHandle().fd);
     }
-#endif
-    region = base::CreateAnonymousSharedMemoryIfNeeded(guid, options);
-  } else {
-    base::SharedMemoryTracker::GetInstance()->MapInternalMemory(
-        region.GetPlatformHandle().fd);
   }
 #endif
 
@@ -386,8 +383,10 @@ bool SharedBufferDispatcher::EndSerialize(void* destination,
     handles[0] = std::move(platform_handles[0]);
     handles[1] = std::move(platform_handles[1]);
 #if defined(CASTANETS)
-    base::SharedMemoryTracker::GetInstance()->AddFDInTransit(
-        guid, handles[0].GetFD().get());
+    if (base::Castanets::IsEnabled()) {
+      base::SharedMemoryTracker::GetInstance()->AddFDInTransit(
+          guid, handles[0].GetFD().get());
+    }
 #endif
     return true;
   }
@@ -399,8 +398,10 @@ bool SharedBufferDispatcher::EndSerialize(void* destination,
       region.PassPlatformHandle(), &platform_handle, &ignored_handle);
   handles[0] = std::move(platform_handle);
 #if defined(CASTANETS)
-  base::SharedMemoryTracker::GetInstance()->AddFDInTransit(
-      guid, handles[0].GetFD().get());
+  if (base::Castanets::IsEnabled()) {
+    base::SharedMemoryTracker::GetInstance()->AddFDInTransit(
+        guid, handles[0].GetFD().get());
+  }
 #endif
   return true;
 }

--- a/mojo/public/cpp/platform/named_platform_channel_posix.cc
+++ b/mojo/public/cpp/platform/named_platform_channel_posix.cc
@@ -18,6 +18,10 @@
 #include "build/build_config.h"
 #include "mojo/public/cpp/platform/features.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace mojo {
 
 namespace {
@@ -95,7 +99,7 @@ PlatformChannelServerEndpoint NamedPlatformChannel::CreateServerEndpoint(
     const Options& options,
     ServerName* server_name) {
 #if defined(CASTANETS)
-  if (options.port > -1) {
+  if (base::Castanets::IsEnabled() && (options.port > -1)) {
     uint16_t port = options.port;
     return PlatformChannelServerEndpoint(CreateTCPServerHandle(port, &port));
   }

--- a/services/network/public/cpp/features.cc
+++ b/services/network/public/cpp/features.cc
@@ -18,11 +18,7 @@ const base::Feature kNetworkErrorLogging{"NetworkErrorLogging",
                                          base::FEATURE_ENABLED_BY_DEFAULT};
 // Enables the network service.
 const base::Feature kNetworkService{"NetworkService",
-#if defined(CASTANETS)
-                                    base::FEATURE_DISABLED_BY_DEFAULT};
-#else
                                     base::FEATURE_ENABLED_BY_DEFAULT};
-#endif
 
 // Out of Blink CORS
 const base::Feature kOutOfBlinkCors {

--- a/third_party/blink/renderer/core/loader/resource/script_resource.cc
+++ b/third_party/blink/renderer/core/loader/resource/script_resource.cc
@@ -50,6 +50,10 @@
 #include "third_party/blink/renderer/platform/shared_buffer.h"
 #include "third_party/blink/renderer/platform/wtf/functional.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace blink {
 
 namespace {
@@ -314,11 +318,13 @@ void ScriptResource::OnDataPipeReadable(MojoResult result,
       data_pipe_->BeginReadData(&data, &data_size, flags_to_pass);
 
 #if defined(CASTANETS)
-  // When JS resources are sent in chunks from browser, there are chances,
-  // we may attempt to read more data than received from data pipe.
-  if (begin_read_result == MOJO_RESULT_SHOULD_WAIT) {
-    watcher_->ArmOrNotify();
-    return;
+  if (base::Castanets::IsEnabled()) {
+    // When JS resources are sent in chunks from browser, there are chances,
+    // we may attempt to read more data than received from data pipe.
+    if (begin_read_result == MOJO_RESULT_SHOULD_WAIT) {
+      watcher_->ArmOrNotify();
+      return;
+    }
   }
 #endif
   // There should be data, so this read should succeed.

--- a/third_party/blink/renderer/platform/fonts/skia/font_cache_skia.cc
+++ b/third_party/blink/renderer/platform/fonts/skia/font_cache_skia.cc
@@ -54,6 +54,10 @@
 #include "third_party/skia/include/core/SkStream.h"
 #include "third_party/skia/include/core/SkTypeface.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace blink {
 
 AtomicString ToAtomicString(const SkString& str) {
@@ -198,9 +202,15 @@ sk_sp<SkTypeface> FontCache::CreateTypeface(
   // TODO(fuchsia): Revisit this and other font code for Fuchsia.
 
   if (creation_params.CreationType() == kCreateFontByFciIdAndTtcIndex) {
-#if !defined(CASTANETS)
+#if defined(CASTANETS)
     // fontconfigInterfaceId() of browser will not be known by renderer in
     // distributed chromium scenario. So lets go by filename.
+    if (!base::Castanets::IsEnabled() &&
+        Platform::Current()->GetSandboxSupport()) {
+      return SkTypeface_Factory::FromFontConfigInterfaceIdAndTtcIndex(
+          creation_params.FontconfigInterfaceId(), creation_params.TtcIndex());
+    }
+#else
     if (Platform::Current()->GetSandboxSupport()) {
       return SkTypeface_Factory::FromFontConfigInterfaceIdAndTtcIndex(
           creation_params.FontconfigInterfaceId(), creation_params.TtcIndex());


### PR DESCRIPTION
This change adds runtime flag to enable castanets.
Runtime flags --enable-forking, --server-address has been removed.
Castanets can be verified as below,

Standalone mode:
chrome <url>

Castanets mode:
Browser: chrome <url> --enable-castanets
Renderer: chrome --type=renderer --enable-castanets=<IP Address>

Signed-off-by: Santhoshkumar Kerur <santhosh.vk@samsung.com>
Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>