### PR TITLE
Launch tasks separately for Offload Settings.

### DIFF
--- a/chrome/android/java/AndroidManifest.xml
+++ b/chrome/android/java/AndroidManifest.xml
@@ -581,6 +581,9 @@ by a child template that "extends" this file.
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|mcc|mnc|screenLayout|smallestScreenSize|uiMode|density"
             android:hardwareAccelerated="false"
             {% endblock %}
+            {% if enable_castanets or enable_service_offloading %}
+            android:documentLaunchMode="intoExisting"
+            {% endif %}
         >
             <!--
               Daydream api categorizes an activity to three categories: Cardboard only, hybrid
@@ -1376,6 +1379,7 @@ android:value="true" />
         {% if enable_offload == "true" %}
         <activity android:name="com.samsung.offloadworker.SettingsActivity"
             android:label="@string/offload_app_name"
+            android:documentLaunchMode="intoExisting"
             android:theme="@style/OffloadAppTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
When Offload Settings is launched, SettingsActivity should be shown but
ChromeTabbedActivity is shown unexpectedly.
For solving the issue, use android:documentLaunchMode="intoExisting"
to launch a separate task based on the intent's Component name and data URI.
Without this, the activity will share all the same activities.