### PR TITLE
[Service Offloading] Fix the getUserMedia issue.

### DIFF
--- a/chrome/browser/media/webrtc/screen_capture_infobar_delegate_android.cc
+++ b/chrome/browser/media/webrtc/screen_capture_infobar_delegate_android.cc
@@ -94,18 +94,9 @@ void ScreenCaptureInfoBarDelegateAndroid::RunCallback(
   if (result == blink::MEDIA_DEVICE_OK) {
     content::DesktopMediaID screen_id = content::DesktopMediaID(
         content::DesktopMediaID::TYPE_SCREEN, webrtc::kFullDesktopScreenId);
-#if defined(SERVICE_OFFLOADING)
-    devices.push_back(
-        blink::MediaStreamDevice(blink::MEDIA_DISPLAY_VIDEO_CAPTURE,
-                                 screen_id.ToString(), "Screen"));
-    devices.push_back(
-        blink::MediaStreamDevice(blink::MEDIA_DISPLAY_AUDIO_CAPTURE,
-                                 screen_id.ToString(), "System Audio"));
-#else
     devices.push_back(
         blink::MediaStreamDevice(blink::MEDIA_GUM_DESKTOP_VIDEO_CAPTURE,
                                  screen_id.ToString(), "Screen"));
-#endif
 
     ui = MediaCaptureDevicesDispatcher::GetInstance()
              ->GetMediaStreamCaptureIndicator()

--- a/content/browser/android/content_startup_flags.cc
+++ b/content/browser/android/content_startup_flags.cc
@@ -106,12 +106,6 @@ void SetContentCommandLineFlags(bool single_process) {
     // Prevents the renderer process from being killed for Service Offloading.
     parsed_command_line->AppendSwitch(
         service_manager::switches::kNoSandbox);
-
-    // For using Knox in the WebRTC Service, permission must be passed to the
-    // renderer process. Currently, the Knox permission only applies to the
-    // browser process and it cannot be propagated to the renderer process.
-    // Therefore we apply single process mode for Knox system input.
-    parsed_command_line->AppendSwitch(switches::kSingleProcess);
   }
 #endif
 }

--- a/content/browser/renderer_host/media/audio_input_delegate_impl.cc
+++ b/content/browser/renderer_host/media/audio_input_delegate_impl.cc
@@ -31,6 +31,10 @@
 #include "media/base/media_switches.h"
 #include "media/base/user_input_monitor.h"
 
+#if defined(SERVICE_OFFLOADING)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 
 namespace {
@@ -131,6 +135,12 @@ std::unique_ptr<media::AudioInputDelegate> AudioInputDelegateImpl::Create(
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
           switches::kUseFakeDeviceForMediaStream)) {
     possibly_modified_parameters.set_format(media::AudioParameters::AUDIO_FAKE);
+  }
+
+  if (base::ServiceOffloading::IsEnabled() &&
+      device->type == blink::MEDIA_DISPLAY_AUDIO_CAPTURE) {
+    // The audio input will be from system capture.
+    possibly_modified_parameters.set_capture_system_audio(true);
   }
 
   auto foreign_socket = std::make_unique<base::CancelableSyncSocket>();

--- a/media/base/audio_parameters.cc
+++ b/media/base/audio_parameters.cc
@@ -7,6 +7,10 @@
 #include "base/logging.h"
 #include "media/base/limits.h"
 
+#if defined(SERVICE_OFFLOADING)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace media {
 
 base::CheckedNumeric<uint32_t> ComputeAudioInputBufferSizeChecked(
@@ -93,6 +97,10 @@ void AudioParameters::Reset(Format format,
   frames_per_buffer_ = frames_per_buffer;
   effects_ = NO_EFFECTS;
   mic_positions_.clear();
+#if defined(SERVICE_OFFLOADING)
+  if (base::ServiceOffloading::IsEnabled())
+    capture_system_audio_ = false;
+#endif
 }
 
 bool AudioParameters::IsValid() const {

--- a/media/base/audio_parameters.h
+++ b/media/base/audio_parameters.h
@@ -270,6 +270,14 @@ class MEDIA_SHMEM_EXPORT AudioParameters {
   }
   AudioLatency::LatencyType latency_tag() const { return latency_tag_; }
 
+#if defined(SERVICE_OFFLOADING)
+  void set_capture_system_audio(bool capture_system_audio) {
+    capture_system_audio_ = capture_system_audio;
+  }
+
+  bool capture_system_audio() const { return capture_system_audio_; }
+#endif
+
   AudioParameters(const AudioParameters&);
   AudioParameters& operator=(const AudioParameters&);
 
@@ -284,6 +292,11 @@ class MEDIA_SHMEM_EXPORT AudioParameters {
   int sample_rate_;               // Sampling frequency/rate.
   int frames_per_buffer_;         // Number of frames in a buffer.
   int effects_;                   // Bitmask using PlatformEffectsMask.
+
+#if defined(SERVICE_OFFLOADING)
+  // The audio input is the system audio.
+  bool capture_system_audio_;
+#endif
 
   // Microphone positions using Cartesian coordinates:
   // x: the horizontal dimension, with positive to the right from the camera's


### PR DESCRIPTION
getUserMedia doesn't work because of the audio capture path.
This patch separates the audio input path between system capture and the voice.
Also, the SingleProcess mode causes the issue that the video from the camera
using getUserMedia is not shown. So the SingleProcess option is removed.