### PR TITLE
[Service Offloading] Don't display https certificate warning

### DIFF
--- a/content/browser/android/content_startup_flags.cc
+++ b/content/browser/android/content_startup_flags.cc
@@ -27,6 +27,7 @@
 
 #if defined(CASTANETS) || defined(SERVICE_OFFLOADING)
 #include "base/distributed_chromium_util.h"
+#include "components/network_session_configurator/common/network_switches.h"
 #endif
 
 namespace content {
@@ -106,6 +107,8 @@ void SetContentCommandLineFlags(bool single_process) {
     // Prevents the renderer process from being killed for Service Offloading.
     parsed_command_line->AppendSwitch(
         service_manager::switches::kNoSandbox);
+    parsed_command_line->AppendSwitch(
+        switches::kIgnoreCertificateErrors);
   }
 #endif
 }


### PR DESCRIPTION
The service offloading scenario doesn't have webview to show
and users are noticed that their app screen will be shared
with Tizen devices. So, the https certificate warning is not necessary.

Signed-off-by: 최영수/Common Platform Lab(SR)/Staff Engineer/삼성전자 <kenshin.choi@samsung.com>