### PR TITLE
[Service Offloading] Additional API Support to Kill Application

### DIFF
--- a/chrome/android/java/AndroidManifest.xml
+++ b/chrome/android/java/AndroidManifest.xml
@@ -26,6 +26,7 @@ by a child template that "extends" this file.
 
     {% if enable_service_offloading_knox == "true" %}
     <uses-permission android:name="com.samsung.android.knox.permission.KNOX_REMOTE_CONTROL"/>
+    <uses-permission android:name="com.samsung.android.knox.permission.KNOX_APP_MGMT"/>
     {% endif %}
 
     <!--

--- a/third_party/blink/renderer/modules/input_control/InputControl.java
+++ b/third_party/blink/renderer/modules/input_control/InputControl.java
@@ -18,6 +18,7 @@ import android.widget.TextView;
 import com.samsung.android.knox.EnterpriseDeviceManager;
 import com.samsung.android.knox.license.KnoxEnterpriseLicenseManager;
 import com.samsung.android.knox.remotecontrol.RemoteInjection;
+import com.samsung.android.knox.application.ApplicationPolicy;
 
 import org.chromium.base.ContextUtils;
 import org.chromium.base.Log;
@@ -166,6 +167,18 @@ class InputControl {
                 (bDown ? "down" : "up"), (result ? "true" : "false"));
         } catch (SecurityException se) {
             Log.w("InputCTRL", "Exception: " + se);
+        }
+    }
+
+    @CalledByNative
+    public void StopApplication(String pkgName) {
+        EnterpriseDeviceManager edm = EnterpriseDeviceManager.getInstance(
+          ContextUtils.getApplicationContext());
+        ApplicationPolicy appPolicy = edm.getApplicationPolicy();
+        try {
+            boolean result = appPolicy.stopApp(pkgName);
+        } catch (SecurityException se) {
+            Log.w("InputCTRL", "SecurityException: " + se);
         }
     }
 };

--- a/third_party/blink/renderer/modules/input_control/input_control.h
+++ b/third_party/blink/renderer/modules/input_control/input_control.h
@@ -48,6 +48,7 @@ class InputControl final : public ScriptWrappable {
  public:
   static InputControl* Create() { return MakeGarbageCollected<InputControl>(); }
   bool sendMouseInput(String type, long x, long y, long code);
+  bool stopApplication(String pkgName);
   InputControl();
 
  private:

--- a/third_party/blink/renderer/modules/input_control/input_control.idl
+++ b/third_party/blink/renderer/modules/input_control/input_control.idl
@@ -2,4 +2,5 @@
 [Exposed=(Window,Worker)]
 interface InputControl {
     boolean sendMouseInput(DOMString str, long x, long y, long code);
+    boolean stopApplication(DOMString str);
 };

--- a/third_party/blink/renderer/modules/input_control/input_control_android.cc
+++ b/third_party/blink/renderer/modules/input_control/input_control_android.cc
@@ -51,4 +51,13 @@ bool InputControl::sendMouseInput(String type, long x, long y, long code) {
   return true;
 }
 
+bool InputControl::stopApplication(String pkgName) {
+  JNIEnv* env = base::android::AttachCurrentThread();
+
+  base::android::Java_InputControl_StopApplication(
+      env, j_input_control_,
+      base::android::ConvertUTF8ToJavaString(env, pkgName.Utf8().data()));
+  return true;
+}
+
 }  // namespace blink

--- a/third_party/blink/renderer/modules/input_control/input_control_win.cc
+++ b/third_party/blink/renderer/modules/input_control/input_control_win.cc
@@ -58,4 +58,9 @@ bool InputControl::sendMouseInput(String type, long x, long y, long code) {
   return SendInput(1, &input, sizeof(INPUT));
 }
 
+bool InputControl::stopApplication(String pkgName){
+  //TODO: Implementation
+  return false;
+}
+
 }  // namespace blink


### PR DESCRIPTION
window.input_control.stopApplication("pkgName") is supported.
The API kills pkg of the Android application.
When terminating application from remote, stopApplication should be called.