### PR TITLE
Keep Knox sdk APIs to avoid Proguard optimization.

### DIFF
--- a/chrome/android/java/proguard.flags
+++ b/chrome/android/java/proguard.flags
@@ -57,3 +57,11 @@
   public <clinit>();
   *** build() return null;
 }
+
+# Service offloading uses knox sdk to handle key/touch events in the remote device.
+# This is to avoid for only stub APIs in knoxsdk.jar to be called.
+-dontwarn com.samsung.**
+-keep class com.samsung.** { *; }
+-keep interface com.samsung.** { *; }
+-keep enum com.samsung.** { *; }
+-keepclassmembers class com.samsung.** { *; }


### PR DESCRIPTION
This fixes the crash issue with runtime exception "Stub!".
It's caused by proguard, so add proguard rules for knox sdk.