### PR TITLE
[Service Offloading] Add activity for integrated settings

### DIFF
--- a/chrome/android/java/AndroidManifest.xml
+++ b/chrome/android/java/AndroidManifest.xml
@@ -1396,6 +1396,7 @@ android:value="true" />
         <activity android:name="com.samsung.offloadsetting.MainActivity"
             android:label="@string/offload_app_name"
             android:documentLaunchMode="intoExisting"
+            android:process=":offload_setting_process"
             android:theme="@style/OffloadAppTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -1404,10 +1405,12 @@ android:value="true" />
         </activity>
 
         <activity android:name="com.samsung.rtcapps.AppSelection"
+            android:process=":offload_setting_process"
             android:theme="@style/OffloadAppTheme">
         </activity>
 
         <activity android:name="com.samsung.offloadworker.SettingsActivity"
+            android:process=":offload_setting_process"
             android:theme="@style/OffloadAppTheme">
         </activity>
 

--- a/chrome/android/java/AndroidManifest.xml
+++ b/chrome/android/java/AndroidManifest.xml
@@ -1393,7 +1393,7 @@ android:value="true" />
         {% endif %}
 
         {% if enable_offload == "true" %}
-        <activity android:name="com.samsung.offloadworker.SettingsActivity"
+        <activity android:name="com.samsung.offloadsetting.MainActivity"
             android:label="@string/offload_app_name"
             android:documentLaunchMode="intoExisting"
             android:theme="@style/OffloadAppTheme">
@@ -1401,6 +1401,14 @@ android:value="true" />
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+
+        <activity android:name="com.samsung.rtcapps.AppSelection"
+            android:theme="@style/OffloadAppTheme">
+        </activity>
+
+        <activity android:name="com.samsung.offloadworker.SettingsActivity"
+            android:theme="@style/OffloadAppTheme">
         </activity>
 
         <receiver


### PR DESCRIPTION
This patch adds activity for integrated settings.
After the patch, neet to run build/update_internal_repo.sh again.

Signed-off-by: yh106.jung <yh106.jung@samsung.com>