### PR TITLE
Fix an AndroidManifest file caused by Settings changes.

### DIFF
--- a/chrome/android/java/AndroidManifest.xml
+++ b/chrome/android/java/AndroidManifest.xml
@@ -1415,7 +1415,7 @@ android:value="true" />
             android:name="com.samsung.offloadworker.OffloadService" />
 
         {% if enable_service_offloading_knox == "true" %}
-        <receiver android:name="com.samsung.rtcapps.SampleAdminReceiver"
+        <receiver android:name="com.samsung.offloadsetting.SampleAdminReceiver"
             android:permission="android.permission.BIND_DEVICE_ADMIN">
             <meta-data
                 android:name="android.app.device_admin"
@@ -1425,7 +1425,7 @@ android:value="true" />
             </intent-filter>
         </receiver>
 
-        <receiver android:name="com.samsung.rtcapps.knox.KnoxLicenseReceiver" >
+        <receiver android:name="com.samsung.offloadsetting.knox.KnoxLicenseReceiver" >
               <intent-filter>
                   <action android:name="com.samsung.android.knox.intent.action.LICENSE_STATUS" />
               </intent-filter>


### PR DESCRIPTION
The code to check permission was modificated on the Offload Settings side.
Reference:
https://github.sec.samsung.net/HighPerformanceWeb/offload.js/pull/342
(Samsung developers only)