### PR TITLE
[Service Offloading] Create the tab in incognito mode.

### DIFF
--- a/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
+++ b/chrome/android/java/src/org/chromium/chrome/browser/ChromeTabbedActivity.java
@@ -1296,7 +1296,11 @@ public class ChromeTabbedActivity
                     "MobileStartup.LoadedHomepageOnColdStart", startupHomepageIsNtp);
         }
 
-        getTabCreator(false).launchUrl(url, TabLaunchType.FROM_CHROME_UI);
+        if (CommandLine.getInstance().hasSwitch(BaseSwitches.ENABLE_SERVICE_OFFLOADING)) {
+            getTabCreator(true).launchUrl(url, TabLaunchType.FROM_CHROME_UI);
+        } else {
+            getTabCreator(false).launchUrl(url, TabLaunchType.FROM_CHROME_UI);
+        }
     }
 
     @Override


### PR DESCRIPTION
When creating a browser tab, the accessed url is cached.
Service offloading requires access to a specific url, but the problem may occur
if a different url is connected by other services.
To prevent that, create the tab in incognito mode so that it is not cached.