### PR TITLE
Fix offload build break

### DIFF
--- a/chrome/android/java/AndroidManifest.xml
+++ b/chrome/android/java/AndroidManifest.xml
@@ -1386,7 +1386,7 @@ android:value="true" />
 
         {% if enable_offload == "true" %}
         <activity android:name="com.samsung.offloadsetting.SettingsActivity"
-            android:label="@string/offload_app_name"
+            android:label="@string/worker_app_name"
             android:documentLaunchMode="intoExisting"
             android:process=":offload_setting_process"
             android:theme="@style/OffloadAppTheme">


### PR DESCRIPTION
- Label is changed from 'offload_app_name' to 'worker_app_name'

Signed-off-by: Hunseop Jeong <hs85.jeong@samsung.com>