### PR TITLE
[JS Offloading] Launch OffloadService by Edge orchestration

### DIFF
--- a/chrome/android/chrome_public_apk_tmpl.gni
+++ b/chrome/android/chrome_public_apk_tmpl.gni
@@ -235,6 +235,10 @@ template("chrome_public_common_apk_or_module_tmpl") {
         proguard_configs +=
             [ "//base/android/proguard/disable_all_obfuscation.flags" ]
       }
+      if (enable_offload) {
+        proguard_configs +=
+            [ "//third_party/offload-js/edge_worker/android/proguard.flags" ]
+      }
     }
 
     if (!defined(use_chromium_linker)) {

--- a/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java
@@ -552,7 +552,8 @@ public class LaunchIntentDispatcher implements IntentHandler.IntentHandlerDelega
         try {
             final Class<?> offloadService =
                     Class.forName("com.samsung.offloadworker.OffloadService");
-            final Method startService = offloadService.getMethod("startService", Context.class);
+            final Method startService =
+                    offloadService.getMethod("startService", Context.class, String.class);
             Context context = ContextUtils.getApplicationContext();
             ActivityManager activityManager =
                     (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
@@ -564,7 +565,8 @@ public class LaunchIntentDispatcher implements IntentHandler.IntentHandlerDelega
                     return;
                 }
             }
-            startService.invoke(null, context);
+            startService.invoke(
+                    null, context, CommandLine.getInstance().getSwitchValue("signaling-server"));
         } catch (Exception e) {
             Log.e(TAG, "Exception while launching OffloadService.", e);
         }


### PR DESCRIPTION
This patch launches OffloadService when a request is recieved from Edge
orchestration.
e.g. com.samsung.android.castanets --type=offloadworker --signaling-server=192.168.0.2

Signed-off-by: yh106.jung <yh106.jung@samsung.com>