### PR TITLE
Load meerkat library with ".cr" suffix for component build

### DIFF
--- a/third_party/meerkat/Component/mmSH/android/java/src/com/samsung/android/meerkat/MeerkatServerService.java
+++ b/third_party/meerkat/Component/mmSH/android/java/src/com/samsung/android/meerkat/MeerkatServerService.java
@@ -39,16 +39,25 @@ import java.io.File;
 
 public class MeerkatServerService extends Service
         implements SharedPreferences.OnSharedPreferenceChangeListener {
-    static {
-        System.loadLibrary("meerkat_server_lib");
-    }
-
     private static final String TAG = "MeerkatServerService";
     private static final String MEERKAT_INI_PATH = "/data/local/tmp/meerkat/server.ini";
     private static final int MEERKAT_NOTIFICATION_ID = 100;
     private static final String MEERKAT_CHANNEL_ID = "meekat_server";
     private static final String MEERKAT_CHANNEL_GROUP_ID = "meekat";
+    private static final String MEERKAT_LIBRARY_NAME = "meerkat_server_lib";
     private static final String ACTION_NOTIFICATION_CLICKED = "com.samsung.android.meerkat.NOTIFICATION_CLICKED";
+
+    static {
+        try {
+            System.loadLibrary(MEERKAT_LIBRARY_NAME);
+        } catch (UnsatisfiedLinkError e) {
+            // In a component build, the ".cr" suffix is added to each library name.
+            Log.w(TAG,
+                    "Couldn't load lib" + MEERKAT_LIBRARY_NAME + ".so, trying lib"
+                            + MEERKAT_LIBRARY_NAME + ".cr.so");
+            System.loadLibrary(MEERKAT_LIBRARY_NAME + ".cr");
+        }
+    }
 
     private static Context applicationContext;
     private static String cachedCapability;


### PR DESCRIPTION
In a component build, the ".cr" suffix is added to each library name.
If the meerkat library loading fails, try to load the library with ".cr"
suffix for component build.

Signed-off-by: Insoon Kim <is46.kim@samsung.com>