### PR TITLE
Do not display Activity when Castanets is launched.

### DIFF
--- a/chrome/android/chrome_java_sources.gni
+++ b/chrome/android/chrome_java_sources.gni
@@ -1831,4 +1831,5 @@ chrome_java_sources = [
 chrome_java_sources += [
   "java/src/org/chromium/chrome/browser/AlwaysOnTopService.java",
   "java/src/org/chromium/chrome/browser/CastanetsSettings.java",
+  "java/src/org/chromium/chrome/browser/firstrun/CastanetsFragment.java",
 ]

--- a/chrome/android/java/AndroidManifest.xml
+++ b/chrome/android/java/AndroidManifest.xml
@@ -647,7 +647,11 @@ by a child template that "extends" this file.
             {{ self.first_run_activity_common() }}>
         </activity>
         <activity android:name="org.chromium.chrome.browser.firstrun.FirstRunActivity"
+            {% if enable_castanets %}
+            android:theme="@style/Theme.Chromium.Castanets"
+            {% else %}
             android:theme="@style/Theme.Chromium.DialogWhenLarge"
+            {% endif %}
             {% block first_run_activity_common %}
             android:label="@string/fre_activity_label"
             android:launchMode="singleInstance"

--- a/chrome/android/java/res/values-v17/styles.xml
+++ b/chrome/android/java/res/values-v17/styles.xml
@@ -228,6 +228,19 @@
     <style name="DimmingDialog" parent="Base.Theme.Chromium.DialogWhenLarge">
         <item name="android:windowLightNavigationBar" tools:targetApi="28">false</item>
     </style>
+    <!-- For Castanets -->
+    <style name="Theme.Chromium.Castanets" parent="Theme.AppCompat.DayNight.DialogWhenLarge">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:textColor">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:windowAnimationStyle">@android:style/Animation</item>
+        <item name="android:windowFullscreen">true</item>
+    </style>
 
     <!-- ThemeOverlay -->
     <style name="Base.OverflowMenuThemeOverlay" parent="Theme.AppCompat.DayNight">

--- a/chrome/android/java/res_castanets/layout/empty_for_castanets.xml
+++ b/chrome/android/java/res_castanets/layout/empty_for_castanets.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/fre_main_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+    <LinearLayout
+        android:id="@+id/fre_image_and_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:gravity="center_horizontal">
+        <LinearLayout
+            android:id="@+id/fre_content_wrapper"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:layout_weight="1">
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/chrome/android/java/src/org/chromium/chrome/browser/firstrun/CastanetsFragment.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/firstrun/CastanetsFragment.java
@@ -1,0 +1,34 @@
+package org.chromium.chrome.browser.firstrun;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.chromium.chrome.R;
+
+public class CastanetsFragment extends Fragment implements FirstRunFragment {
+    public static class Page implements FirstRunPage<CastanetsFragment> {
+        @Override
+        public boolean shouldSkipPageOnCreate() {
+            return FirstRunStatus.shouldSkipWelcomePage();
+        }
+
+        @Override
+        public CastanetsFragment instantiateFragment() {
+            return new CastanetsFragment();
+        }
+    }
+
+    @Override
+    public View onCreateView(
+            LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.empty_for_castanets, container, false);
+    }
+
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+    }
+}

--- a/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunActivity.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/firstrun/FirstRunActivity.java
@@ -131,7 +131,11 @@ public class FirstRunActivity extends FirstRunActivityBase implements FirstRunPa
     private void createPageSequence() {
         // An optional welcome page.
         if (mShowWelcomePage) {
-            mPages.add(new ToSAndUMAFirstRunFragment.Page());
+            if (CommandLine.getInstance().hasSwitch(BaseSwitches.ENABLE_CASTANETS)) {
+                mPages.add(new CastanetsFragment.Page());
+            } else {
+                mPages.add(new ToSAndUMAFirstRunFragment.Page());
+            }
             mFreProgressStates.add(FRE_PROGRESS_WELCOME_SHOWN);
         }
 


### PR DESCRIPTION
It makes Castanets show and hide transparent Activity using
the customized fragment and theme.
So, it appears to the user that nothing appears.