### PR TITLE
[Offload.js] Add intent filter for 'Always allow'

### DIFF
--- a/chrome/android/java/AndroidManifest.xml
+++ b/chrome/android/java/AndroidManifest.xml
@@ -1411,6 +1411,7 @@ android:value="true" />
             android:exported="false">
             <intent-filter>
                 <action android:name="com.samsung.offloadworker.ALLOW" />
+                <action android:name="com.samsung.offloadworker.ALWAYS_ALLOW" />
                 <action android:name="com.samsung.offloadworker.BLOCK" />
             </intent-filter>
         </receiver>


### PR DESCRIPTION
This patch adds intent filter for 'Always allow' option.

Signed-off-by: yh106.jung <yh106.jung@samsung.com>