### PR TITLE
Show home screen intent only when castanets runtime flag is provided.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,30 +144,30 @@ $ autoninja -C out/Android chrome_public_apk
 #### 5.1 Run castanets in a local Ubuntu machine
 Start first chrome instance: Browser Process
 ```sh
-$ out/Default/chrome <URL>
+$ out/Default/chrome <URL> --enable-castanets
 ```
 
 Start second chrome instance: Renderer Process
 ```sh
-$ out/Default/chrome --type=renderer --server-address=127.0.0.1
+$ out/Default/chrome --type=renderer --enable-castanets=127.0.0.1
 ```
 
 #### 5.2 Run castanets in a distributed environment
 ##### 5.2.1 Local Ubuntu Browser and Remote Ubuntu Renderer
 _Device A: Browser Process_
 ```sh
-$ out/Default/chrome <URL>
+$ out/Default/chrome <URL> --enable-castanets
 ```
 
 _Device B: Renderer Process_
 ```sh
-$ out/Default/chrome --type=renderer --server-address=<BROWSER IP ADDR>
+$ out/Default/chrome --type=renderer --enable-castanets=<BROWSER IP ADDR>
 ```
 
 ##### 5.2.2 Local Ubuntu Browser and Remote Android Renderer
 _Device A: Browser Process_
 ```sh
-$ out/Default/chrome <URL>
+$ out/Default/chrome <URL> --enable-castanets
 ```
 _Android Device B: Renderer Process_
 Please setup adb(Android Debug Bridge) first.
@@ -175,6 +175,6 @@ Please setup adb(Android Debug Bridge) first.
 To run Android renderer,
 **adb shell with su permission**
 ```sh
-$(adb) echo "_ --type=renderer --server-address="BROWSER IP ADDR"" > /data/local/tmp/chrome-command-line
+$(adb) echo "_ --type=renderer --enable-castanets="BROWSER IP ADDR"" > /data/local/tmp/chrome-command-line
 ```
 Then touch the Castanets icon from the screen to execute renderer

--- a/base/android/java/src/org/chromium/base/BaseSwitches.java
+++ b/base/android/java/src/org/chromium/base/BaseSwitches.java
@@ -30,6 +30,9 @@ public abstract class BaseSwitches {
     // Enables the reached code profiler.
     public static final String ENABLE_REACHED_CODE_PROFILER = "enable-reached-code-profiler";
 
+    /* To Notify chrome/android that castanets will be enabled. */
+    public static final String ENABLE_CASTANETS = "enable-castanets";
+
     // Prevent instantiation.
     private BaseSwitches() {}
 }

--- a/chrome/android/java/src/org/chromium/chrome/browser/init/AsyncInitializationActivity.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/init/AsyncInitializationActivity.java
@@ -31,6 +31,8 @@ import android.view.ViewTreeObserver.OnPreDrawListener;
 import android.view.WindowManager;
 
 import org.chromium.base.ApiCompatibilityUtils;
+import org.chromium.base.BaseSwitches;
+import org.chromium.base.CommandLine;
 import org.chromium.base.ContextUtils;
 import org.chromium.base.Log;
 import org.chromium.base.OffloadingUtils;
@@ -279,9 +281,9 @@ public abstract class AsyncInitializationActivity extends ChromeBaseAppCompatAct
     @SuppressLint("MissingSuperCall")  // Called in onCreateInternal.
     protected final void onCreate(Bundle savedInstanceState) {
         // Hide the activity if castanets is enabled and runs as renderer process,
-        if (OffloadingUtils.IsCastanets()) {
+        if (CommandLine.getInstance().hasSwitch(BaseSwitches.ENABLE_CASTANETS)) {
             Intent startMain = new Intent(Intent.ACTION_MAIN);
-            startMain.addCategory (Intent.CATEGORY_HOME);
+            startMain.addCategory(Intent.CATEGORY_HOME);
             startMain.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             startActivity(startMain);
         } else if (OffloadingUtils.IsServiceOffloading()) {


### PR DESCRIPTION
This change,
i. Shows home screen intent only when --enable-castanets is provided.
ii. Corrects README with updated runtime flags.

Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>