### PR TITLE
[DWE] Remove service client if it was expired

### DIFF
--- a/third_party/meerkat/Component/mmDiscovery/service_provider.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/service_provider.cpp
@@ -249,11 +249,12 @@ void ServiceProvider::InvalidateServiceList() {
   for (int i = 0; i < count;) {
     auto* info = service_providers_.GetAt(i);
     bool should_remove = false;
-    if (info->service_client->GetState() == CServiceClient::DISCONNECTED)
+    if (info->service_client->GetState() == CServiceClient::DISCONNECTED) {
       should_remove = true;
-    else if (current_time - info->last_update_time >= kExpiresMs &&
-             info->service_client->GetState() == CServiceClient::NONE)
+    } else if (current_time - info->last_update_time >= kExpiresMs) {
+      info->service_client->StopClient();
       should_remove = true;
+    }
 
     if (should_remove) {
       DPRINT(COMM, DEBUG_INFO,


### PR DESCRIPTION
Client is still remaining in the list of meerkat
even if it was not available due to some issue like a network problem.

We remove the service client if it has already expired after 3 seconds.