### PR TITLE
Update Settings and Remove App Icon

### DIFF
--- a/chrome/android/java/AndroidManifest.xml
+++ b/chrome/android/java/AndroidManifest.xml
@@ -596,7 +596,9 @@ by a child template that "extends" this file.
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.DEFAULT" />
+                {% if enable_castanets != "true" %}
                 <category android:name="android.intent.category.LAUNCHER" />
+                {% endif %}
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.APP_BROWSER" />
                 {% if channel in ['dev', 'canary', 'default'] %}
@@ -1383,7 +1385,7 @@ android:value="true" />
         {% endif %}
 
         {% if enable_offload == "true" %}
-        <activity android:name="com.samsung.offloadsetting.MainActivity"
+        <activity android:name="com.samsung.offloadsetting.SettingsActivity"
             android:label="@string/offload_app_name"
             android:documentLaunchMode="intoExisting"
             android:process=":offload_setting_process"
@@ -1395,11 +1397,6 @@ android:value="true" />
         </activity>
 
         <activity android:name="com.samsung.rtcapps.AppSelection"
-            android:process=":offload_setting_process"
-            android:theme="@style/OffloadAppTheme">
-        </activity>
-
-        <activity android:name="com.samsung.offloadworker.SettingsActivity"
             android:process=":offload_setting_process"
             android:theme="@style/OffloadAppTheme">
         </activity>

--- a/third_party/meerkat/Component/mmSH/android/java/src/com/samsung/android/meerkat/MeerkatServerService.java
+++ b/third_party/meerkat/Component/mmSH/android/java/src/com/samsung/android/meerkat/MeerkatServerService.java
@@ -29,6 +29,7 @@ import android.content.pm.PackageManager;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.IBinder;
+import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
@@ -49,6 +50,7 @@ public class MeerkatServerService extends Service
     private static final String MEERKAT_CHANNEL_ID = "meekat_server";
     private static final String MEERKAT_CHANNEL_GROUP_ID = "meekat";
     private static final String ACTION_NOTIFICATION_CLICKED = "com.samsung.android.meerkat.NOTIFICATION_CLICKED";
+    private static final String PREF_KEY_ENABLE_CASTANETS = "enable_castanets";
 
     private static Context applicationContext;
     private static String cachedCapability;
@@ -61,6 +63,11 @@ public class MeerkatServerService extends Service
         @Override
         public void onReceive(Context context, Intent intent) {
             if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
+                if (!PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
+                            PREF_KEY_ENABLE_CASTANETS, false)) {
+                    Log.i(TAG, "Castanets is Disabled.");
+                    return;
+                }
                 Intent serviceIntent = new Intent(context, MeerkatServerService.class);
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     context.startForegroundService(serviceIntent);


### PR DESCRIPTION
- Remove Castanets App Icon for testing in Launcher
- Replace settings MainActivity with SettingsActivity
- Start Meerkat service only when Castanets is enabled

Signed-off-by: Insoon Kim <is46.kim@samsung.com>