### PR TITLE
[Service Offloading] Allow getDisplayMedia in non-secure context.

### DIFF
--- a/third_party/blink/renderer/core/dom/document.cc
+++ b/third_party/blink/renderer/core/dom/document.cc
@@ -310,6 +310,10 @@
 #include "third_party/blink/renderer/platform/wtf/text/text_encoding_registry.h"
 #include "third_party/blink/renderer/platform/wtf/time.h"
 
+#if defined(SERVICE_OFFLOADING)
+#include "base/distributed_chromium_util.h"
+#endif
+
 #ifndef NDEBUG
 using WeakDocumentSet = blink::HeapHashSet<blink::WeakMember<blink::Document>>;
 static WeakDocumentSet& liveDocumentSet();
@@ -6598,6 +6602,11 @@ void Document::InitSecureContextState() {
   } else {
     secure_context_state_ = SecureContextState::kNonSecure;
   }
+
+#if defined(SERVICE_OFFLOADING)
+  if (base::ServiceOffloading::IsEnabled())
+    secure_context_state_ = SecureContextState::kSecure;
+#endif
   DCHECK_NE(secure_context_state_, SecureContextState::kUnknown);
 }
 


### PR DESCRIPTION
In Service offloading, the android device gets contents for the webrtc server
from the client device. The android device needs to use http protocol to access
the client device, but getDisplayMedia does not work with http content.
So, this patch allows that getDisplayMedia works on the http content by setting
the document state to 'Secure'.