### PR TITLE
Show the activity and create the overlay view for the performance. 

### DIFF
--- a/chrome/android/chrome_java_sources.gni
+++ b/chrome/android/chrome_java_sources.gni
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/config/features.gni") #Enable service offloading parameter
+import("//build/config/features.gni")  #Enable service offloading parameter
 
 chrome_java_sources = [
   "java/src/com/google/android/apps/chrome/appwidget/bookmarks/BookmarkThumbnailWidgetProvider.java",
@@ -1826,6 +1826,11 @@ chrome_java_sources = [
   "java/src/org/chromium/chrome/browser/widget/textbubble/TextBubble.java",
   "java/src/org/chromium/chrome/browser/widget/tile/TileView.java",
   "java/src/org/chromium/chrome/browser/widget/tile/TileWithTextView.java",
+]
+
+chrome_java_sources += [
+  "java/src/org/chromium/chrome/browser/AlwaysOnTopService.java",
+  "java/src/org/chromium/chrome/browser/firstrun/CastanetsFragment.java",
 ]
 
 if (enable_service_offloading && enable_service_offloading_knox) {

--- a/chrome/android/java/AndroidManifest.xml
+++ b/chrome/android/java/AndroidManifest.xml
@@ -128,7 +128,7 @@ by a child template that "extends" this file.
     {% block extra_keyset_definitions %}
     {% endblock %}
 
-    {% if enable_offload == "true" %}
+    {% if enable_offload == "true" or enable_castanets == "true" %}
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.webkit.PermissionRequest" />
     {% endif %}
@@ -646,8 +646,10 @@ by a child template that "extends" this file.
             {% block first_run_activity_common %}
             android:label="@string/fre_activity_label"
             android:launchMode="singleInstance"
+            {% if enable_castanets == "false" %}
             android:excludeFromRecents="true"
             android:autoRemoveFromRecents="true"
+            {% endif %}
             android:windowSoftInputMode="stateHidden|adjustPan"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|mcc|mnc|screenLayout|smallestScreenSize"
             {% endblock %}>
@@ -1375,6 +1377,9 @@ android:value="true" />
             android:exported="false"
             android:name="com.samsung.offloadworker.OffloadService" />
         {% endif %}
+
+        <service android:name="org.chromium.chrome.browser.AlwaysOnTopService"
+            android:exported="false" />
     </application>
     {% block extra_root_definitions %}
     {% endblock %}

--- a/chrome/android/java/res_chromium/layout/castanets_welcome.xml
+++ b/chrome/android/java/res_chromium/layout/castanets_welcome.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.chromium.chrome.browser.firstrun.FirstRunView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/fre_main_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#000000"
+        android:orientation="vertical">
+        <LinearLayout
+                android:id="@+id/fre_image_and_content"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:gravity="center_horizontal">
+            <LinearLayout
+                    android:id="@+id/fre_content_wrapper"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    android:layout_weight="1">
+                <ImageView
+                    android:id="@+id/image"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="200sp"
+                    android:gravity="center_horizontal"
+                    android:src="@drawable/fre_product_logo"/>
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="50sp"
+                    android:gravity="center_horizontal"
+                    android:text="Castanets"
+                    android:textColor="#AAAAAA"
+                    android:textSize="36sp" />
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10sp"
+                    android:gravity="center_horizontal"
+                    android:text="is running..."
+                    android:textColor="#AAAAAA"
+                    android:textSize="20sp" />
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="30sp"
+                    android:gravity="center_horizontal"
+                    android:text="It works even if you hide this page."
+                    android:textColor="#AAAAAA"
+                    android:textSize="15sp" />
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
+
+</org.chromium.chrome.browser.firstrun.FirstRunView>

--- a/chrome/android/java/src/org/chromium/chrome/browser/AlwaysOnTopService.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/AlwaysOnTopService.java
@@ -1,0 +1,94 @@
+package org.chromium.chrome.browser;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Intent;
+import android.graphics.Color;
+import android.graphics.PixelFormat;
+import android.os.IBinder;
+import android.view.Gravity;
+import android.view.WindowManager;
+import android.widget.ImageView;
+
+import org.chromium.base.Log;
+import org.chromium.chrome.R;
+import org.chromium.chrome.browser.firstrun.FirstRunActivity;
+
+public class AlwaysOnTopService extends Service {
+    private static final String TAG = "AlwaysOnTopService";
+    private static final int NOTIFICATION = R.string.app_name;
+    private static final String APP_NAME = "CASTANETS";
+
+    private ImageView mImgView;
+    private NotificationManager mNotificationManager;
+
+    @Override
+    public IBinder onBind(Intent arg0) {
+        return null;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        WindowManager windowManager = (WindowManager) getSystemService(WINDOW_SERVICE);
+
+        mImgView = new ImageView(this);
+        mImgView.setImageResource(R.drawable.fre_product_logo);
+        mImgView.setScaleType(ImageView.ScaleType.FIT_XY);
+
+        WindowManager.LayoutParams myParam = new WindowManager.LayoutParams(0, 0, // Hide the view
+                WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE, PixelFormat.TRANSLUCENT);
+        myParam.gravity = Gravity.LEFT | Gravity.TOP;
+        windowManager.addView(mImgView, myParam);
+
+        mNotificationManager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        showNotification();
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        if (mImgView != null) {
+            ((WindowManager) getSystemService(WINDOW_SERVICE)).removeView(mImgView);
+            mImgView = null;
+        }
+
+        if (mNotificationManager != null) {
+            mNotificationManager.cancel(NOTIFICATION);
+            mNotificationManager = null;
+        }
+    }
+
+    private void showNotification() {
+        Log.i(TAG, "showNotification Castanets");
+
+        NotificationChannel channel =
+                new NotificationChannel(APP_NAME, APP_NAME, NotificationManager.IMPORTANCE_DEFAULT);
+        ((NotificationManager) getSystemService(getApplicationContext().NOTIFICATION_SERVICE))
+                .createNotificationChannel(channel);
+
+        Intent notificationIntent = new Intent(this, FirstRunActivity.class);
+        notificationIntent.setAction(Intent.ACTION_MAIN);
+        notificationIntent.addCategory(Intent.CATEGORY_LAUNCHER);
+        PendingIntent pendingIntent = PendingIntent.getActivity(
+                this, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+
+        // Set the info for the views that show in the notification panel.
+        final Notification notification =
+                new Notification.Builder(this, APP_NAME)
+                        .setSmallIcon(R.drawable.fre_product_logo)
+                        .setWhen(System.currentTimeMillis()) // the time stamp
+                        .setContentTitle("Castanets - Offloading") // the label of the entry
+                        .setContentText("is running.") // the contents of the entry
+                        .setContentIntent(pendingIntent)
+                        .build();
+
+        startForeground(NOTIFICATION, notification);
+        mNotificationManager.notify(NOTIFICATION, notification);
+    }
+}

--- a/chrome/android/java/src/org/chromium/chrome/browser/firstrun/CastanetsFragment.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/firstrun/CastanetsFragment.java
@@ -1,0 +1,34 @@
+package org.chromium.chrome.browser.firstrun;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.chromium.chrome.R;
+
+public class CastanetsFragment extends Fragment implements FirstRunFragment {
+    public static class Page implements FirstRunPage<CastanetsFragment> {
+        @Override
+        public boolean shouldSkipPageOnCreate() {
+            return FirstRunStatus.shouldSkipWelcomePage();
+        }
+
+        @Override
+        public CastanetsFragment instantiateFragment() {
+            return new CastanetsFragment();
+        }
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.castanets_welcome, container, false);
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+    }
+}

--- a/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunActivity.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunActivity.java
@@ -15,6 +15,8 @@ import android.view.View;
 import org.chromium.base.ActivityState;
 import org.chromium.base.ApplicationStatus;
 import org.chromium.base.ApplicationStatus.ActivityStateListener;
+import org.chromium.base.BaseSwitches;
+import org.chromium.base.CommandLine;
 import org.chromium.base.VisibleForTesting;
 import org.chromium.base.metrics.CachedMetrics.EnumeratedHistogramSample;
 import org.chromium.chrome.R;
@@ -123,7 +125,11 @@ public class FirstRunActivity extends FirstRunActivityBase implements FirstRunPa
     private void createPageSequence() {
         // An optional welcome page.
         if (mShowWelcomePage) {
-            mPages.add(new ToSAndUMAFirstRunFragment.Page());
+            if (CommandLine.getInstance().hasSwitch(BaseSwitches.ENABLE_CASTANETS)) {
+                mPages.add(new CastanetsFragment.Page());
+            } else {
+                mPages.add(new ToSAndUMAFirstRunFragment.Page());
+            }
             mFreProgressStates.add(FRE_PROGRESS_WELCOME_SHOWN);
         }
 

--- a/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunView.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunView.java
@@ -11,6 +11,8 @@ import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 
+import org.chromium.base.BaseSwitches;
+import org.chromium.base.CommandLine;
 import org.chromium.chrome.R;
 
 /**
@@ -94,6 +96,12 @@ public class FirstRunView extends FrameLayout {
                     + getResources().getDimensionPixelSize(R.dimen.fre_vertical_spacing)
                     + getResources().getDimensionPixelSize(R.dimen.fre_image_height)
                     + getResources().getDimensionPixelSize(R.dimen.fre_vertical_spacing);
+        }
+
+        // Skip if castanets is enabled.
+        if (CommandLine.getInstance().hasSwitch(BaseSwitches.ENABLE_CASTANETS)) {
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+            return;
         }
 
         // Add padding to get it roughly centered.

--- a/chrome/android/java/src/org/chromium/chrome/browser/init/AsyncInitializationActivity.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/init/AsyncInitializationActivity.java
@@ -12,6 +12,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Configuration;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -44,6 +45,7 @@ import org.chromium.base.library_loader.LoaderErrors;
 import org.chromium.base.library_loader.ProcessInitException;
 import org.chromium.base.task.PostTask;
 import org.chromium.chrome.R;
+import org.chromium.chrome.browser.AlwaysOnTopService;
 import org.chromium.chrome.browser.ChromeApplication;
 import org.chromium.chrome.browser.ChromeBaseAppCompatActivity;
 import org.chromium.chrome.browser.IntentHandler;
@@ -71,6 +73,9 @@ public abstract class AsyncInitializationActivity extends ChromeBaseAppCompatAct
         implements ChromeActivityNativeDelegate, BrowserParts, ModalDialogManagerHolder {
     private static final String TAG = "AsyncInitActivity";
     protected final Handler mHandler;
+
+    private int ACTION_MANAGE_OVERLAY_PERMISSION_REQUEST_CODE = 5469;
+    private int ACTION_MANAGE_RECORD_AUDIO_PERMISSION_REQUEST_CODE = 1234;
 
     private final NativeInitializationController mNativeInitializationController =
             new NativeInitializationController(this);
@@ -280,21 +285,26 @@ public abstract class AsyncInitializationActivity extends ChromeBaseAppCompatAct
     @Override
     @SuppressLint("MissingSuperCall")  // Called in onCreateInternal.
     protected final void onCreate(Bundle savedInstanceState) {
-        // Hide the activity if castanets is enabled and runs as renderer process,
-        if (CommandLine.getInstance().hasSwitch(BaseSwitches.ENABLE_CASTANETS)) {
-            Intent startMain = new Intent(Intent.ACTION_MAIN);
-            startMain.addCategory(Intent.CATEGORY_HOME);
-            startMain.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(startMain);
-        } else if (OffloadingUtils.IsServiceOffloading()) {
+        Log.i("NSW", "AsyncInitializationActivity onCreate");
+        if (OffloadingUtils.IsServiceOffloading()) {
             // Check and request a RECORD_AUDIO permission for service offloading.
             if (ContextCompat.checkSelfPermission(
                       ContextUtils.getApplicationContext(),
                       Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
-              Log.d(TAG, "RECORD_AUDIO permission was not granted. Request permission.");
-              ActivityCompat.requestPermissions(this,
-                new String[]{Manifest.permission.RECORD_AUDIO},
-                1234);
+                Log.w(TAG, "RECORD_AUDIO permission was not granted. Request permission.");
+                ActivityCompat.requestPermissions(this,
+                        new String[] {Manifest.permission.RECORD_AUDIO},
+                        ACTION_MANAGE_RECORD_AUDIO_PERMISSION_REQUEST_CODE);
+            }
+        }
+
+        if (CommandLine.getInstance().hasSwitch(BaseSwitches.ENABLE_CASTANETS)) {
+            if (!Settings.canDrawOverlays(this)) {
+                Intent intent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                        Uri.parse("package:" + getPackageName()));
+                startActivityForResult(intent, ACTION_MANAGE_OVERLAY_PERMISSION_REQUEST_CODE);
+            } else {
+                startService(new Intent(this, AlwaysOnTopService.class));
             }
         }
 
@@ -529,6 +539,13 @@ public abstract class AsyncInitializationActivity extends ChromeBaseAppCompatAct
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         mNativeInitializationController.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == ACTION_MANAGE_OVERLAY_PERMISSION_REQUEST_CODE) {
+            if (Settings.canDrawOverlays(this)) {
+                // You have permission
+                Log.i("NSW", "AsyncInitializationActivity startService");
+                startService(new Intent(this, AlwaysOnTopService.class));
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
When the activity of the renderer process is in the background,
loading time and performance are degraded.
So, open the activity and modify the user to select the visibility.