### PR TITLE
Support shared memory for platform generic sensor.

### DIFF
--- a/mojo/public/c/system/buffer.h
+++ b/mojo/public/c/system/buffer.h
@@ -15,6 +15,10 @@
 #include "mojo/public/c/system/system_export.h"
 #include "mojo/public/c/system/types.h"
 
+#if defined(CASTANETS)
+#include "base/unguessable_token.h"
+#endif
+
 // Flags passed to |MojoCreateSharedBuffer()| via
 // |MojoCreateSharedBufferOptions|. See values defined below.
 typedef uint32_t MojoCreateSharedBufferFlags;
@@ -60,9 +64,19 @@ struct MOJO_ALIGNAS(8) MojoSharedBufferInfo {
 
   // The size of the shared buffer.
   uint64_t size;
+
+#if defined(CASTANETS)
+  base::UnguessableToken guid;
+#endif
 };
+
+#if defined(CASTANETS)
+MOJO_STATIC_ASSERT(sizeof(struct MojoSharedBufferInfo) == 32,
+                   "MojoSharedBufferInfo has wrong size");
+#else
 MOJO_STATIC_ASSERT(sizeof(struct MojoSharedBufferInfo) == 16,
                    "MojoSharedBufferInfo has wrong size");
+#endif
 
 // Flags passed to |MojoDuplicateBufferHandle()| via
 // |MojoDuplicateBufferHandleOptions|. See values defined below.

--- a/mojo/public/cpp/system/buffer.cc
+++ b/mojo/public/cpp/system/buffer.cc
@@ -51,4 +51,14 @@ uint64_t SharedBufferHandle::GetSize() const {
              : 0;
 }
 
+#if defined(CASTANETS)
+base::UnguessableToken SharedBufferHandle::GetGUID() const {
+  MojoSharedBufferInfo buffer_info;
+  buffer_info.struct_size = sizeof(buffer_info);
+  return (MOJO_RESULT_OK == MojoGetBufferInfo(value(), nullptr, &buffer_info))
+             ? buffer_info.guid
+             : base::UnguessableToken();
+}
+#endif
+
 }  // namespace mojo

--- a/mojo/public/cpp/system/buffer.h
+++ b/mojo/public/cpp/system/buffer.h
@@ -79,6 +79,11 @@ class MOJO_CPP_SYSTEM_EXPORT SharedBufferHandle : public Handle {
 
   // Get the size of this shared buffer.
   uint64_t GetSize() const;
+
+#if defined(CASTANETS)
+  // Get the guid associated with the shared buffer.
+  base::UnguessableToken GetGUID() const;
+#endif
 };
 
 static_assert(sizeof(SharedBufferHandle) == sizeof(Handle),


### PR DESCRIPTION
This change,
1. Adds support for shared memory in generic sensor module.
2. Adds GetGUID API for SharedBufferHandle.

Signed-off-by: suyambu.rm <suyambu.rm@samsung.com>