### PR TITLE
[Meerkat] Remove unused switches for service offloading

### DIFF
--- a/third_party/meerkat/Component/mmDiscovery/service_server.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/service_server.cpp
@@ -110,18 +110,20 @@ VOID CServiceServer::DataRecv(OSAL_Socket_Handle iEventSock,
     std::vector<char*> argv;
     t_HandlePacket(argv, pData + strlen(kServiceRequestScheme));
 
-    char server_address[35] = {'\0',};
-    snprintf(server_address, sizeof(server_address) - 1,
-             "--enable-castanets=%s", pszsource_addr);
-    argv.push_back(server_address);
+    const std::string switches(argv.front());
+    if (switches.find("--enable-castanets")) {
+      char server_address[35] = {'\0',};
+      snprintf(server_address, sizeof(server_address) - 1,
+               "--enable-castanets=%s", pszsource_addr);
+      argv.push_back(server_address);
 
-    // TODO: |server_address_old| should be remove after applying
-    // https://github.com/Samsung/Castanets/pull/75.
-    char server_address_old[35] = {'\0',};
-    snprintf(server_address_old, sizeof(server_address_old) - 1,
-             "--server-address=%s", pszsource_addr);
-    argv.push_back(server_address_old);
-
+      // TODO: |server_address_old| should be remove after applying
+      // https://github.com/Samsung/Castanets/pull/75.
+      char server_address_old[35] = {'\0',};
+      snprintf(server_address_old, sizeof(server_address_old) - 1,
+               "--server-address=%s", pszsource_addr);
+      argv.push_back(server_address_old);
+    }
 #if defined(ANDROID)
     if (!Java_startCastanetsRenderer(argv))
 #else


### PR DESCRIPTION
This removes unused switches such as --enable-castanets and --server-address
for service offloading.

Signed-off-by: 최영수/Common Platform Lab(SR)/Staff Engineer/삼성전자 <kenshin.choi@samsung.com>