### PR TITLE
[Meerkat] Append browser's address only when castanets enabled

### DIFF
--- a/third_party/meerkat/Component/mmDiscovery/service_server.h
+++ b/third_party/meerkat/Component/mmDiscovery/service_server.h
@@ -46,8 +46,7 @@ class CServiceServer : public mmProto::CpTcpServer {
   VOID EventNotify(OSAL_Socket_Handle iEventSock,
                    CbSocket::SOCKET_NOTIFYTYPE type);
  private:
-  VOID t_HandlePacket(std::vector<char*>& argv /*out*/,
-                      char* packet_string /*in*/);
+  void HandleServiceRequest(const char* address, char* args);
 
   GetTokenFunc get_token_;
   VerifyTokenFunc verify_token_;


### PR DESCRIPTION
This patch appends browser's address to castanets switch only when
castanets enabled.

Signed-off-by: yh106.jung <yh106.jung@samsung.com>