### PR TITLE
[Meerkat] Use ini file for the initialization on debug mode

### DIFF
--- a/third_party/meerkat/Component/mmSH/android/server_runner_jni.cpp
+++ b/third_party/meerkat/Component/mmSH/android/server_runner_jni.cpp
@@ -221,10 +221,11 @@ jint Native_startServer(JNIEnv* env, jobject /* this */, jstring j_ini_path) {
     params.multicast_port = kMulticastPort;
     params.service_port = kServicePort;
     params.monitor_port = kMonitorPort;
-    params.get_token = &Java_getIdToken;
-    params.verify_token = &Java_verifyIdToken;
-    params.get_capability = &Java_getCapability;
   }
+
+  params.get_token = &Java_getIdToken;
+  params.verify_token = &Java_verifyIdToken;
+  params.get_capability = &Java_getCapability;
 
   g_server_runner = new ServerRunner(params);
   int exit_code = g_server_runner->Initialize();

--- a/third_party/meerkat/Component/mmSH/server_runner.h
+++ b/third_party/meerkat/Component/mmSH/server_runner.h
@@ -32,17 +32,17 @@ class ServerRunner {
  public:
   struct ServerRunnerParams {
     std::string multicast_addr;
-    int multicast_port;
-    int service_port;
+    int multicast_port = -1;
+    int monitor_port = -1;
+    int service_port = -1;
     std::string exec_path;
-    int monitor_port;
-    bool with_presence;
+    bool with_presence = false;
     std::string presence_addr;
-    int presence_port;
-    bool is_daemon;
-    GetTokenFunc get_token;
-    VerifyTokenFunc verify_token;
-    GetCapabilityFunc get_capability;
+    int presence_port = -1;
+    bool is_daemon = false;
+    GetTokenFunc get_token = nullptr;
+    VerifyTokenFunc verify_token = nullptr;
+    GetCapabilityFunc get_capability = nullptr;
   };
 
   static bool BuildParams(const std::string& ini_path,


### PR DESCRIPTION
This patch uses an ini file for the initialization of Meerkat server
when Service Offloading is set as debug app.

1. Settings > Developer options > Select debug app
2. In the terminal, adb push [your ini fle] /data/local/tmp/meerkat/server.ini
3. Start Meerkat

Signed-off-by: yh106.jung <yh106.jung@samsung.com>