### PR TITLE
[Meerkat] Use multicast address only for service offloading

### DIFF
--- a/third_party/meerkat/BUILD.gn
+++ b/third_party/meerkat/BUILD.gn
@@ -114,6 +114,9 @@ shared_library("meerkat_server_lib") {
   configs += [ ":meerkat_config" ]
 
   deps = [ ":meerkat_server" ]
+  if (enable_service_offloading) {
+    deps += [ "//base" ]
+  }
   sources = [
     "Component/mmSH/android/server_runner_jni.cpp",
     "Component/mmSH/android/server_runner_jni.h",

--- a/third_party/meerkat/Component/mmSH/android/server_runner_jni.cpp
+++ b/third_party/meerkat/Component/mmSH/android/server_runner_jni.cpp
@@ -19,6 +19,9 @@
 #include <android/log.h>
 #include <jni.h>
 
+#if defined(SERVICE_OFFLOADING)
+#include "base/distributed_chromium_util.h"
+#endif
 #include "server_runner.h"
 
 static JavaVM* g_jvm = nullptr;
@@ -169,7 +172,15 @@ jint Native_startServer(JNIEnv* env, jobject /* this */) {
 
   ServerRunner::ServerRunnerParams params;
   // TODO(yh106.jung): Read from configuration file
-  params.multicast_addr = "224.1.1.11";
+#if defined(SERVICE_OFFLOADING)
+  if (base::ServiceOffloading::IsEnabled()) {
+    params.multicast_addr = "224.1.1.7";
+  } else {
+#endif
+    params.multicast_addr = "224.1.1.11";
+#if defined(SERVICE_OFFLOADING)
+  }
+#endif
   params.multicast_port = 9901;
   params.service_port = 9902;
   params.exec_path = "com.samsung.android.castanets";


### PR DESCRIPTION
This adds multicast address that is different from the one of
resource offloading to avoid conflicts.

Signed-off-by: 최영수/Common Platform Lab(SR)/Staff Engineer/삼성전자 <kenshin.choi@samsung.com>