### PR TITLE
[Service Offloading] Crash with getDisplayMedia constraints except fo…

### DIFF
--- a/chrome/browser/media/webrtc/permission_bubble_media_access_handler.cc
+++ b/chrome/browser/media/webrtc/permission_bubble_media_access_handler.cc
@@ -180,9 +180,12 @@ void PermissionBubbleMediaAccessHandler::ProcessQueuedAccessRequest(
       blink::MediaStreamDevices devices;
       devices.push_back(blink::MediaStreamDevice(
           blink::MEDIA_DISPLAY_VIDEO_CAPTURE, screen_id.ToString(), "Screen"));
-      devices.push_back(
-          blink::MediaStreamDevice(blink::MEDIA_DISPLAY_AUDIO_CAPTURE,
-                                   screen_id.ToString(), "System Audio"));
+      // Check Audio type to add a device for System Audio.
+      if (request.audio_type == blink::MEDIA_DISPLAY_AUDIO_CAPTURE) {
+        devices.push_back(
+            blink::MediaStreamDevice(blink::MEDIA_DISPLAY_AUDIO_CAPTURE,
+                                     screen_id.ToString(), "System Audio"));
+      }
 
       std::unique_ptr<content::MediaStreamUI> ui =
           MediaCaptureDevicesDispatcher::GetInstance()


### PR DESCRIPTION
…r audio.

If getDisplayMedia is used with the constraints which includes only 'video'
except for 'audio', it makes the crash issue because an audio stream device
is always added now.
This patch adds a condition to check whether audio is requested or not.