### PR TITLE
Fix dispatch error for FrameHostMsg_FocusedNodeChanged IPC.

### DIFF
--- a/content/browser/frame_host/render_frame_host_impl.cc
+++ b/content/browser/frame_host/render_frame_host_impl.cc
@@ -3537,7 +3537,12 @@ void RenderFrameHostImpl::OnSelectionChanged(const base::string16& text,
 
 void RenderFrameHostImpl::OnFocusedNodeChanged(
     bool is_editable_element,
-    const gfx::Rect& bounds_in_frame_widget) {
+    const gfx::Rect& bounds_in_frame_widget
+#if defined(CASTANETS)
+    ,
+    const FrameHostMsg_FocusedNodeChanged_Params& params
+#endif
+) {
   if (!GetView())
     return;
 

--- a/content/browser/frame_host/render_frame_host_impl.h
+++ b/content/browser/frame_host/render_frame_host_impl.h
@@ -109,6 +109,9 @@ struct FrameMsg_TextTrackSettings_Params;
 #if BUILDFLAG(USE_EXTERNAL_POPUP_MENU)
 struct FrameHostMsg_ShowPopup_Params;
 #endif
+#if defined(CASTANETS)
+struct FrameHostMsg_FocusedNodeChanged_Params;
+#endif
 
 namespace blink {
 class AssociatedInterfaceProvider;
@@ -1158,8 +1161,15 @@ class CONTENT_EXPORT RenderFrameHostImpl
   void OnSelectionChanged(const base::string16& text,
                           uint32_t offset,
                           const gfx::Range& range);
+#if defined(CASTANETS)
+  void OnFocusedNodeChanged(
+      bool is_editable_element,
+      const gfx::Rect& bounds_in_frame_widget,
+      const FrameHostMsg_FocusedNodeChanged_Params& params);
+#else
   void OnFocusedNodeChanged(bool is_editable_element,
                             const gfx::Rect& bounds_in_frame_widget);
+#endif
   void OnUpdateUserActivationState(blink::UserActivationUpdateType update_type);
   void OnSetHasReceivedUserGestureBeforeNavigation(bool value);
   void OnSetNeedsOcclusionTracking(bool needs_tracking);

--- a/content/common/frame_messages.h
+++ b/content/common/frame_messages.h
@@ -1220,9 +1220,22 @@ IPC_SYNC_MESSAGE_CONTROL3_1(FrameHostMsg_Are3DAPIsBlocked,
 // keyboard input (true for textfields, text areas and content editable divs).
 // The second parameter is the node bounds relative to local root's
 // RenderWidgetHostView.
+#if defined(CASTANETS)
+IPC_STRUCT_BEGIN(FrameHostMsg_FocusedNodeChanged_Params)
+  IPC_STRUCT_MEMBER(bool, is_radio_or_checkbox_input_node)
+  IPC_STRUCT_MEMBER(int, password_input_minlength)
+  IPC_STRUCT_MEMBER(bool, is_content_editable)
+IPC_STRUCT_END()
+
+IPC_MESSAGE_ROUTED3(FrameHostMsg_FocusedNodeChanged,
+                    bool /* is_editable_node */,
+                    gfx::Rect /* node_bounds */,
+                    FrameHostMsg_FocusedNodeChanged_Params /* params */)
+#else
 IPC_MESSAGE_ROUTED2(FrameHostMsg_FocusedNodeChanged,
                     bool /* is_editable_node */,
                     gfx::Rect /* node_bounds */)
+#endif
 
 #if BUILDFLAG(ENABLE_PLUGINS)
 // Notification sent from a renderer to the browser that a Pepper plugin

--- a/content/renderer/render_frame_impl.cc
+++ b/content/renderer/render_frame_impl.cc
@@ -6302,8 +6302,14 @@ void RenderFrameImpl::FocusedElementChanged(const WebElement& element) {
     is_editable = element.IsEditable();
     node_bounds = gfx::Rect(rect);
   }
+#if defined(CASTANETS)
+  FrameHostMsg_FocusedNodeChanged_Params params;
+  Send(new FrameHostMsg_FocusedNodeChanged(routing_id_, is_editable,
+                                           node_bounds, params));
+#else
   Send(new FrameHostMsg_FocusedNodeChanged(routing_id_, is_editable,
                                            node_bounds));
+#endif
   // Ensures that further text input state can be sent even when previously
   // focused input and the newly focused input share the exact same state.
   GetLocalRootRenderWidget()->ClearTextInputState();

--- a/ipc/ipc_message_templates.h
+++ b/ipc/ipc_message_templates.h
@@ -146,6 +146,10 @@ class MessageT<Meta, std::tuple<Ins...>, void> : public Message {
       DispatchToMethod(obj, func, parameter, std::move(p));
       return true;
     }
+#if defined(CASTANETS)
+    LOG(ERROR) << "IPC Dispatch error for " << Meta::kName
+               << " TYPE: " << msg->type() << " ID: " << Meta::ID;
+#endif
     return false;
   }
 
@@ -197,6 +201,10 @@ class MessageT<Meta, std::tuple<Ins...>, std::tuple<Outs...>>
       NOTREACHED() << "Error deserializing message " << msg->type();
       reply->set_reply_error();
       sender->Send(reply);
+#if defined(CASTANETS)
+      LOG(ERROR) << "IPC Dispatch error for " << Meta::kName
+                 << " TYPE: " << msg->type() << " ID: " << Meta::ID;
+#endif
       return false;
     }
 
@@ -221,6 +229,10 @@ class MessageT<Meta, std::tuple<Ins...>, std::tuple<Outs...>>
       NOTREACHED() << "Error deserializing message " << msg->type();
       reply->set_reply_error();
       obj->Send(reply);
+#if defined(CASTANETS)
+      LOG(ERROR) << "IPC Dispatch error for " << Meta::kName
+                 << " TYPE: " << msg->type() << " ID: " << Meta::ID;
+#endif
       return false;
     }
 
@@ -243,6 +255,10 @@ class MessageT<Meta, std::tuple<Ins...>, std::tuple<Outs...>>
       NOTREACHED() << "Error deserializing message " << msg->type();
       reply->set_reply_error();
       obj->Send(reply);
+#if defined(CASTANETS)
+      LOG(ERROR) << "IPC Dispatch error for " << Meta::kName
+                 << " TYPE: " << msg->type() << " ID: " << Meta::ID;
+#endif
       return false;
     }
 


### PR DESCRIPTION
IPC dispatch error is observed for FrameHostMsg_FocusedNodeChanged
when we focus button/textbox. This change makes the params similar to
efl port and also adds a error log when such dispatch error occurs
for debugging.

Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>