### PR TITLE
Add Castanets Internal Repo for Settings UI

### DIFF
--- a/build/update_internal_repo.sh
+++ b/build/update_internal_repo.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+[ -d third_party/castanets-internal ] || git clone git@github.sec.samsung.net:HighPerformanceWeb/castanets-internal.git third_party/castanets-internal
+git -C third_party/castanets-internal pull
+
 [ -d third_party/offload-js ] || git clone git@github.sec.samsung.net:HighPerformanceWeb/offload.js.git third_party/offload-js
 git -C third_party/offload-js pull

--- a/chrome/android/BUILD.gn
+++ b/chrome/android/BUILD.gn
@@ -472,6 +472,9 @@ android_library("chrome_java") {
   if (enable_offload) {
     deps += [ "//third_party/offload-js:offload_java" ]
   }
+  if (enable_service_offloading_knox) {
+    deps += [ "//third_party/castanets-internal:castanets_internal_java" ]
+  }
   if (enable_castanets) {
     deps += [ "//third_party/meerkat:meerkat_server_java" ]
   }

--- a/third_party/blink/renderer/modules/input_control/BUILD.gn
+++ b/third_party/blink/renderer/modules/input_control/BUILD.gn
@@ -20,7 +20,7 @@ if (is_android && enable_service_offloading_knox && enable_service_offloading) {
 
     deps = [
       "//base:base_java",
-      "//third_party/offload-js:com_samsung_knox_sdk_java",
+      "//third_party/castanets-internal:com_samsung_knox_sdk_java",
       "//base:jni_java",
     ]
 


### PR DESCRIPTION
This patch moves Castanets Settings UI to castanets-internal repo and adds the internal repo in third_party like offload-js.

Signed-off-by: Insoon Kim <is46.kim@samsung.com>