### PR TITLE
Toggle android specific setting for better renderer performance

### DIFF
--- a/gpu/command_buffer/client/cmd_buffer_helper.h
+++ b/gpu/command_buffer/client/cmd_buffer_helper.h
@@ -26,7 +26,7 @@ namespace gpu {
 
 class Buffer;
 
-#if !defined(OS_ANDROID)
+#if !defined(OS_ANDROID) || defined(CASTANETS)
 #define CMD_HELPER_PERIODIC_FLUSH_CHECK
 const int kCommandsPerFlushCheck = 100;
 const int kPeriodicFlushDelayInMicroseconds =

--- a/third_party/blink/public/common/page/launching_process_state.h
+++ b/third_party/blink/public/common/page/launching_process_state.h
@@ -12,7 +12,7 @@ namespace blink {
 
 // This file is used to maintain a consistent initial set of state between the
 // RendererProcessHostImpl and the RendererSchedulerImpl.
-#if defined(OS_ANDROID)
+#if defined(OS_ANDROID) && !defined(CASTANETS)
 // This matches Android's ChildProcessConnection state before OnProcessLaunched.
 constexpr bool kLaunchingProcessIsBackgrounded = true;
 #else


### PR DESCRIPTION
[Performance] Toggle android specific setting for better renderer performance.

1. kLaunchingProcessIsBackgrounded is set by default which enables dom timer
throttling, which made SetInterval firing too slow on tizen-android.

2. Enable Periodic flush for android as well.

Signed-off-by: v-saha <v.saha@samsung.com>