### PR TITLE
Shared memory changes for castanets -3 

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,39 @@
+# Defines the Chromium style for automatic reformatting.
+# http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+BasedOnStyle: Chromium
+# This defaults to 'Auto'. Explicitly set it for a while, so that
+# 'vector<vector<int> >' in existing files gets formatted to
+# 'vector<vector<int>>'. ('Auto' means that clang-format will only use
+# 'int>>' if the file already contains at least one such instance.)
+Standard: Cpp11
+
+# Make sure code like:
+# IPC_BEGIN_MESSAGE_MAP()
+#   IPC_MESSAGE_HANDLER(WidgetHostViewHost_Update, OnUpdate)
+# IPC_END_MESSAGE_MAP()
+# gets correctly indented.
+MacroBlockBegin: "^\
+BEGIN_MSG_MAP|\
+BEGIN_MSG_MAP_EX|\
+BEGIN_SAFE_MSG_MAP_EX|\
+CR_BEGIN_MSG_MAP_EX|\
+IPC_BEGIN_MESSAGE_MAP|\
+IPC_BEGIN_MESSAGE_MAP_WITH_PARAM|\
+IPC_PROTOBUF_MESSAGE_TRAITS_BEGIN|\
+IPC_STRUCT_BEGIN|\
+IPC_STRUCT_BEGIN_WITH_PARENT|\
+IPC_STRUCT_TRAITS_BEGIN|\
+POLPARAMS_BEGIN|\
+PPAPI_BEGIN_MESSAGE_MAP$"
+MacroBlockEnd: "^\
+CR_END_MSG_MAP|\
+END_MSG_MAP|\
+IPC_END_MESSAGE_MAP|\
+IPC_PROTOBUF_MESSAGE_TRAITS_END|\
+IPC_STRUCT_END|\
+IPC_STRUCT_TRAITS_END|\
+POLPARAMS_END|\
+PPAPI_END_MESSAGE_MAP$"
+
+# TODO: Remove this once clang-format r357700 is rolled in.
+JavaImportGroups: ['android', 'androidx', 'com', 'dalvik', 'junit', 'org', 'com.google.android.apps.chrome', 'org.chromium', 'java', 'javax']

--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -113,6 +113,9 @@ config("base_flags") {
       # https://groups.google.com/a/chromium.org/d/topic/chromium-dev/B9Q5KTD7iCo/discussion
       "-Wglobal-constructors",
     ]
+    if (enable_castanets) {
+      cflags += [ "-Wno-thread-safety-analysis" ]
+    }
   }
 }
 
@@ -1213,6 +1216,8 @@ jumbo_component("base") {
       "memory/castanets_memory_mapping.h",
       "memory/castanets_memory_syncer.cc",
       "memory/castanets_memory_syncer.h",
+      "memory/shared_memory_locker.cc",
+      "memory/shared_memory_locker.h",
     ]
   }
 

--- a/base/memory/castanets_memory_syncer.cc
+++ b/base/memory/castanets_memory_syncer.cc
@@ -44,7 +44,7 @@ UnknownMemorySyncer::ConvertToExternal(SyncDelegate *delegate) {
       memory = mapping_info_->MapForSync(fd_in_transit_);
 
     for (auto &it : pending_syncs_)
-      delegate->SendSyncEvent(mapping_info_, it.offset, it.size);
+      delegate->SendSyncEvent(mapping_info_, it.offset, it.size, false);
 
     if (memory)
       mapping_info_->UnmapForSync(memory);

--- a/base/memory/castanets_memory_syncer.h
+++ b/base/memory/castanets_memory_syncer.h
@@ -20,9 +20,11 @@ class BASE_EXPORT SyncDelegate {
 public:
   virtual ~SyncDelegate() {}
 
-  virtual void
-  SendSyncEvent(scoped_refptr<base::CastanetsMemoryMapping> mapping_info,
-                size_t offset, size_t sync_size) = 0;
+  virtual void SendSyncEvent(
+      scoped_refptr<base::CastanetsMemoryMapping> mapping_info,
+      size_t offset,
+      size_t sync_size,
+      bool write_lock = true) = 0;
 };
 
 class BASE_EXPORT CastanetsMemorySyncer {

--- a/base/memory/shared_memory_helper.cc
+++ b/base/memory/shared_memory_helper.cc
@@ -199,38 +199,39 @@ subtle::PlatformSharedMemoryRegion CreateAnonymousSharedMemoryIfNeeded(
   static base::Lock* lock = new base::Lock;
   base::AutoLock auto_lock(*lock);
 
-  int fd = SharedMemoryTracker::GetInstance()->Find(guid);
+  subtle::PlatformSharedMemoryRegion region =
+      SharedMemoryTracker::GetInstance()->FindMemoryHolder(guid);
+  if (region.IsValid())
+    return region;
+
   ScopedFD new_fd;
   ScopedFD readonly_fd;
 
-  if (fd < 0) {
-    FilePath path;
-    if (!CreateAnonymousSharedMemory(option, &new_fd, &readonly_fd, &path))
-      return subtle::PlatformSharedMemoryRegion();
-    fd = new_fd.get();
-    VLOG(1) << "Create anonymous shared memory for Castanets" << guid;
-  }
+  FilePath path;
+  VLOG(1) << "Create anonymous shared memory for Castanets" << guid;
+  if (!CreateAnonymousSharedMemory(option, &new_fd, &readonly_fd, &path))
+    return subtle::PlatformSharedMemoryRegion();
 
   struct stat stat;
-  CHECK(!fstat(fd, &stat));
+  CHECK(!fstat(new_fd.get(), &stat));
   const size_t current_size = stat.st_size;
   if (current_size != option.size)
-    CHECK(!HANDLE_EINTR(ftruncate(fd, option.size)));
-
-  new_fd.reset(HANDLE_EINTR(dup(fd)));
-  SharedMemoryTracker::GetInstance()->RemoveHolder(guid);
+    CHECK(!HANDLE_EINTR(ftruncate(new_fd.get(), option.size)));
 
   subtle::PlatformSharedMemoryRegion::Mode mode =
       subtle::PlatformSharedMemoryRegion::Mode::kUnsafe;
   if (option.share_read_only) {
     mode = subtle::PlatformSharedMemoryRegion::Mode::kReadOnly;
     if (!readonly_fd.is_valid())
-      readonly_fd.reset(HANDLE_EINTR(dup(fd)));
+      readonly_fd.reset(HANDLE_EINTR(dup(new_fd.get())));
   }
 
-  return subtle::PlatformSharedMemoryRegion::Take(
-      subtle::ScopedFDPair(std::move(new_fd), std::move(readonly_fd)),
-      mode, option.size, guid);
+  region = subtle::PlatformSharedMemoryRegion::Take(
+      subtle::ScopedFDPair(std::move(new_fd), std::move(readonly_fd)), mode,
+      option.size, guid);
+
+  SharedMemoryTracker::GetInstance()->AddHolder(region.Duplicate());
+  return region;
 }
 #endif // defined(CASTANETS)
 

--- a/base/memory/shared_memory_locker.cc
+++ b/base/memory/shared_memory_locker.cc
@@ -1,0 +1,82 @@
+// Copyright 2019 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/memory/shared_memory_locker.h"
+
+#include "base/lazy_instance.h"
+
+namespace base {
+
+constexpr size_t kLockPoolSize = 32;
+
+class LockPool {
+ public:
+  LockPool() = default;
+  ~LockPool() = default;
+
+  Lock* GetLock() {
+    base::AutoLock lock(lock_);
+    if (index_ == kLockPoolSize)
+      index_ = 0;
+    return &pool_[index_++];
+  }
+
+ private:
+  base::Lock lock_;
+  Lock pool_[kLockPoolSize];
+  size_t index_ = kLockPoolSize;
+
+  DISALLOW_COPY_AND_ASSIGN(LockPool);
+};
+
+base::LazyInstance<LockPool>::Leaky g_lock_pool = LAZY_INSTANCE_INITIALIZER;
+
+Lock* GetGlobalLock() {
+  return g_lock_pool.Get().GetLock();
+}
+
+SharedMemoryLocker::SharedMemoryLocker() = default;
+
+SharedMemoryLocker::~SharedMemoryLocker() = default;
+
+SharedMemoryLocker* SharedMemoryLocker::GetInstance() {
+  static SharedMemoryLocker* instance = new SharedMemoryLocker;
+  return instance;
+}
+
+void SharedMemoryLocker::LockGuid(const UnguessableToken& guid) {
+  scoped_refptr<GuidLocker> locker = nullptr;
+  {
+    AutoLock lock(guid_lock_);
+    auto it = guid_locks_.find(guid);
+    if (it != guid_locks_.end()) {
+      locker = it->second;
+      it->second->AddRef();
+    } else {
+      locker = new GuidLocker(guid, GetGlobalLock());
+      guid_locks_.emplace(guid, locker);
+    }
+  }
+  locker->lock_->Acquire();
+}
+
+void SharedMemoryLocker::UnlockGuid(const UnguessableToken& guid) {
+  AutoLock lock(guid_lock_);
+  auto it = guid_locks_.find(guid);
+  CHECK(it != guid_locks_.end());
+  it->second->lock_->Release();
+
+  if (it->second->HasOneRef())
+    guid_locks_.erase(it);
+  else
+    it->second->Release();
+}
+
+SharedMemoryLocker::GuidLocker::GuidLocker(const UnguessableToken& guid,
+                                           Lock* lock)
+    : guid_(guid), lock_(lock) {}
+
+SharedMemoryLocker::GuidLocker::~GuidLocker() = default;
+
+}  // namespace base

--- a/base/memory/shared_memory_locker.h
+++ b/base/memory/shared_memory_locker.h
@@ -1,0 +1,64 @@
+// Copyright 2019 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef BASE_MEMORY_SHARED_MEMORY_LOCKER_H_
+#define BASE_MEMORY_SHARED_MEMORY_LOCKER_H_
+
+#include <map>
+
+#include "base/base_export.h"
+#include "base/memory/ref_counted.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/synchronization/lock.h"
+#include "base/unguessable_token.h"
+
+namespace base {
+
+// SharedMemoryLocker provides the lock for the corresponding guid.
+class BASE_EXPORT SharedMemoryLocker {
+ public:
+  // Returns a singleton instance.
+  static SharedMemoryLocker* GetInstance();
+
+  void LockGuid(const UnguessableToken& guid);
+  void UnlockGuid(const UnguessableToken& guid);
+
+ private:
+  SharedMemoryLocker();
+  ~SharedMemoryLocker();
+
+  class GuidLocker : public RefCountedThreadSafe<GuidLocker> {
+   private:
+    friend class RefCountedThreadSafe<GuidLocker>;
+    friend class SharedMemoryLocker;
+
+    GuidLocker(const UnguessableToken& guid, Lock* lock);
+    ~GuidLocker();
+
+    UnguessableToken guid_;
+    Lock* const lock_;
+  };
+
+  Lock guid_lock_;
+  std::map<UnguessableToken, scoped_refptr<GuidLocker>> guid_locks_;
+
+  DISALLOW_COPY_AND_ASSIGN(SharedMemoryLocker);
+};
+
+class AutoGuidLock {
+ public:
+  explicit AutoGuidLock(const UnguessableToken& guid) : guid_(guid) {
+    SharedMemoryLocker::GetInstance()->LockGuid(guid_);
+  }
+
+  ~AutoGuidLock() { SharedMemoryLocker::GetInstance()->UnlockGuid(guid_); }
+
+ private:
+  UnguessableToken guid_;
+  DISALLOW_COPY_AND_ASSIGN(AutoGuidLock);
+};
+
+}  // namespace base
+
+#endif  // BASE_MEMORY_SHARED_MEMORY_LOCKER_H_

--- a/base/memory/shared_memory_tracker.cc
+++ b/base/memory/shared_memory_tracker.cc
@@ -20,6 +20,7 @@
 #include "base/memory/castanets_memory_mapping.h"
 #include "base/memory/castanets_memory_syncer.h"
 #include "base/memory/platform_shared_memory_region.h"
+#include "base/memory/shared_memory_locker.h"
 
 namespace base {
 
@@ -104,6 +105,7 @@ void SharedMemoryTracker::IncrementMemoryUsage(
                   UsageInfo(mapping.mapped_size(), mapping.guid()));
 
 #if defined(CASTANETS)
+  AutoGuidLock guid_lock(mapping.guid());
   AddMapping(mapping.guid(), mapping.mapped_size(), mapping.raw_memory_ptr());
   // The shared memory corresponding to the guid began to be used somewhere.
   // Therefore delete the holder if it exists.
@@ -117,6 +119,7 @@ void SharedMemoryTracker::DecrementMemoryUsage(
   DCHECK(usages_.find(mapping.raw_memory_ptr()) != usages_.end());
   usages_.erase(mapping.raw_memory_ptr());
 #if defined(CASTANETS)
+  AutoGuidLock guid_lock(mapping.guid());
   RemoveMapping(mapping.guid(), mapping.raw_memory_ptr());
 #endif
 }

--- a/base/memory/shared_memory_tracker.h
+++ b/base/memory/shared_memory_tracker.h
@@ -25,6 +25,7 @@ class ProcessMemoryDump;
 }
 
 #if defined(CASTANETS)
+class CastanetsMemoryHolder;
 class CastanetsMemoryMapping;
 class CastanetsMemorySyncer;
 class SyncDelegate;
@@ -59,7 +60,8 @@ class BASE_EXPORT SharedMemoryTracker : public trace_event::MemoryDumpProvider {
   void AddHolder(subtle::PlatformSharedMemoryRegion handle);
   void RemoveHolder(const UnguessableToken& guid);
 
-  int Find(const UnguessableToken& id);
+  subtle::PlatformSharedMemoryRegion FindMemoryHolder(
+      const UnguessableToken& id);
   scoped_refptr<CastanetsMemoryMapping>
   FindMappedMemory(const UnguessableToken &id);
   void AddFDInTransit(const UnguessableToken &guid, int fd);
@@ -100,10 +102,12 @@ class BASE_EXPORT SharedMemoryTracker : public trace_event::MemoryDumpProvider {
   Lock usages_lock_;
   std::map<void*, UsageInfo> usages_;
 #if defined(CASTANETS)
+  friend class CastanetsMemoryHolder;
   void AddMapping(const UnguessableToken &guid, size_t size, void *ptr);
   void RemoveMapping(const UnguessableToken &guid, void *ptr);
 
   std::unique_ptr<UnknownMemorySyncer> TakeUnknownMemory(int fd);
+  Lock mapping_lock_;
 
   std::map<UnguessableToken, scoped_refptr<CastanetsMemoryMapping>> mappings_;
 
@@ -119,7 +123,7 @@ class BASE_EXPORT SharedMemoryTracker : public trace_event::MemoryDumpProvider {
   std::map<UnguessableToken, std::set<int>> handles_;
 
   Lock holders_lock_;
-  std::map<UnguessableToken, subtle::PlatformSharedMemoryRegion> holders_;
+  std::map<UnguessableToken, CastanetsMemoryHolder> holders_;
 #endif
 
   DISALLOW_COPY_AND_ASSIGN(SharedMemoryTracker);

--- a/base/threading/thread_restrictions.h
+++ b/base/threading/thread_restrictions.h
@@ -209,6 +209,7 @@ namespace mojo {
 class CoreLibraryInitializer;
 class SyncCallRestrictions;
 namespace core {
+class NodeController;
 class ScopedIPCSupport;
 }
 }
@@ -449,6 +450,9 @@ class BASE_EXPORT ScopedAllowBaseSyncPrimitives {
   friend class internal::TaskTracker;
   friend class leveldb_env::DBTracker;
   friend class media::BlockingUrlProtocol;
+#if defined(CASTANETS)
+  friend class mojo::core::NodeController;
+#endif
   friend class mojo::core::ScopedIPCSupport;
   friend class net::MultiThreadedCertVerifierScopedAllowBaseSyncPrimitives;
   friend class rlz_lib::FinancialPing;

--- a/components/viz/service/display_embedder/server_shared_bitmap_manager.cc
+++ b/components/viz/service/display_embedder/server_shared_bitmap_manager.cc
@@ -90,7 +90,9 @@ std::unique_ptr<SharedBitmap> ServerSharedBitmapManager::GetSharedBitmapFromId(
       bitmap_size > data->size()) {
     return nullptr;
   }
-
+#if defined(CASTANETS)
+  mojo::WaitSyncSharedMemory(data->mapped_id());
+#endif
   if (!data->memory()) {
     return nullptr;
   }

--- a/mojo/core/BUILD.gn
+++ b/mojo/core/BUILD.gn
@@ -2,9 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/config/features.gni")
 import("//build/config/chromeos/ui_mode.gni")
 import("//build/config/compiler/compiler.gni")
+import("//build/config/features.gni")
 import("//build/config/nacl/config.gni")
 import("//testing/libfuzzer/fuzzer_test.gni")
 import("//testing/test.gni")
@@ -144,6 +144,8 @@ template("core_impl_source_set") {
       sources += [
         "broker_castanets.cc",
         "broker_castanets.h",
+        "castanets_fence.cc",
+        "castanets_fence.h",
       ]
     }
 
@@ -156,7 +158,7 @@ template("core_impl_source_set") {
 
     deps = []
     if (enable_castanets) {
-      deps += ["//mojo/public/cpp/platform:platform"]
+      deps += [ "//mojo/public/cpp/platform:platform" ]
     }
     if (is_android) {
       deps += [ "//third_party/ashmem" ]

--- a/mojo/core/broker_castanets.cc
+++ b/mojo/core/broker_castanets.cc
@@ -12,6 +12,7 @@
 #include "base/memory/castanets_memory_mapping.h"
 #include "base/memory/platform_shared_memory_region.h"
 #include "base/memory/shared_memory_helper.h"
+#include "base/memory/shared_memory_locker.h"
 #include "base/memory/shared_memory_tracker.h"
 #include "base/threading/thread_task_runner_handle.h"
 #include "build/build_config.h"
@@ -229,6 +230,7 @@ void BrokerCastanets::OnBufferSync(uint64_t guid_high, uint64_t guid_low,
   CHECK(tcp_connection_);
   base::UnguessableToken guid =
       base::UnguessableToken::Deserialize(guid_high, guid_low);
+  base::AutoGuidLock guid_lock(guid);
   VLOG(2) << "Recv sync" << guid << " offset: " << offset
           << ", sync_size: " << sync_bytes
           << ", buffer_size: " << buffer_bytes;

--- a/mojo/core/broker_castanets.cc
+++ b/mojo/core/broker_castanets.cc
@@ -8,6 +8,7 @@
 #include <sys/mman.h>
 
 #include "base/bind.h"
+#include "base/lazy_instance.h"
 #include "base/logging.h"
 #include "base/memory/castanets_memory_mapping.h"
 #include "base/memory/platform_shared_memory_region.h"
@@ -16,9 +17,12 @@
 #include "base/memory/shared_memory_tracker.h"
 #include "base/threading/thread_task_runner_handle.h"
 #include "build/build_config.h"
+#include "crypto/random.h"
 #include "mojo/core/broker_messages.h"
+#include "mojo/core/castanets_fence.h"
 #include "mojo/core/channel.h"
 #include "mojo/core/connection_params.h"
+#include "mojo/core/node_channel.h"
 #include "mojo/core/platform_handle_utils.h"
 #include "mojo/public/cpp/platform/socket_utils_posix.h"
 #include "mojo/public/cpp/platform/tcp_platform_handle_utils.h"
@@ -27,6 +31,42 @@ namespace mojo {
 namespace core {
 
 namespace {
+
+constexpr size_t kRandomIdCacheSize = 256;
+
+// This class is cloned form RandomNameGenerator in node.cc.
+// Random fence id generator which maintains a cache of random bytes to draw
+// from. This amortizes the cost of random id generation on platforms where
+// RandBytes may have significant per-call overhead.
+
+class RandomIdGenerator {
+ public:
+  RandomIdGenerator() = default;
+  ~RandomIdGenerator() = default;
+
+  FenceId GenerateRandomId() {
+    base::AutoLock lock(lock_);
+    if (cache_index_ == kRandomIdCacheSize) {
+      crypto::RandBytes(cache_, sizeof(FenceId) * kRandomIdCacheSize);
+      cache_index_ = 0;
+    }
+    return cache_[cache_index_++];
+  }
+
+ private:
+  base::Lock lock_;
+  FenceId cache_[kRandomIdCacheSize];
+  size_t cache_index_ = kRandomIdCacheSize;
+
+  DISALLOW_COPY_AND_ASSIGN(RandomIdGenerator);
+};
+
+base::LazyInstance<RandomIdGenerator>::Leaky g_id_generator =
+    LAZY_INSTANCE_INITIALIZER;
+
+FenceId GenerateRandomFenceId() {
+  return g_id_generator.Get().GenerateRandomId();
+}
 
 Channel::MessagePtr WaitForBrokerMessage(
     int socket_fd,
@@ -80,9 +120,11 @@ Channel::MessagePtr WaitForBrokerMessage(
 }  // namespace
 
 BrokerCastanets::BrokerCastanets(PlatformHandle handle,
-                                 scoped_refptr<base::TaskRunner> io_task_runner)
+                                 scoped_refptr<base::TaskRunner> io_task_runner,
+                                 CastanetsFenceManager* fence_manager)
     : host_(false),
-      sync_channel_(std::move(handle)) {
+      sync_channel_(std::move(handle)),
+      fence_queue_(std::make_unique<CastanetsFenceQueue>(fence_manager)) {
   CHECK(sync_channel_.is_valid());
 
   int fd = sync_channel_.GetFD().get();
@@ -127,11 +169,14 @@ void BrokerCastanets::StartChannelOnIOThread() {
   channel_->Start();
 }
 
-BrokerCastanets::BrokerCastanets(base::ProcessHandle client_process,
-                                 ConnectionParams connection_params,
-                                 const ProcessErrorCallback& process_error_callback)
+BrokerCastanets::BrokerCastanets(
+    base::ProcessHandle client_process,
+    ConnectionParams connection_params,
+    const ProcessErrorCallback& process_error_callback,
+    CastanetsFenceManager* fence_manager)
     : process_error_callback_(process_error_callback),
-      host_(true)
+      host_(true),
+      fence_queue_(std::make_unique<CastanetsFenceQueue>(fence_manager))
 #if defined(OS_WIN)
       ,
       client_process_(ScopedProcessHandle::CloneFrom(client_process))
@@ -154,12 +199,14 @@ BrokerCastanets::~BrokerCastanets() {
 }
 
 void BrokerCastanets::SendSyncEvent(
-    scoped_refptr<base::CastanetsMemoryMapping> mapping_info, size_t offset,
-    size_t sync_size) {
+    scoped_refptr<base::CastanetsMemoryMapping> mapping_info,
+    size_t offset,
+    size_t sync_size,
+    bool write_lock) {
   CHECK(tcp_connection_);
   SyncSharedBufferImpl(mapping_info->guid(),
-                       static_cast<uint8_t *>(mapping_info->GetMemory()),
-                       offset, sync_size, mapping_info->mapped_size());
+                       static_cast<uint8_t*>(mapping_info->GetMemory()), offset,
+                       sync_size, mapping_info->mapped_size(), write_lock);
 }
 
 bool BrokerCastanets::SyncSharedBuffer(
@@ -193,46 +240,59 @@ bool BrokerCastanets::SyncSharedBuffer(
 }
 
 void BrokerCastanets::SyncSharedBufferImpl(const base::UnguessableToken& guid,
-                                           uint8_t* memory, size_t offset,
-                                           size_t sync_size, size_t mapped_size) {
-
+                                           uint8_t* memory,
+                                           size_t offset,
+                                           size_t sync_size,
+                                           size_t mapped_size,
+                                           bool write_lock) {
   CHECK_GE(mapped_size, offset + sync_size);
   BufferSyncData* buffer_sync = nullptr;
   void* extra_data = nullptr;
   Channel::MessagePtr out_message =
       CreateBrokerMessage(BrokerMessageType::BUFFER_SYNC, 0, sync_size,
                           &buffer_sync, &extra_data);
+  FenceId fence_id = GenerateRandomFenceId();
   buffer_sync->guid_high = guid.GetHighForSerialization();
   buffer_sync->guid_low = guid.GetLowForSerialization();
-
+  buffer_sync->fence_id = fence_id;
   buffer_sync->offset = offset;
   buffer_sync->sync_bytes = sync_size;
   buffer_sync->buffer_bytes = mapped_size;
   memcpy(extra_data, memory + offset, sync_size);
+
+  base::AutoLock lock(sync_lock_);
+
   VLOG(2) << "Send Sync" << guid << " offset: " << offset
           << ", sync_size: " << sync_size
-          << ", buffer_size: " << buffer_sync->buffer_bytes;
+          << ", buffer_size: " << buffer_sync->buffer_bytes
+          << ", fence_id: " << fence_id;
   channel_->Write(std::move(out_message));
-
+  node_channel_->AddSyncFence(guid, fence_id, write_lock);
 }
 
-void BrokerCastanets::OnBufferSync(uint64_t guid_high, uint64_t guid_low,
-                                   uint32_t offset, uint32_t sync_bytes,
-                                   uint32_t buffer_bytes, const void* data) {
+void BrokerCastanets::OnBufferSync(uint64_t guid_high,
+                                   uint64_t guid_low,
+                                   uint32_t fence_id,
+                                   uint32_t offset,
+                                   uint32_t sync_bytes,
+                                   uint32_t buffer_bytes,
+                                   const void* data) {
   CHECK(tcp_connection_);
   base::UnguessableToken guid =
       base::UnguessableToken::Deserialize(guid_high, guid_low);
   base::AutoGuidLock guid_lock(guid);
-  VLOG(2) << "Recv sync" << guid << " offset: " << offset
-          << ", sync_size: " << sync_bytes
-          << ", buffer_size: " << buffer_bytes;
 
+  VLOG(2) << "Recv sync" << guid << " offset: " << offset
+          << ", sync_size: " << sync_bytes << ", buffer_size: " << buffer_bytes
+          << ", fence_id: " << fence_id;
   scoped_refptr<base::CastanetsMemoryMapping> mapping =
       base::SharedMemoryTracker::GetInstance()->FindMappedMemory(guid);
   if (mapping) {
     CHECK_GE(mapping->mapped_size(), offset + sync_bytes);
     memcpy(static_cast<uint8_t *>(mapping->GetMemory()) + offset, data,
            sync_bytes);
+
+    fence_queue_->RemoveFence(guid, fence_id);
     return;
   }
 
@@ -247,6 +307,13 @@ void BrokerCastanets::OnBufferSync(uint64_t guid_high, uint64_t guid_low,
   uint8_t* ptr = static_cast<uint8_t*>(memory);
   memcpy(ptr + offset, data, sync_bytes);
   munmap(ptr, sync_bytes + offset);
+
+  fence_queue_->RemoveFence(guid, fence_id);
+}
+
+void BrokerCastanets::AddSyncFence(const base::UnguessableToken& guid,
+                                   uint32_t fence_id) {
+  fence_queue_->AddFence(guid, fence_id);
 }
 
 PlatformChannelEndpoint BrokerCastanets::GetInviterEndpoint() {
@@ -444,8 +511,9 @@ void BrokerCastanets::OnChannelMessage(const void* payload,
           reinterpret_cast<const BufferSyncData*>(header + 1);
       if (payload_size == sizeof(BrokerMessageHeader) +
           sizeof(BufferSyncData) + sync->sync_bytes)
-        OnBufferSync(sync->guid_high, sync->guid_low, sync->offset,
-            sync->sync_bytes, sync->buffer_bytes, sync + 1);
+        OnBufferSync(sync->guid_high, sync->guid_low, sync->fence_id,
+                     sync->offset, sync->sync_bytes, sync->buffer_bytes,
+                     sync + 1);
       else
         LOG(WARNING) << "Wrong size for sync data";
       break;

--- a/mojo/core/broker_castanets.cc
+++ b/mojo/core/broker_castanets.cc
@@ -84,7 +84,6 @@ BrokerCastanets::BrokerCastanets(PlatformHandle handle,
     : host_(false),
       sync_channel_(std::move(handle)) {
   CHECK(sync_channel_.is_valid());
-  io_thread_checker_.DetachFromThread();
 
   int fd = sync_channel_.GetFD().get();
   // Mark the channel as blocking.
@@ -120,7 +119,6 @@ BrokerCastanets::BrokerCastanets(PlatformHandle handle,
 }
 
 void BrokerCastanets::StartChannelOnIOThread() {
-  CHECK(io_thread_checker_.CalledOnValidThread());
   channel_ = Channel::Create(
       this,
       ConnectionParams(PlatformChannelEndpoint(
@@ -141,7 +139,6 @@ BrokerCastanets::BrokerCastanets(base::ProcessHandle client_process,
 {
   CHECK(connection_params.endpoint().is_valid() ||
         connection_params.server_endpoint().is_valid());
-  CHECK(io_thread_checker_.CalledOnValidThread());
 
   sync_channel_ = PlatformHandle(base::ScopedFD(
       connection_params.server_endpoint().platform_handle().GetFD().get()));
@@ -198,9 +195,6 @@ bool BrokerCastanets::SyncSharedBuffer(
 void BrokerCastanets::SyncSharedBufferImpl(const base::UnguessableToken& guid,
                                            uint8_t* memory, size_t offset,
                                            size_t sync_size, size_t mapped_size) {
-  bool in_io_thread = io_thread_checker_.CalledOnValidThread(); // workaround
-  if (!in_io_thread)
-    BeginSync(guid);
 
   CHECK_GE(mapped_size, offset + sync_size);
   BufferSyncData* buffer_sync = nullptr;
@@ -220,8 +214,6 @@ void BrokerCastanets::SyncSharedBufferImpl(const base::UnguessableToken& guid,
           << ", buffer_size: " << buffer_sync->buffer_bytes;
   channel_->Write(std::move(out_message));
 
-  if (!in_io_thread)
-    WaitSync(guid);
 }
 
 void BrokerCastanets::OnBufferSync(uint64_t guid_high, uint64_t guid_low,
@@ -241,7 +233,6 @@ void BrokerCastanets::OnBufferSync(uint64_t guid_high, uint64_t guid_low,
     CHECK_GE(mapping->mapped_size(), offset + sync_bytes);
     memcpy(static_cast<uint8_t *>(mapping->GetMemory()) + offset, data,
            sync_bytes);
-    SendSyncAck(guid_high, guid_low);
     return;
   }
 
@@ -256,16 +247,6 @@ void BrokerCastanets::OnBufferSync(uint64_t guid_high, uint64_t guid_low,
   uint8_t* ptr = static_cast<uint8_t*>(memory);
   memcpy(ptr + offset, data, sync_bytes);
   munmap(ptr, sync_bytes + offset);
-  SendSyncAck(guid_high, guid_low);
-}
-
-void BrokerCastanets::SendSyncAck(uint64_t guid_high, uint64_t guid_low) {
-  BufferSyncAckData* sync_ack;
-  Channel::MessagePtr out_message = CreateBrokerMessage(
-      BrokerMessageType::BUFFER_SYNC_ACK, 0, 0, &sync_ack);
-  sync_ack->guid_high = guid_high;
-  sync_ack->guid_low = guid_low;
-  channel_->Write(std::move(out_message));
 }
 
 PlatformChannelEndpoint BrokerCastanets::GetInviterEndpoint() {
@@ -469,52 +450,9 @@ void BrokerCastanets::OnChannelMessage(const void* payload,
         LOG(WARNING) << "Wrong size for sync data";
       break;
     }
-    case BrokerMessageType::BUFFER_SYNC_ACK:
-      if (payload_size ==
-          sizeof(BrokerMessageHeader) + sizeof(BufferSyncAckData)) {
-        const BufferSyncAckData* sync_ack =
-            reinterpret_cast<const BufferSyncAckData*>(header + 1);
-        base::UnguessableToken guid =
-            base::UnguessableToken::Deserialize(sync_ack->guid_high,
-                                                sync_ack->guid_low);
-        EndSync(guid);
-      }
-      break;
-
     default:
       DLOG(ERROR) << "Unexpected broker message type: " << header->type;
       break;
-  }
-}
-
-void BrokerCastanets::BeginSync(const base::UnguessableToken& guid) {
-  base::AutoLock lock(sync_lock_);
-  CHECK(sync_waits_.find(guid) == sync_waits_.end());
-  sync_waits_.emplace(std::piecewise_construct,
-                      std::make_tuple(guid), std::make_tuple());
-}
-
-void BrokerCastanets::EndSync(const base::UnguessableToken& guid) {
-  base::AutoLock lock(sync_lock_);
-  auto it = sync_waits_.find(guid);
-  if (it == sync_waits_.end())
-    return;
-  it->second.Signal();
-}
-
-void BrokerCastanets::WaitSync(const base::UnguessableToken& guid) {
-  SyncWaitMap::iterator it;
-  {
-    base::AutoLock lock(sync_lock_);
-    it = sync_waits_.find(guid);
-    if (it == sync_waits_.end())
-      return;
-  }
-  if (!it->second.IsSignaled())
-    it->second.Wait();
-  {
-    base::AutoLock lock(sync_lock_);
-    sync_waits_.erase(it);
   }
 }
 

--- a/mojo/core/broker_castanets.h
+++ b/mojo/core/broker_castanets.h
@@ -92,12 +92,6 @@ public:
 
   void OnBufferRequest(uint32_t num_bytes);
 
-  void BeginSync(const base::UnguessableToken& guid);
-  void EndSync(const base::UnguessableToken& guid);
-  void WaitSync(const base::UnguessableToken& guid);
-
-  void SendSyncAck(uint64_t guid_high, uint64_t guid_low);
-
   void SyncSharedBufferImpl(const base::UnguessableToken& guid,
                             uint8_t* memory, size_t offset,
                             size_t sync_size, size_t mapped_size);
@@ -112,16 +106,11 @@ public:
   // first message over |sync_channel_|.
   PlatformChannelEndpoint inviter_endpoint_;
 
-  base::Lock sync_lock_;
-  typedef std::map<base::UnguessableToken, base::WaitableEvent> SyncWaitMap;
-  SyncWaitMap sync_waits_;
-
 #if defined(OS_WIN)
   ScopedProcessHandle client_process_;
 #endif
 
   scoped_refptr<Channel> channel_;
-  base::ThreadCheckerImpl io_thread_checker_;
   DISALLOW_COPY_AND_ASSIGN(BrokerCastanets);
 };
 

--- a/mojo/core/broker_messages.h
+++ b/mojo/core/broker_messages.h
@@ -18,7 +18,6 @@ enum BrokerMessageType : uint32_t {
   BUFFER_REQUEST,
   BUFFER_RESPONSE,
   BUFFER_SYNC,
-  BUFFER_SYNC_ACK,
 };
 
 struct BrokerMessageHeader {
@@ -45,11 +44,6 @@ struct BufferSyncData {
   uint32_t sync_bytes;
   uint32_t buffer_bytes;
   uint32_t padding;
-};
-
-struct BufferSyncAckData {
-  uint64_t guid_high;
-  uint64_t guid_low;
 };
 
 #if defined(OS_WIN) || defined(CASTANETS)

--- a/mojo/core/broker_messages.h
+++ b/mojo/core/broker_messages.h
@@ -40,10 +40,10 @@ struct BufferResponseData {
 struct BufferSyncData {
   uint64_t guid_high;
   uint64_t guid_low;
+  uint32_t fence_id;
   uint32_t offset;
   uint32_t sync_bytes;
   uint32_t buffer_bytes;
-  uint32_t padding;
 };
 
 #if defined(OS_WIN) || defined(CASTANETS)

--- a/mojo/core/castanets_fence.cc
+++ b/mojo/core/castanets_fence.cc
@@ -1,0 +1,104 @@
+// Copyright 2019 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "mojo/core/castanets_fence.h"
+
+namespace mojo {
+namespace core {
+
+scoped_refptr<CastanetsFence> CastanetsFence::Create(
+    const base::UnguessableToken& guid,
+    FenceId fence_id) {
+  return new CastanetsFence(guid, fence_id);
+}
+
+void CastanetsFence::Wait() {
+  if (!event_.IsSignaled())
+    event_.Wait();
+}
+
+CastanetsFenceManager::CastanetsFenceManager() = default;
+
+CastanetsFenceManager::~CastanetsFenceManager() {
+  CHECK(fence_map_.empty());
+}
+
+void CastanetsFenceManager::FenceAdded(
+    scoped_refptr<CastanetsFence> added_fence) {
+  base::AutoLock lock(map_lock_);
+  auto it = fence_map_.find(added_fence->guid_);
+  if (it == fence_map_.end()) {
+    fence_map_.emplace(
+        std::piecewise_construct, std::forward_as_tuple(added_fence->guid_),
+        std::forward_as_tuple(
+            std::initializer_list<scoped_refptr<CastanetsFence>>{added_fence}));
+  } else {
+    it->second.push(added_fence);
+  }
+}
+
+void CastanetsFenceManager::FenceRemoved(
+    scoped_refptr<CastanetsFence> removed_fence) {
+  base::AutoLock lock(map_lock_);
+  auto it = fence_map_.find(removed_fence->guid_);
+  CHECK(it != fence_map_.end());
+  FenceQueue& fence_queue = it->second;
+  fence_queue.pop();
+  if (fence_queue.empty())
+    fence_map_.erase(it);
+}
+
+base::Optional<FenceQueue> CastanetsFenceManager::GetFences(
+    const base::UnguessableToken& guid) {
+  base::AutoLock lock(map_lock_);
+  auto it = fence_map_.find(guid);
+  if (it != fence_map_.end()) {
+    FenceQueue fence_queue(it->second);
+    return std::move(fence_queue);
+  }
+  return base::nullopt;
+}
+
+CastanetsFenceQueue::CastanetsFenceQueue(CastanetsFenceManager* manager)
+    : manager_(manager) {
+  CHECK(manager_);
+}
+
+CastanetsFenceQueue::~CastanetsFenceQueue() {
+  CHECK(fence_queue_.empty());
+  CHECK(complete_queue_.empty());
+}
+
+void CastanetsFenceQueue::AddFence(const base::UnguessableToken& guid,
+                                   FenceId fence_id) {
+  if (complete_queue_.empty()) {
+    scoped_refptr<CastanetsFence> new_fence =
+        CastanetsFence::Create(guid, fence_id);
+    fence_queue_.push(new_fence);
+    manager_->FenceAdded(new_fence);
+    return;
+  }
+
+  FenceId complete_id = complete_queue_.front();
+  CHECK(fence_id == complete_id);
+  complete_queue_.pop();
+}
+
+void CastanetsFenceQueue::RemoveFence(const base::UnguessableToken& guid,
+                                      FenceId fence_id) {
+  if (fence_queue_.empty()) {
+    complete_queue_.push(fence_id);
+    return;
+  }
+
+  scoped_refptr<CastanetsFence> fence = fence_queue_.front();
+  CHECK(guid == fence->guid_);
+  CHECK(fence_id == fence->fence_id_);
+  fence->event_.Signal();
+  fence_queue_.pop();
+  manager_->FenceRemoved(fence);
+}
+
+}  // namespace core
+}  // namespace mojo

--- a/mojo/core/castanets_fence.h
+++ b/mojo/core/castanets_fence.h
@@ -1,0 +1,97 @@
+// Copyright 2019 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef MOJO_CORE_CASTANETS_FENCE_H_
+#define MOJO_CORE_CASTANETS_FENCE_H_
+
+#include <map>
+#include <set>
+
+#include "base/containers/queue.h"
+#include "base/memory/ref_counted.h"
+#include "base/optional.h"
+#include "base/synchronization/lock.h"
+#include "base/synchronization/waitable_event.h"
+#include "base/unguessable_token.h"
+
+namespace mojo {
+namespace core {
+
+typedef uint32_t FenceId;
+
+// Each BUFFER_SYNC message is paired with one Fence
+class CastanetsFence : public base::RefCountedThreadSafe<CastanetsFence> {
+ public:
+  static scoped_refptr<CastanetsFence> Create(
+      const base::UnguessableToken& guid,
+      FenceId fence_id);
+
+  void Wait();
+
+ private:
+  friend class base::RefCountedThreadSafe<CastanetsFence>;
+  friend class CastanetsFenceManager;
+  friend class CastanetsFenceQueue;
+
+  CastanetsFence(const base::UnguessableToken& guid, FenceId fence_id)
+      : guid_(guid),
+        fence_id_(fence_id),
+        event_(base::WaitableEvent::ResetPolicy::MANUAL,
+               base::WaitableEvent::InitialState::NOT_SIGNALED) {}
+
+  ~CastanetsFence() = default;
+
+  base::UnguessableToken guid_;
+  FenceId fence_id_;
+  base::WaitableEvent event_;
+
+  DISALLOW_COPY_AND_ASSIGN(CastanetsFence);
+};
+
+// A FenceQueue notify the FenceManager whenever a Fence is pushed or poped.
+// The manager manages FenceQueues based on GUID.
+typedef std::queue<scoped_refptr<CastanetsFence>> FenceQueue;
+
+class CastanetsFenceManager {
+ public:
+  CastanetsFenceManager();
+  ~CastanetsFenceManager();
+
+  void FenceAdded(scoped_refptr<CastanetsFence> added_fence);
+  void FenceRemoved(scoped_refptr<CastanetsFence> removed_fence);
+
+  base::Optional<FenceQueue> GetFences(const base::UnguessableToken& guid);
+
+ private:
+  base::Lock map_lock_;
+  std::map<base::UnguessableToken, FenceQueue> fence_map_;
+
+  DISALLOW_COPY_AND_ASSIGN(CastanetsFenceManager);
+};
+
+// Each node has one FenceQueue. When you receive a BUFFER_SYNC message,
+// create a Fence and push it. When you're done syncing, pop the Fence
+// to remove it.
+class CastanetsFenceQueue {
+ public:
+  CastanetsFenceQueue() = delete;
+  CastanetsFenceQueue(CastanetsFenceManager* manager);
+  ~CastanetsFenceQueue();
+
+  void AddFence(const base::UnguessableToken& guid, FenceId fence_id);
+  void RemoveFence(const base::UnguessableToken& guid, FenceId fence_id);
+
+ private:
+  FenceQueue fence_queue_;
+  base::queue<FenceId> complete_queue_;
+
+  CastanetsFenceManager* manager_;
+
+  DISALLOW_COPY_AND_ASSIGN(CastanetsFenceQueue);
+};
+
+}  // namespace core
+}  // namespace mojo
+
+#endif  // MOJO_CORE_CASTANETS_FENCE_H_

--- a/mojo/core/channel.h
+++ b/mojo/core/channel.h
@@ -309,6 +309,10 @@ class MOJO_SYSTEM_IMPL_EXPORT Channel
   // of closing it.
   virtual void LeakHandle() = 0;
 
+#if defined(CASTANETS)
+  virtual void WriteNoLockImmediately(MessagePtr message) {}
+#endif
+
  protected:
   // Constructor for implementations to call. |delegate| and |handle_policy|
   // should be passed from Create(). |buffer_policy| should be specified by

--- a/mojo/core/channel_posix.cc
+++ b/mojo/core/channel_posix.cc
@@ -152,6 +152,29 @@ class ChannelPosix : public Channel,
     }
   }
 
+#if defined(CASTANETS)
+  void WriteNoLockImmediately(MessagePtr message) override {
+    bool write_error = false;
+
+    if (reject_writes_)
+      return;
+    if (outgoing_messages_.empty()) {
+      if (!WriteNoLock(MessageView(std::move(message), 0)))
+        reject_writes_ = write_error = true;
+    } else {
+      outgoing_messages_.emplace_back(std::move(message), 0);
+    }
+
+    if (write_error) {
+      // Invoke OnWriteError() asynchronously on the IO thread, in case Write()
+      // was called by the delegate, in which case we should not re-enter it.
+      io_task_runner_->PostTask(
+          FROM_HERE, base::BindOnce(&ChannelPosix::OnWriteError, this,
+                                    Error::kDisconnected));
+    }
+  }
+#endif
+
   void LeakHandle() override {
     DCHECK(io_task_runner_->RunsTasksInCurrentSequence());
     leak_handle_ = true;

--- a/mojo/core/core.cc
+++ b/mojo/core/core.cc
@@ -1170,6 +1170,14 @@ MojoResult Core::SyncPlatformSharedMemoryRegion(
 
   return MOJO_RESULT_OK;
 }
+MojoResult Core::WaitSyncPlatformSharedMemoryRegion(
+    const MojoSharedBufferGuid* guid) {
+  const base::UnguessableToken& token =
+      base::UnguessableToken::Deserialize(guid->high, guid->low);
+  GetNodeController()->WaitSyncSharedBuffer(token);
+
+  return MOJO_RESULT_OK;
+}
 #endif
 
 MojoResult Core::CreateInvitation(const MojoCreateInvitationOptions* options,

--- a/mojo/core/core.h
+++ b/mojo/core/core.h
@@ -290,6 +290,9 @@ class MOJO_SYSTEM_IMPL_EXPORT Core {
       const MojoSharedBufferGuid* guid,
       size_t offset,
       size_t sync_size);
+
+  MojoResult WaitSyncPlatformSharedMemoryRegion(
+      const MojoSharedBufferGuid* guid);
 #endif
   // Invitation API.
   MojoResult CreateInvitation(const MojoCreateInvitationOptions* options,

--- a/mojo/core/data_pipe_consumer_dispatcher.cc
+++ b/mojo/core/data_pipe_consumer_dispatcher.cc
@@ -105,6 +105,9 @@ MojoResult DataPipeConsumerDispatcher::ReadData(
     const MojoReadDataOptions& options,
     void* elements,
     uint32_t* num_bytes) {
+#if defined(CASTANETS)
+  node_controller_->WaitSyncSharedBuffer(ring_buffer_mapping_.guid());
+#endif
   base::AutoLock lock(lock_);
 
   if (!shared_ring_buffer_.IsValid() || in_transit_)
@@ -198,6 +201,9 @@ MojoResult DataPipeConsumerDispatcher::ReadData(
 MojoResult DataPipeConsumerDispatcher::BeginReadData(
     const void** buffer,
     uint32_t* buffer_num_bytes) {
+#if defined(CASTANETS)
+  node_controller_->WaitSyncSharedBuffer(ring_buffer_mapping_.guid());
+#endif
   base::AutoLock lock(lock_);
   if (!shared_ring_buffer_.IsValid() || in_transit_)
     return MOJO_RESULT_INVALID_ARGUMENT;

--- a/mojo/core/entrypoints.cc
+++ b/mojo/core/entrypoints.cc
@@ -292,6 +292,11 @@ MojoResult MojoSyncPlatformSharedMemoryRegionImpl(
   return g_core->SyncPlatformSharedMemoryRegion(
       guid, offset, sync_size);
 }
+
+MojoResult MojoWaitSyncPlatformSharedMemoryRegionImpl(
+    const MojoSharedBufferGuid* guid) {
+  return g_core->WaitSyncPlatformSharedMemoryRegion(guid);
+}
 #endif
 
 MojoResult MojoCreateInvitationImpl(const MojoCreateInvitationOptions* options,
@@ -406,6 +411,7 @@ MojoSystemThunks g_thunks = {sizeof(MojoSystemThunks),
                              MojoWrapPlatformSharedMemoryRegionImpl,
                              MojoUnwrapPlatformSharedMemoryRegionImpl,
                              MojoSyncPlatformSharedMemoryRegionImpl,
+                             MojoWaitSyncPlatformSharedMemoryRegionImpl,
                              MojoCreateInvitationImpl,
                              MojoAttachMessagePipeToInvitationImpl,
                              MojoExtractMessagePipeFromInvitationImpl,

--- a/mojo/core/node_channel.cc
+++ b/mojo/core/node_channel.cc
@@ -43,6 +43,9 @@ enum class MessageType : uint32_t {
 #endif
   ACCEPT_PEER,
   BIND_BROKER_HOST,
+#if defined(CASTANETS)
+  ADD_SYNC_FENCE,
+#endif
 };
 
 struct Header {
@@ -77,6 +80,14 @@ struct AddBrokerClientData {
   uint32_t padding;
 #endif
 };
+
+#if defined(CASTANETS)
+struct AddSyncFenceData {
+  base::UnguessableToken guid;
+  uint32_t fence_id;
+  uint32_t padding;
+};
+#endif
 
 #if !defined(OS_WIN)
 static_assert(sizeof(base::ProcessHandle) == sizeof(uint32_t),
@@ -727,6 +738,18 @@ void NodeChannel::OnChannelMessage(const void* payload,
       }
       break;
 
+#if defined(CASTANETS)
+    case MessageType::ADD_SYNC_FENCE: {
+      const AddSyncFenceData* data;
+      if (GetMessagePayload(payload, payload_size, &data)) {
+        delegate_->OnAddSyncFence(remote_process_handle_.get(), data->guid,
+                                  data->fence_id);
+        return;
+      }
+      break;
+    }
+#endif
+
     default:
       // Ignore unrecognized message types, allowing for future extensibility.
       return;
@@ -770,6 +793,29 @@ void NodeChannel::WriteChannelMessage(Channel::MessagePtr message) {
   else
     channel_->Write(std::move(message));
 }
+
+#if defined(CASTANETS)
+void NodeChannel::AddSyncFence(base::UnguessableToken guid,
+                               uint32_t fence_id,
+                               bool write_lock) {
+  AddSyncFenceData* data;
+  Channel::MessagePtr message = CreateMessage(
+      MessageType::ADD_SYNC_FENCE, sizeof(AddSyncFenceData), 0, &data);
+  data->guid = guid;
+  data->fence_id = fence_id;
+  data->padding = 0;
+  if (write_lock)
+    WriteChannelMessage(std::move(message));
+  else {
+    CHECK(message->data_num_bytes() < GetConfiguration().max_message_num_bytes);
+    if (!channel_) {
+      DLOG(ERROR) << "Dropping message on closed channel.";
+    } else {
+      channel_->WriteNoLockImmediately(std::move(message));
+    }
+  }
+}
+#endif
 
 }  // namespace core
 }  // namespace mojo

--- a/mojo/core/node_channel.h
+++ b/mojo/core/node_channel.h
@@ -22,6 +22,10 @@
 #include "mojo/core/ports/name.h"
 #include "mojo/core/scoped_process_handle.h"
 
+#if defined(CASTANETS)
+#include "base/unguessable_token.h"
+#endif
+
 namespace mojo {
 namespace core {
 
@@ -67,6 +71,11 @@ class NodeChannel : public base::RefCountedThreadSafe<NodeChannel>,
     virtual void OnEventMessageFromRelay(const ports::NodeName& from_node,
                                          const ports::NodeName& source_node,
                                          Channel::MessagePtr message) = 0;
+#endif
+#if defined(CASTANETS)
+    virtual void OnAddSyncFence(base::ProcessHandle process_handle,
+                                base::UnguessableToken guid,
+                                uint32_t fence_id) = 0;
 #endif
     virtual void OnAcceptPeer(const ports::NodeName& from_node,
                               const ports::NodeName& token,
@@ -152,6 +161,11 @@ class NodeChannel : public base::RefCountedThreadSafe<NodeChannel>,
   // provided as additional message metadata from the (trusted) relay node.
   void EventMessageFromRelay(const ports::NodeName& source,
                              Channel::MessagePtr message);
+#endif
+#if defined(CASTANETS)
+  void AddSyncFence(base::UnguessableToken guid,
+                    uint32_t fence_id,
+                    bool write_lock);
 #endif
 
  private:

--- a/mojo/core/node_controller.cc
+++ b/mojo/core/node_controller.cc
@@ -39,6 +39,7 @@
 #include "base/memory/castanets_memory_mapping.h"
 #include "base/memory/castanets_memory_syncer.h"
 #include "base/memory/shared_memory_tracker.h"
+#include "base/threading/thread_restrictions.h"
 #include "mojo/core/broker_castanets.h"
 #include "mojo/core/castanets_fence.h"
 #include "mojo/public/cpp/platform/tcp_platform_handle_utils.h"
@@ -426,6 +427,7 @@ void NodeController::WaitSyncSharedBuffer(const base::UnguessableToken& guid) {
   base::Optional<FenceQueue> fence_queue = fence_manager_->GetFences(guid);
   if (fence_queue) {
     while (!fence_queue->empty()) {
+      base::ScopedAllowBaseSyncPrimitives allow_base_sync_primitives;
       fence_queue->front()->Wait();
       fence_queue->pop();
     }

--- a/mojo/core/node_controller.cc
+++ b/mojo/core/node_controller.cc
@@ -40,6 +40,7 @@
 #include "base/memory/castanets_memory_syncer.h"
 #include "base/memory/shared_memory_tracker.h"
 #include "mojo/core/broker_castanets.h"
+#include "mojo/core/castanets_fence.h"
 #include "mojo/public/cpp/platform/tcp_platform_handle_utils.h"
 #endif
 
@@ -159,6 +160,9 @@ NodeController::NodeController(Core* core)
       name_(GetRandomNodeName()),
       node_(new ports::Node(name_, this)) {
   DVLOG(1) << "Initializing node " << name_;
+#if defined(CASTANETS)
+  fence_manager_ = std::make_unique<CastanetsFenceManager>();
+#endif
 }
 
 void NodeController::SetIOTaskRunner(
@@ -209,8 +213,9 @@ void NodeController::AcceptBrokerClientInvitation(
     DCHECK(connection_params.endpoint().is_valid());
     base::ElapsedTimer timer;
 #if defined(CASTANETS)
-  broker_ = std::make_unique<BrokerCastanets>(
-      connection_params.TakeEndpoint().TakePlatformHandle(), io_task_runner_);
+    broker_ = std::make_unique<BrokerCastanets>(
+        connection_params.TakeEndpoint().TakePlatformHandle(), io_task_runner_,
+        fence_manager_.get());
 #else
     broker_ = std::make_unique<Broker>(
         connection_params.TakeEndpoint().TakePlatformHandle(),
@@ -403,6 +408,19 @@ NodeController::GetSyncDelegate(base::ProcessHandle process) {
   CHECK_GE(process, 0);
   return nullptr;
 }
+void NodeController::OnAddSyncFence(base::ProcessHandle process_handle,
+                                    base::UnguessableToken guid,
+                                    uint32_t fence_id) {
+  if (broker_) {
+    broker_->AddSyncFence(guid, fence_id);
+    return;
+  }
+
+  base::AutoLock broker_lock(broker_hosts_lock_);
+  auto host = broker_hosts_.find(process_handle);
+  CHECK(host != broker_hosts_.end());
+  host->second->AddSyncFence(guid, fence_id);
+}
 #endif
 
 void NodeController::RequestShutdown(base::OnceClosure callback) {
@@ -481,9 +499,9 @@ void NodeController::SendBrokerClientInvitationOnIOThread(
         ConnectionParams(mojo::PlatformChannelServerEndpoint(
             mojo::PlatformHandle(CreateTCPServerHandle(port, &port))));
     std::unique_ptr<BrokerCastanets> broker_host =
-        std::make_unique<BrokerCastanets>(target_process.get(),
-                                          std::move(connection_params),
-                                          process_error_callback);
+        std::make_unique<BrokerCastanets>(
+            target_process.get(), std::move(connection_params),
+            process_error_callback, fence_manager_.get());
     channel_ok = broker_host->SendPortNumber(port);
     base::AutoLock lock(broker_hosts_lock_);
     broker_hosts_.emplace(target_process.get(), std::move(broker_host));
@@ -528,6 +546,14 @@ void NodeController::SendBrokerClientInvitationOnIOThread(
       NodeChannel::Create(this, std::move(node_connection_params),
                           Channel::HandlePolicy::kAcceptHandles,
                           io_task_runner_, process_error_callback);
+#if defined(CASTANETS)
+  {
+    base::AutoLock broker_lock(broker_hosts_lock_);
+    auto host = broker_hosts_.find(target_process.get());
+    if (host != broker_hosts_.end())
+      host->second->SetNodeChannel(channel);
+  }
+#endif
 
 #else   // !defined(OS_MACOSX) && !defined(OS_NACL) && !defined(OS_FUCHSIA)
   scoped_refptr<NodeChannel> channel = NodeChannel::Create(
@@ -587,6 +613,9 @@ void NodeController::AcceptBrokerClientInvitationOnIOThread(
       // signal for normal child process termination.
       bootstrap_inviter_channel_->LeakHandleOnShutdown();
     }
+#if defined(CASTANETS)
+    broker_->SetNodeChannel(bootstrap_inviter_channel_);
+#endif
   }
   bootstrap_inviter_channel_->Start();
   if (broker_host_handle)

--- a/mojo/core/node_controller.cc
+++ b/mojo/core/node_controller.cc
@@ -421,6 +421,16 @@ void NodeController::OnAddSyncFence(base::ProcessHandle process_handle,
   CHECK(host != broker_hosts_.end());
   host->second->AddSyncFence(guid, fence_id);
 }
+
+void NodeController::WaitSyncSharedBuffer(const base::UnguessableToken& guid) {
+  base::Optional<FenceQueue> fence_queue = fence_manager_->GetFences(guid);
+  if (fence_queue) {
+    while (!fence_queue->empty()) {
+      fence_queue->front()->Wait();
+      fence_queue->pop();
+    }
+  }
+}
 #endif
 
 void NodeController::RequestShutdown(base::OnceClosure callback) {

--- a/mojo/core/node_controller.h
+++ b/mojo/core/node_controller.h
@@ -124,6 +124,8 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
                         size_t offset,
                         size_t sync_size);
 
+  void WaitSyncSharedBuffer(const base::UnguessableToken& guid);
+
   base::SyncDelegate *GetSyncDelegate(base::ProcessHandle process);
 #endif
 

--- a/mojo/core/node_controller.h
+++ b/mojo/core/node_controller.h
@@ -43,6 +43,7 @@ namespace core {
 
 #if defined(CASTANETS)
 class BrokerCastanets;
+class CastanetsFenceManager;
 #endif
 
 class Broker;
@@ -249,6 +250,11 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
                                const ports::NodeName& source_node,
                                Channel::MessagePtr message) override;
 #endif
+#if defined(CASTANETS)
+  void OnAddSyncFence(base::ProcessHandle process_handle,
+                      base::UnguessableToken guid,
+                      uint32_t fence_id) override;
+#endif
   void OnAcceptPeer(const ports::NodeName& from_node,
                     const ports::NodeName& token,
                     const ports::NodeName& peer_name,
@@ -360,6 +366,8 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
   base::Lock broker_hosts_lock_;
   std::unordered_map<base::ProcessHandle, std::unique_ptr<BrokerCastanets>>
       broker_hosts_;
+
+  std::unique_ptr<CastanetsFenceManager> fence_manager_;
 #else
   std::unique_ptr<Broker> broker_;
 #endif

--- a/mojo/public/c/system/platform_handle.h
+++ b/mojo/public/c/system/platform_handle.h
@@ -333,6 +333,8 @@ MOJO_SYSTEM_EXPORT MojoResult MojoSyncPlatformSharedMemoryRegion(
     const struct MojoSharedBufferGuid* guid,
     size_t offset,
     size_t sync_size);
+MOJO_SYSTEM_EXPORT MojoResult
+MojoWaitSyncPlatformSharedMemoryRegion(const struct MojoSharedBufferGuid* guid);
 #endif
 
 #ifdef __cplusplus

--- a/mojo/public/c/system/thunks.cc
+++ b/mojo/public/c/system/thunks.cc
@@ -426,6 +426,11 @@ MojoResult MojoSyncPlatformSharedMemoryRegion(
   return INVOKE_THUNK(SyncPlatformSharedMemoryRegion,
                       guid, offset, sync_size);
 }
+
+MojoResult MojoWaitSyncPlatformSharedMemoryRegion(
+    const struct MojoSharedBufferGuid* guid) {
+  return INVOKE_THUNK(WaitSyncPlatformSharedMemoryRegion, guid);
+}
 #endif
 
 MojoResult MojoCreateInvitation(const MojoCreateInvitationOptions* options,

--- a/mojo/public/c/system/thunks.h
+++ b/mojo/public/c/system/thunks.h
@@ -190,6 +190,8 @@ struct MojoSystemThunks {
       const struct MojoSharedBufferGuid* guid,
       size_t offset,
       size_t sync_size);
+  MojoResult (*WaitSyncPlatformSharedMemoryRegion)(
+      const struct MojoSharedBufferGuid* guid);
 #endif
   // Invitation API.
   MojoResult (*CreateInvitation)(

--- a/mojo/public/cpp/system/platform_handle.cc
+++ b/mojo/public/cpp/system/platform_handle.cc
@@ -246,6 +246,14 @@ MojoResult SyncSharedMemoryHandle(const base::UnguessableToken& guid,
   return MojoSyncPlatformSharedMemoryRegion(
       &mojo_guid, offset, sync_size);
 }
+
+MojoResult WaitSyncSharedMemory(const base::UnguessableToken& guid) {
+  MojoSharedBufferGuid mojo_guid;
+  mojo_guid.high = guid.GetHighForSerialization();
+  mojo_guid.low = guid.GetLowForSerialization();
+
+  return MojoWaitSyncPlatformSharedMemoryRegion(&mojo_guid);
+}
 #endif
 
 ScopedSharedBufferHandle WrapReadOnlySharedMemoryRegion(

--- a/mojo/public/cpp/system/platform_handle.h
+++ b/mojo/public/cpp/system/platform_handle.h
@@ -104,6 +104,9 @@ MOJO_CPP_SYSTEM_EXPORT MojoResult
 SyncSharedMemoryHandle(const base::UnguessableToken& guid,
                        size_t offset,
                        size_t sync_size);
+
+MOJO_CPP_SYSTEM_EXPORT MojoResult
+WaitSyncSharedMemory(const base::UnguessableToken& guid);
 #endif
 
 // Helpers for wrapping and unwrapping new base shared memory API primitives.


### PR DESCRIPTION
Reference:

1. https://github.com/Samsung/Castanets/pull/282/commits/08fdaa7b12d347c4e6cab8e3ee1d704b6d887896
2. https://github.com/Samsung/Castanets/pull/282/commits/221cfe266df2e4de2ab553e76a881c8c10b6f133
3. https://github.com/Samsung/Castanets/pull/282/commits/de26b9ba7a907b32908e4c218f25332f0039b3f7
4. https://github.com/Samsung/Castanets/pull/282/commits/f5ad5ee41b751ac14601f1a54069acf6c91923ac
5. https://github.com/Samsung/Castanets/pull/282/commits/2eef176c2b8b604321a2c12566beedd48942a0ff
6. https://github.com/Samsung/Castanets/pull/282/commits/1e70559c482dff4a34a97314f0285e6a8e90c1b7
7. https://github.com/Samsung/Castanets/pull/282/commits/75c8526209d65f6d92cc01380ab88fcfa7b58651

Changes from https://github.com/Samsung/Castanets/pull/282/commits/9905ae6c109c8ec785887ad821106313defbd216 are applied in the commits of "Add SharedMemoryLocker & AutoGuidLock" and "Apply the fence to the sync message", as they were fixup of index increment.