### PR TITLE
Keep screen on if the castanets activity is shown.

### DIFF
--- a/chrome/android/java/res_chromium/layout/castanets_welcome.xml
+++ b/chrome/android/java/res_chromium/layout/castanets_welcome.xml
@@ -54,6 +54,14 @@
                     android:text="It works even if you hide this page."
                     android:textColor="#AAAAAA"
                     android:textSize="15sp" />
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="30sp"
+                    android:gravity="center_horizontal"
+                    android:text="The screen does not turn off\n while castanets is running."
+                    android:textColor="#FF5555"
+                    android:textSize="15sp" />
             </LinearLayout>
         </LinearLayout>
     </LinearLayout>

--- a/chrome/android/java/src/org/chromium/chrome/browser/AlwaysOnTopService.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/AlwaysOnTopService.java
@@ -42,7 +42,8 @@ public class AlwaysOnTopService extends Service {
 
         WindowManager.LayoutParams myParam = new WindowManager.LayoutParams(0, 0, // Hide the view
                 WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY,
-                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE, PixelFormat.TRANSLUCENT);
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE |
+                WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON, PixelFormat.TRANSLUCENT);
         myParam.gravity = Gravity.LEFT | Gravity.TOP;
         windowManager.addView(mImgView, myParam);
 


### PR DESCRIPTION
When the screen is turned off, performance may be degraded.
Add the keepScreenOn option and description on the activity.