### PR TITLE
[Meerkat] Change Meerkat Multicast IP

### DIFF
--- a/chrome/android/java/AndroidManifest.xml
+++ b/chrome/android/java/AndroidManifest.xml
@@ -1396,6 +1396,13 @@ android:value="true" />
             </intent-filter>
         </activity>
 
+        <provider
+            android:name="com.samsung.offloadsetting.SettingProvider"
+            android:authorities="com.samsung.offloadsetting.SettingProvider"
+            android:process=":offload_setting_process"
+            android:exported="false">
+        </provider>
+
         <activity android:name="com.samsung.offloadsetting.OffloadPermissionActivity"
             android:process=":offload_setting_process"
             android:theme="@style/OffloadAppTheme">

--- a/third_party/meerkat/Component/client.ini
+++ b/third_party/meerkat/Component/client.ini
@@ -2,6 +2,6 @@
 run-as-damon=false
 
 [multicast]
-address=224.1.1.11
+address=224.0.0.250
 port=9901
 self-discovery-enabled=false

--- a/third_party/meerkat/Component/mmDiscovery/discovery_server.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/discovery_server.cpp
@@ -50,6 +50,7 @@ BOOL CDiscoveryServer::StartServer(const CHAR* channel_address,
 
   if (!CpUdpServer::Join(channel_address)) {
     DPRINT(COMM, DEBUG_ERROR, "CpUdpServer::Join() Fail\n");
+    CbSocket::Close();
     return false;
   }
 
@@ -60,7 +61,8 @@ BOOL CDiscoveryServer::StartServer(const CHAR* channel_address,
 
   query_request_count_ = 0;
 
-  DPRINT(COMM, DEBUG_INFO, "Start discovery server with [%d] port\n", port);
+  DPRINT(COMM, DEBUG_INFO, "Start discovery server with [%s:%d]\n",
+         channel_address, port);
   return TRUE;
 }
 

--- a/third_party/meerkat/Component/mmDiscovery/monitor_server.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/monitor_server.cpp
@@ -89,7 +89,11 @@ VOID ServerSocket::DataRecv(OSAL_Socket_Handle sock,
         '\0',
     };
     mmBase::strlcpy(buf_, monitor_info_.c_str(), sizeof(buf_));
-    CpTcpServer::DataSend(sock, buf_, monitor_info_.length());
+    int monitor_len = monitor_info_.length();
+    CpTcpServer::DataSend(sock, buf_,
+                          (monitor_len > MAX_MONITOR_MSG_BUFF)
+                              ? MAX_MONITOR_MSG_BUFF
+                              : monitor_len);
   }
 }
 

--- a/third_party/meerkat/Component/mmDiscovery/service_provider.cpp
+++ b/third_party/meerkat/Component/mmDiscovery/service_provider.cpp
@@ -50,8 +50,10 @@ ServiceInfo::ServiceInfo()
       authorized(false) {}
 
 ServiceInfo::~ServiceInfo() {
-  if (service_client)
+  if (service_client) {
+    service_client->StopClient();
     delete service_client;
+  }
 }
 
 ServiceProvider::ServiceProvider()
@@ -263,6 +265,7 @@ void ServiceProvider::InvalidateServiceList() {
              info->service_client->GetServerPort());
       if (service_providers_.DelAt(i) == 0)
         break;
+      --count;
     } else {
       ++i;
     }

--- a/third_party/meerkat/Component/mmSH/android/java/src/com/samsung/android/meerkat/MeerkatServerService.java
+++ b/third_party/meerkat/Component/mmSH/android/java/src/com/samsung/android/meerkat/MeerkatServerService.java
@@ -160,6 +160,11 @@ public class MeerkatServerService extends Service
         sharedPreferences.unregisterOnSharedPreferenceChangeListener(this);
         if (meerkatRunner != null) {
             nativeStopServer();
+            try {
+                meerkatRunner.join(1000);
+            } catch (Exception e) {
+                Log.e(TAG, "meerkatRunner.join() failed. " + e);
+            }
             meerkatRunner = null;
         }
         super.onDestroy();

--- a/third_party/meerkat/Component/mmSH/android/server_runner_jni.cpp
+++ b/third_party/meerkat/Component/mmSH/android/server_runner_jni.cpp
@@ -28,7 +28,7 @@ static ServerRunner* g_server_runner = nullptr;
 
 static const char* const kLogTag = "MeerkatServer_JNI";
 static const char* const kMeerkatServerServiceName = "com/samsung/android/meerkat/MeerkatServerService";
-static const char* const kMulticastAddress = "224.1.1.11";
+static const char* const kMulticastAddress = "224.0.0.250";
 static const int kMulticastPort = 9901;
 static const int kServicePort = 9902;
 static const int kMonitorPort = 9903;

--- a/third_party/meerkat/Component/mmSH/android/server_runner_jni.cpp
+++ b/third_party/meerkat/Component/mmSH/android/server_runner_jni.cpp
@@ -197,7 +197,7 @@ bool Java_startCastanetsRenderer(std::vector<char*>& argv) {
   return ret == JNI_TRUE;
 }
 
-jint Native_startServer(JNIEnv* env, jobject /* this */, jstring j_ini_path) {
+jint Native_startServer(JNIEnv* env, jobject /* this */, jstring j_ini_path, jstring j_multicast_addr) {
   __android_log_print(ANDROID_LOG_DEBUG, kLogTag, "Start server runner");
 
   if (g_server_runner) {
@@ -221,7 +221,13 @@ jint Native_startServer(JNIEnv* env, jobject /* this */, jstring j_ini_path) {
     params.multicast_port = kMulticastPort;
     params.service_port = kServicePort;
     params.monitor_port = kMonitorPort;
+    if (j_multicast_addr && env->GetStringUTFLength(j_multicast_addr) > 0) {
+      auto* multicast_addr = env->GetStringUTFChars(j_multicast_addr, nullptr);
+      params.multicast_addr = multicast_addr;
+      env->ReleaseStringUTFChars(j_multicast_addr, multicast_addr);
+    }
   }
+  __android_log_print(ANDROID_LOG_INFO, kLogTag, "Multicast Address : %s", params.multicast_addr.c_str());
 
   params.get_token = &Java_getIdToken;
   params.verify_token = &Java_verifyIdToken;
@@ -250,7 +256,7 @@ void Native_stopServer(JNIEnv* env, jobject /* this */) {
 }
 
 static JNINativeMethod kNativeMethods[] = {
-  {"nativeStartServer", "(Ljava/lang/String;)I", reinterpret_cast<void*>(&Native_startServer)},
+  {"nativeStartServer", "(Ljava/lang/String;Ljava/lang/String;)I", reinterpret_cast<void*>(&Native_startServer)},
   {"nativeStopServer", "()V", reinterpret_cast<void*>(&Native_stopServer)},
 };
 

--- a/third_party/meerkat/Component/mmSH/client_runner.h
+++ b/third_party/meerkat/Component/mmSH/client_runner.h
@@ -17,9 +17,12 @@
 #include <memory>
 #include <string>
 
-#if defined(LINUX) && !defined(ANDROID)
+#if defined(USE_DBUS)
+#include <Ecore.h>
 #include <dbus/dbus.h>
 #endif
+
+#include "bTask.h"
 
 class CDiscoveryClient;
 class CServiceClient;
@@ -63,12 +66,17 @@ class ClientRunner {
   int Run();
 #endif
   void Stop();
+#if defined(USE_DBUS)
+  void DBusMessageCallback();
+#endif
 
  private:
   bool BeforeRun();
   void AfterRun();
 
-#if defined(LINUX) && !defined(ANDROID)
+#if defined(USE_DBUS)
+  void InitDBusConnection();
+  void FreeDBusConnection();
   void RunService(DBusMessage* msg);
   void GetDevicelist(DBusMessage* msg);
   void RequestService(DBusMessage* msg);
@@ -84,8 +92,9 @@ class ClientRunner {
   std::unique_ptr<CNetTunProc*> tun_client_;
 #endif
 
-#if defined(LINUX) && !defined(ANDROID)
+#if defined(USE_DBUS)
   DBusConnection* conn_ = nullptr;
+  Ecore_Fd_Handler* conn_fd_handler_ = nullptr;
 #endif
 
   bool keep_running_;

--- a/third_party/meerkat/Component/server.ini
+++ b/third_party/meerkat/Component/server.ini
@@ -2,7 +2,7 @@
 run-as-damon=false
 
 [multicast]
-address=224.1.1.11
+address=224.0.0.250
 port=9901
 
 [service]


### PR DESCRIPTION
- Change default multicast IP to 224.0.0.250
- Print all logs with "meerkat" log tag
- Join the thread to make sure that the thread stop when MeerkatServerService is destroyed
- This starts the MeerkatServer with multicast address from SettingProvider.
