### PR TITLE
[Service Offloading] Supports input handling

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -2012,7 +2012,7 @@ jumbo_component("base") {
   set_sources_assignment_filter(sources_assignment_filter)
 
   # Distributed chromium
-  if (enable_castanets) {
+  if (enable_castanets || enable_service_offloading) {
     sources += [
       "distributed_chromium_util.cc",
       "distributed_chromium_util.h",
@@ -3167,6 +3167,12 @@ if (is_android) {
     ]
   }
 
+  if (enable_service_offloading && enable_service_offloading_knox){
+    android_java_prebuilt("com_samsung_knox_sdk_java") {
+      jar_path = "//third_party/blink/renderer/modules/input_control/libs/com_samsung_knox_sdk/knoxsdk.jar"
+    }
+  }
+
   android_library("base_java") {
     srcjar_deps = [
       ":base_android_java_enums_srcjar",
@@ -3311,6 +3317,10 @@ if (is_android) {
     if (enable_service_offloading) {
       java_files +=
           [ "android/java/src/org/chromium/base/AudioRecordBridge.java" ]
+    }
+
+    if (enable_service_offloading && enable_service_offloading_knox){
+      deps += [ ":com_samsung_knox_sdk_java", ]
     }
   }
 

--- a/base/base_switches.cc
+++ b/base/base_switches.cc
@@ -145,4 +145,9 @@ const char kTcpLaunchTimeout[] = "tcp-launch-timeout";
 const char kSecureConnection[] = "secure-connection";
 #endif
 
+#if defined(SERVICE_OFFLOADING)
+//Enable Service offloading feature
+const char kEnableServiceOffloading[] = "enable-service-offloading";
+#endif
+
 }  // namespace switches

--- a/base/base_switches.h
+++ b/base/base_switches.h
@@ -59,6 +59,9 @@ extern const char kTcpLaunchTimeout[];
 extern const char kSecureConnection[];
 #endif
 
+#if defined(SERVICE_OFFLOADING)
+extern const char kEnableServiceOffloading[];
+#endif
 }  // namespace switches
 
 #endif  // BASE_BASE_SWITCHES_H_

--- a/base/distributed_chromium_util.cc
+++ b/base/distributed_chromium_util.cc
@@ -8,7 +8,7 @@
 #include "base/command_line.h"
 
 namespace base {
-
+#if defined(CASTANETS)
 bool Castanets::IsEnabled() {
   return (CommandLine::ForCurrentProcess()->HasSwitch(
              switches::kEnableCastanets))
@@ -26,5 +26,14 @@ std::string Castanets::ServerAddress() {
 
   return server_address;
 }
+#endif
 
+#if defined(SERVICE_OFFLOADING)
+bool ServiceOffloading::IsEnabled() {
+  return (CommandLine::ForCurrentProcess()->HasSwitch(
+             switches::kEnableServiceOffloading))
+             ? true
+             : false;
+}
+#endif
 }  // namespace base

--- a/base/distributed_chromium_util.h
+++ b/base/distributed_chromium_util.h
@@ -11,11 +11,20 @@
 #include "base/base_export.h"
 
 namespace base {
+#if defined(CASTANETS)
 class BASE_EXPORT Castanets {
  public:
   static bool IsEnabled();
   static std::string ServerAddress();
 };
+#endif
+
+#if defined(SERVICE_OFFLOADING)
+class BASE_EXPORT ServiceOffloading {
+ public:
+  static bool IsEnabled();
+};
+#endif
 
 }  // namespace base
 

--- a/chrome/android/BUILD.gn
+++ b/chrome/android/BUILD.gn
@@ -392,6 +392,10 @@ android_library("chrome_java") {
     "//url/mojom:url_mojom_gurl_java",
   ]
 
+  if (enable_service_offloading && enable_service_offloading_knox){
+    deps += [ "//base:com_samsung_knox_sdk_java", ]
+  }
+
   deps += feed_deps
 
   srcjar_deps = [
@@ -1116,6 +1120,10 @@ jinja_template_resources("chrome_public_apk_template_resources") {
   ]
   res_dir = "java/res_template"
   variables = [ "manifest_package=$manifest_package" ]
+
+  if (enable_service_offloading && enable_service_offloading_knox) {
+    resources += [ "java/res_template/xml/device_admin_receiver.xml", ]
+  }
 }
 
 jinja_template_resources("chrome_test_apk_template_resources") {

--- a/chrome/android/chrome_java_sources.gni
+++ b/chrome/android/chrome_java_sources.gni
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//build/config/features.gni") #Enable service offloading parameter
+
 chrome_java_sources = [
   "java/src/com/google/android/apps/chrome/appwidget/bookmarks/BookmarkThumbnailWidgetProvider.java",
   "java/src/org/chromium/chrome/browser/ActivityTabProvider.java",
@@ -1825,3 +1827,10 @@ chrome_java_sources = [
   "java/src/org/chromium/chrome/browser/widget/tile/TileView.java",
   "java/src/org/chromium/chrome/browser/widget/tile/TileWithTextView.java",
 ]
+
+if (enable_service_offloading && enable_service_offloading_knox) {
+  chrome_java_sources += [
+    "java/src/org/chromium/chrome/browser/init/KnoxLicenseReceiver.java",
+    "java/src/org/chromium/chrome/browser/init/SampleAdminReceiver.java",
+  ]
+}

--- a/chrome/android/java/AndroidManifest.xml
+++ b/chrome/android/java/AndroidManifest.xml
@@ -24,6 +24,10 @@ by a child template that "extends" this file.
     <uses-permission-sdk-23 android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    {% if enable_service_offloading_knox == "true" %}
+    <uses-permission android:name="com.samsung.android.knox.permission.KNOX_REMOTE_CONTROL"/>
+    {% endif %}
+
     <!--
       Enable runtime permissions as uses-permission in tip of tree builds
       only for ease of development on Android L and earlier. For consumer
@@ -429,6 +433,24 @@ by a child template that "extends" this file.
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+
+        {% if enable_service_offloading_knox == "true" %}
+        <receiver android:name="org.chromium.chrome.browser.init.SampleAdminReceiver"
+            android:permission="android.permission.BIND_DEVICE_ADMIN">
+            <meta-data
+                android:name="android.app.device_admin"
+                android:resource="@xml/device_admin_receiver" />
+            <intent-filter>
+                <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
+            </intent-filter>
+        </receiver>
+
+        <receiver android:name="org.chromium.chrome.browser.init.KnoxLicenseReceiver" >
+              <intent-filter>
+                  <action android:name="com.samsung.android.knox.intent.action.LICENSE_STATUS" />
+              </intent-filter>
+        </receiver>
+        {% endif %}
 
         <!-- Upgrade related -->
         <receiver android:name="org.chromium.chrome.browser.upgrade.PackageReplacedBroadcastReceiver"

--- a/chrome/android/java/res_template/xml/device_admin_receiver.xml
+++ b/chrome/android/java/res_template/xml/device_admin_receiver.xml
@@ -1,0 +1,4 @@
+<device-admin xmlns:android="http://schemas.android.com/apk/res/android">
+	<uses-policies>
+	</uses-policies>
+</device-admin>

--- a/chrome/android/java/src/org/chromium/chrome/browser/init/KnoxLicenseReceiver.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/init/KnoxLicenseReceiver.java
@@ -1,0 +1,82 @@
+package org.chromium.chrome.browser.init;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.samsung.android.knox.EnterpriseDeviceManager;
+import com.samsung.android.knox.license.EnterpriseLicenseManager;
+import com.samsung.android.knox.license.KnoxEnterpriseLicenseManager;
+
+
+public class KnoxLicenseReceiver extends BroadcastReceiver {
+    private int DEFAULT_ERROR_CODE = -1;
+    public static final String TAG = "Knox";
+
+    private void showToast(Context context, int msg_res) {
+        Toast.makeText(context, context.getResources().getString(msg_res), Toast.LENGTH_SHORT)
+                .show();
+    }
+
+    private void showToast(Context context, String msg) {
+        Toast.makeText(context, msg, Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        int msg_res = -1;
+
+        if (intent == null) {
+            // No intent action is available
+            showToast(context, "no_intent");
+            return;
+        } else {
+            String action = intent.getAction();
+            if (action == null) {
+                // No intent action is available
+                showToast(context, "no_intent_action");
+                return;
+            } else if (action.equals(KnoxEnterpriseLicenseManager.ACTION_LICENSE_STATUS)) {
+                // Intent from KPE license activation attempt is obtained
+                int errorCode = intent.getIntExtra(
+                        KnoxEnterpriseLicenseManager.EXTRA_LICENSE_ERROR_CODE, DEFAULT_ERROR_CODE);
+
+                if (errorCode == KnoxEnterpriseLicenseManager.ERROR_NONE) {
+                    // license activated successfully
+                    showToast(context, "klm_activated_succesfully");
+                    Log.i(TAG, "klm_activated_succesfully");
+                    return;
+                } else {
+                    // license activation failed
+                    switch (errorCode) {
+                        case KnoxEnterpriseLicenseManager.ERROR_INTERNAL:
+                        case KnoxEnterpriseLicenseManager.ERROR_INTERNAL_SERVER:
+                        case KnoxEnterpriseLicenseManager.ERROR_INVALID_LICENSE:
+                        case KnoxEnterpriseLicenseManager.ERROR_INVALID_PACKAGE_NAME:
+                        case KnoxEnterpriseLicenseManager.ERROR_LICENSE_TERMINATED:
+                        case KnoxEnterpriseLicenseManager.ERROR_NETWORK_DISCONNECTED:
+                        case KnoxEnterpriseLicenseManager.ERROR_NETWORK_GENERAL:
+                        case KnoxEnterpriseLicenseManager.ERROR_NOT_CURRENT_DATE:
+                        case KnoxEnterpriseLicenseManager.ERROR_NULL_PARAMS:
+                        case KnoxEnterpriseLicenseManager.ERROR_UNKNOWN:
+                        case KnoxEnterpriseLicenseManager.ERROR_USER_DISAGREES_LICENSE_AGREEMENT:
+                            msg_res = errorCode;
+                            break;
+
+                        default:
+                            showToast(context, "err_klm_code_unknown");
+                            Log.i(TAG, "err_klm_code_unknown");
+                            return;
+                    }
+
+                    // Display error message
+                    showToast(context, msg_res);
+                    Log.i(TAG, context.getString(msg_res));
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/chrome/android/java/src/org/chromium/chrome/browser/init/SampleAdminReceiver.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/init/SampleAdminReceiver.java
@@ -1,0 +1,26 @@
+// Copyright 2012 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.chrome.browser.init;
+
+import android.app.admin.DeviceAdminReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.widget.Toast;
+
+public class SampleAdminReceiver extends DeviceAdminReceiver {
+    void showToast(Context context, CharSequence msg) {
+        Toast.makeText(context, msg, Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void onEnabled(Context context, Intent intent) {
+        showToast(context, "admin_enabled");
+    }
+
+    @Override
+    public void onDisabled(Context context, Intent intent) {
+        showToast(context, "admin_disabled");
+    }
+}

--- a/content/browser/renderer_host/render_process_host_impl.cc
+++ b/content/browser/renderer_host/render_process_host_impl.cc
@@ -3111,6 +3111,9 @@ void RenderProcessHostImpl::PropagateBrowserCommandLineToRenderer(
 #if defined(CASTANETS)
     switches::kEnableCastanets,
 #endif
+#if defined(SERVICE_OFFLOADING)
+    switches::kEnableServiceOffloading,
+#endif
   };
   renderer_cmd->CopySwitchesFrom(browser_cmd, kSwitchNames,
                                  base::size(kSwitchNames));

--- a/content/public/android/BUILD.gn
+++ b/content/public/android/BUILD.gn
@@ -292,6 +292,10 @@ android_library("content_java") {
     "java/src/org/chromium/content_public/common/ServiceManagerConnection.java",
     "java/src/org/chromium/content_public/common/UseZoomForDSFPolicy.java",
   ]
+
+  if (enable_service_offloading && enable_service_offloading_knox) {
+    deps += [ "//third_party/blink/renderer/modules/input_control:input_control_java", ]
+  }
 }
 
 java_strings_grd("content_strings_grd") {

--- a/third_party/.gitignore
+++ b/third_party/.gitignore
@@ -41,6 +41,7 @@
 /auto/src
 /bazel/desugar/Desugar.jar
 /bison
+/blink/renderer/modules/input_control/libs/
 /boringssl/src
 /bouncycastle/lib/
 /breakpad/breakpad

--- a/third_party/blink/renderer/modules/BUILD.gn
+++ b/third_party/blink/renderer/modules/BUILD.gn
@@ -179,19 +179,23 @@ target("jumbo_" + modules_target_type, "modules") {
     "//third_party/zlib",
   ]
 
+  if (((is_android && enable_service_offloading_knox) || is_win) && enable_service_offloading) {
+    sub_modules += ["//third_party/blink/renderer/modules/input_control:input_control_offloading", ]
+
+    if (is_android) {
+      deps += [ "input_control:input_control_jni_headers", ]
+    }
+  }
+
   public_deps = sub_modules
   allow_circular_includes_from = sub_modules
 
   if (!is_android) {
-    deps += [ "//third_party/blink/renderer/modules/serial" ]
+    deps += [ "//third_party/blink/renderer/modules/serial", ]
   }
 
   if (is_win) {
     cflags = [ "/wd4334" ]  # Result of 32-bit shift implicitly converted to 64 bits.
-  }
-
-  if (((is_android && enable_service_offloading_knox) || is_win) && enable_service_offloading) {
-    sub_modules += ["//third_party/blink/renderer/modules/input_control"]
   }
 
   configs -= [ "//build/config/compiler:default_symbols" ]

--- a/third_party/blink/renderer/modules/input_control/BUILD.gn
+++ b/third_party/blink/renderer/modules/input_control/BUILD.gn
@@ -12,7 +12,7 @@ if (is_android && enable_service_offloading_knox && enable_service_offloading) {
     sources = [
       "InputControl.java",
     ]
-    jni_package = "input_control"
+    jni_package = [ "input_control", ]
   }
 
   android_library("input_control_java") {
@@ -24,31 +24,30 @@ if (is_android && enable_service_offloading_knox && enable_service_offloading) {
       "//base:jni_java",
     ]
 
-    annotation_processor_deps = [ "//base/android/jni_generator:jni_processor" ]
+    annotation_processor_deps = [ "//base/android/jni_generator:jni_processor", ]
   }
 }
 
 if ((is_win || (is_android && enable_service_offloading_knox)) &&
     enable_service_offloading) {
-  blink_modules_sources("input_control") {
-    deps = [
-      "//base",
-    ]
+  blink_modules_sources("input_control_offloading") {
+    deps = [ "//base", ]
 
-    sources = [
-      "input_control.h",
+    sources = [ 
+        "input_control.h", 
+        "window_input_call.cc",
+        "window_input_call.h",
     ]
 
     if (is_win) {
       sources += [
         "input_control_win.cc",
-        "window_input_call.cc",
-        "window_input_call.h",
       ]
-    } else if (is_android && enable_service_offloading_knox) {
-      deps += [ ":input_control_jni_headers" ]
+    } 
+    if (is_android) {
+      deps += [ ":input_control_jni_headers", ]
 
-      sources += [ "input_control_android.cc" ]
+      sources += [ "input_control_android.cc", ]
     }
   }
 }

--- a/third_party/blink/renderer/modules/modules_idl_files.gni
+++ b/third_party/blink/renderer/modules/modules_idl_files.gni
@@ -528,6 +528,7 @@ if (!is_android) {
                                      ],
                                      "abspath")
 }
+
 if (((is_android && enable_service_offloading_knox) || is_win) &&
     enable_service_offloading) {
   modules_idl_files +=
@@ -536,7 +537,7 @@ if (((is_android && enable_service_offloading_knox) || is_win) &&
 
 if (support_webgl2_compute_context) {
   modules_idl_files +=
-      get_path_info([ "webgl/webgl2_compute_rendering_context.idl" ], "abspath")
+      get_path_info([ "webgl/webgl2_compute_rendering_context.idl", ], "abspath")
 }
 
 modules_callback_function_idl_files =
@@ -974,10 +975,10 @@ if (!is_android) {
                       "serial/worker_navigator_serial.idl",
                     ],
                     "abspath")
-  if (enable_service_offloading && is_win) {
-    modules_dependency_idl_files +=
-        get_path_info([ "input_control/window_input_call.idl" ], "abspath")
-  }
+}
+
+if (((is_android && enable_service_offloading_knox) || is_win) && enable_service_offloading) {
+  modules_dependency_idl_files += get_path_info([ "input_control/window_input_call.idl", ],"abspath")
 }
 
 if (support_webgl2_compute_context) {


### PR DESCRIPTION
Support Key event and mouse event
For Android, only Galaxy phone is enabled with the patch.
Even for Galaxy, the Knox library should be manually added