### PR TITLE
Add support of run time flags for enable Castanets

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -2084,6 +2084,14 @@ jumbo_component("base") {
     sources += [ "time/time_android.cc" ]
   }
 
+  # Distributed chromium
+  if (enable_castanets) {
+    sources += [
+      "distributed_chromium_util.cc",
+      "distributed_chromium_util.h",
+    ]
+  }
+
   if (!use_glib) {
     sources -= [
       "message_loop/message_pump_glib.cc",

--- a/base/base_switches.cc
+++ b/base/base_switches.cc
@@ -151,10 +151,8 @@ const char kEnableThreadInstructionCount[] = "enable-thread-instruction-count";
 #endif
 
 #if defined(CASTANETS)
-const char kEnableForking[] = "enable-forking";
-
-// Specify distributed chrome server address.
-const char kServerAddress[] = "server-address";
+// Enable features for distributed chromium.
+const char kEnableCastanets[] = "enable-castanets";
 
 const char kTcpLaunchTimeout[] = "tcp-launch-timeout";
 

--- a/base/base_switches.h
+++ b/base/base_switches.h
@@ -57,8 +57,7 @@ extern const char kEnableThreadInstructionCount[];
 #endif
 
 #if defined(CASTANETS)
-extern const char kEnableForking[];
-extern const char kServerAddress[];
+extern const char kEnableCastanets[];
 extern const char kTcpLaunchTimeout[];
 extern const char kSecureConnection[];
 #endif

--- a/base/distributed_chromium_util.cc
+++ b/base/distributed_chromium_util.cc
@@ -1,0 +1,30 @@
+// Copyright 2020 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/distributed_chromium_util.h"
+
+#include "base/base_switches.h"
+#include "base/command_line.h"
+
+namespace base {
+
+bool Castanets::IsEnabled() {
+  return (CommandLine::ForCurrentProcess()->HasSwitch(
+             switches::kEnableCastanets))
+             ? true
+             : false;
+}
+
+std::string Castanets::ServerAddress() {
+  std::string server_address;
+  base::CommandLine* command_line = CommandLine::ForCurrentProcess();
+  if (command_line->HasSwitch(switches::kEnableCastanets)) {
+    server_address =
+        command_line->GetSwitchValueASCII(switches::kEnableCastanets);
+  }
+
+  return server_address;
+}
+
+}  // namespace base

--- a/base/distributed_chromium_util.h
+++ b/base/distributed_chromium_util.h
@@ -1,0 +1,22 @@
+// Copyright 2020 Samsung Electronics. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef BASE_DISTRIBUTED_CHROMIUM_H_
+#define BASE_DISTRIBUTED_CHROMIUM_H_
+
+#include <stddef.h>
+#include <string>
+
+#include "base/base_export.h"
+
+namespace base {
+class BASE_EXPORT Castanets {
+ public:
+  static bool IsEnabled();
+  static std::string ServerAddress();
+};
+
+}  // namespace base
+
+#endif  // BASE_DISTRIBUTED_CHROMIUM_H_

--- a/base/memory/platform_shared_memory_region_posix.cc
+++ b/base/memory/platform_shared_memory_region_posix.cc
@@ -17,6 +17,7 @@
 #if defined(CASTANETS)
 #include "base/base_switches.h"
 #include "base/command_line.h"
+#include "base/distributed_chromium_util.h"
 #endif
 
 #if defined(OS_ANDROID) && defined(CASTANETS)
@@ -173,8 +174,7 @@ PlatformSharedMemoryRegion PlatformSharedMemoryRegion::Duplicate() const {
 bool PlatformSharedMemoryRegion::ConvertToReadOnly() {
 
 #if defined(CASTANETS)
-  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kEnableForking)) {
+  if (base::Castanets::IsEnabled()) {
     mode_ = Mode::kReadOnly;
     return true;
   }

--- a/base/process/kill_posix.cc
+++ b/base/process/kill_posix.cc
@@ -20,6 +20,10 @@
 #include "base/threading/platform_thread.h"
 #include "build/build_config.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace base {
 
 namespace {
@@ -30,7 +34,7 @@ TerminationStatus GetTerminationStatusImpl(ProcessHandle handle,
   DCHECK(exit_code);
 
 #if defined(CASTANETS)
-  if (handle == kCastanetsProcessHandle) {
+  if (base::Castanets::IsEnabled() && (handle == kCastanetsProcessHandle)) {
     *exit_code = 0;
     return TERMINATION_STATUS_NORMAL_TERMINATION;
   }
@@ -99,7 +103,7 @@ TerminationStatus GetTerminationStatus(ProcessHandle handle, int* exit_code) {
 TerminationStatus GetKnownDeadTerminationStatus(ProcessHandle handle,
                                                 int* exit_code) {
 #if defined(CASTANETS)
-  if (handle == kCastanetsProcessHandle)
+  if (base::Castanets::IsEnabled() && (handle == kCastanetsProcessHandle))
     return GetTerminationStatusImpl(handle, true /* can_block */, exit_code);
 #endif
   bool result = kill(handle, SIGKILL) == 0;

--- a/base/process/process_posix.cc
+++ b/base/process/process_posix.cc
@@ -27,6 +27,10 @@
 #include "base/test/clang_profiling.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace {
 
 #if !defined(OS_NACL_NONSFI)
@@ -188,7 +192,8 @@ bool WaitForExitWithTimeoutImpl(base::ProcessHandle handle,
                                 base::TimeDelta timeout) {
 
 #if defined(CASTANETS)
-  if (handle < base::kCastanetsProcessHandle) {
+  if (base::Castanets::IsEnabled() &&
+      (handle < base::kCastanetsProcessHandle)) {
     *exit_code = -1;
     return true;
   }
@@ -292,7 +297,7 @@ void Process::TerminateCurrentProcessImmediately(int exit_code) {
 
 bool Process::IsValid() const {
 #if defined(CASTANETS)
-  if (process_ < kCastanetsProcessHandle)
+  if (base::Castanets::IsEnabled() && (process_ < kCastanetsProcessHandle))
     return true;
 #endif
   return process_ != kNullProcessHandle;
@@ -311,7 +316,7 @@ Process Process::Duplicate() const {
 
 ProcessId Process::Pid() const {
 #if defined(CASTANETS)
-  if (process_ < kCastanetsProcessHandle)
+  if (base::Castanets::IsEnabled() && (process_ < kCastanetsProcessHandle))
     return kCastanetsProcessId;
 #endif
   DCHECK(IsValid());
@@ -332,7 +337,7 @@ void Process::Close() {
 #if !defined(OS_NACL_NONSFI)
 bool Process::Terminate(int exit_code, bool wait) const {
 #if defined(CASTANETS)
-  if (process_ < kCastanetsProcessHandle) {
+  if (base::Castanets::IsEnabled() && (process_ < kCastanetsProcessHandle)) {
     // TODO(hw1008.kim): We have to send exit_code to the remote child process?
     return true;
   }
@@ -403,7 +408,7 @@ bool Process::SetProcessBackgrounded(bool value) {
 
 int Process::GetPriority() const {
 #if defined(CASTANETS)
-  if (process_ < kCastanetsProcessHandle)
+  if (base::Castanets::IsEnabled() && (process_ < kCastanetsProcessHandle))
     return 0; // The default priority is 0
 #endif
   DCHECK(IsValid());

--- a/cc/raster/one_copy_raster_buffer_provider.cc
+++ b/cc/raster/one_copy_raster_buffer_provider.cc
@@ -34,6 +34,7 @@
 
 #if defined(CASTANETS)
 #include "base/command_line.h"
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -341,8 +342,9 @@ void OneCopyRasterBufferProvider::PlaybackToStagingBuffer(
         raster_source, raster_full_rect, playback_rect, transform,
         dst_color_space, /*gpu_compositing=*/true, playback_settings);
 #if defined(CASTANETS)
-    if (std::string("renderer") ==
-        base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
+    if (base::Castanets::IsEnabled() &&
+        (std::string("renderer") ==
+         base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type"))) {
       mojo::SyncSharedMemory2d(
           buffer->CloneHandle().region.GetGUID(), staging_buffer->size.width(),
           staging_buffer->size.height(),

--- a/cc/tiles/tile_manager.cc
+++ b/cc/tiles/tile_manager.cc
@@ -35,6 +35,7 @@
 
 #if defined(CASTANETS)
 #include "base/command_line.h"
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif // defined(CASTANETS)
 
@@ -133,8 +134,9 @@ class RasterTaskImpl : public TileTask {
                              raster_transform_, playback_settings_, url_);
 
 #if defined(CASTANETS)
-    if (std::string("renderer") ==
-        base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
+    if (base::Castanets::IsEnabled() &&
+        (std::string("renderer") ==
+         base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type"))) {
       ResourcePool::SoftwareBacking* sw_backing = resource_.software_backing();
       if (sw_backing) {
         int bytes_per_pixel = BitsPerPixel(resource_.format()) / 8;

--- a/cc/trees/layer_tree_host_impl.cc
+++ b/cc/trees/layer_tree_host_impl.cc
@@ -131,6 +131,7 @@
 #include "ui/gfx/skia_util.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -5988,9 +5989,11 @@ void LayerTreeHostImpl::CreateUIResource(UIResourceId uid,
     transferable.format = format;
   } else {
 #if defined(CASTANETS)
-    mojo::SyncSharedMemory(
-        shm.region.GetGUID(), 0,
-        upload_size.width() * upload_size.height() * BitsPerPixel(format) / 8);
+    if (base::Castanets::IsEnabled()) {
+      mojo::SyncSharedMemory(shm.region.GetGUID(), 0,
+                             upload_size.width() * upload_size.height() *
+                                 BitsPerPixel(format) / 8);
+    }
 #endif
     layer_tree_frame_sink_->DidAllocateSharedBitmap(std::move(shm.region),
                                                     shared_bitmap_id);

--- a/components/subresource_filter/content/renderer/unverified_ruleset_dealer.cc
+++ b/components/subresource_filter/content/renderer/unverified_ruleset_dealer.cc
@@ -7,6 +7,10 @@
 #include "components/subresource_filter/content/common/subresource_filter_messages.h"
 #include "ipc/ipc_message_macros.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace subresource_filter {
 
 UnverifiedRulesetDealer::UnverifiedRulesetDealer() = default;
@@ -26,8 +30,10 @@ bool UnverifiedRulesetDealer::OnControlMessageReceived(
 void UnverifiedRulesetDealer::OnSetRulesetForProcess(
     const IPC::PlatformFileForTransit& platform_file) {
 #if defined(CASTANETS)
-  LOG(INFO) << "SKIP!!!!! UnverifiedRulesetDealer::OnSetRulesetForProcess";
-  return;
+  if (base::Castanets::IsEnabled()) {
+    LOG(INFO) << "SKIP!!!!! UnverifiedRulesetDealer::OnSetRulesetForProcess";
+    return;
+  }
 #else
   SetRulesetFile(IPC::PlatformFileForTransitToFile(platform_file));
 #endif

--- a/components/viz/service/display_embedder/server_shared_bitmap_manager.cc
+++ b/components/viz/service/display_embedder/server_shared_bitmap_manager.cc
@@ -23,6 +23,7 @@
 #include "ui/gfx/geometry/size.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -95,7 +96,8 @@ std::unique_ptr<SharedBitmap> ServerSharedBitmapManager::GetSharedBitmapFromId(
     return nullptr;
   }
 #if defined(CASTANETS)
-  mojo::WaitSyncSharedMemory(data->mapped_id());
+  if (base::Castanets::IsEnabled())
+    mojo::WaitSyncSharedMemory(data->mapped_id());
 #endif
   if (!data->memory()) {
     return nullptr;

--- a/content/app/content_main_runner_impl.cc
+++ b/content/app/content_main_runner_impl.cc
@@ -103,6 +103,7 @@
 #include "ui/gfx/switches.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "components/viz/common/switches.h"
 #include "gpu/config/gpu_switches.h"
 #include "ui/gl/gl_switches.h"
@@ -659,26 +660,28 @@ int ContentMainRunnerImpl::Initialize(const ContentMainParams& params) {
       command_line.GetSwitchValueASCII(switches::kProcessType);
 
 #if defined(CASTANETS)
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(service_manager::switches::kNoSandbox);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoZygote);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      switches::kInProcessGPU);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      switches::kDisableAcceleratedVideoDecode);
+  if (base::Castanets::IsEnabled()) {
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        service_manager::switches::kNoSandbox);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoZygote);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        switches::kInProcessGPU);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        switches::kDisableAcceleratedVideoDecode);
 
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      switches::kProcessPerTab);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        switches::kProcessPerTab);
 
-  base::CommandLine::ForCurrentProcess()->AppendSwitch("no-first-run");
-  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kLang,
-                                                            "en-US");
-  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
-      switches::kNumRasterThreads, "4");
+    base::CommandLine::ForCurrentProcess()->AppendSwitch("no-first-run");
+    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kLang,
+                                                              "en-US");
+    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
+        switches::kNumRasterThreads, "4");
 
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      switches::kDisallowNonExactResourceReuse);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      switches::kIgnoreGpuBlacklist);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        switches::kDisallowNonExactResourceReuse);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        switches::kIgnoreGpuBlacklist);
 #if defined(OS_LINUX)
   base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
       switches::kEnableLogging, "stderr");
@@ -687,6 +690,7 @@ int ContentMainRunnerImpl::Initialize(const ContentMainParams& params) {
       switches::kDisableGpuDriverBugWorkarounds);
   base::CommandLine::ForCurrentProcess()->AppendSwitch(
       switches::kDisableFrameRateLimit);
+  }
 #endif  // CASTANETS
 
 #if defined(OS_WIN)

--- a/content/browser/android/content_startup_flags.cc
+++ b/content/browser/android/content_startup_flags.cc
@@ -15,6 +15,7 @@
 #include "ui/base/ui_base_switches.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "components/viz/common/switches.h"
 #include "services/service_manager/sandbox/switches.h"
 #include "ui/gl/gl_switches.h"
@@ -33,21 +34,23 @@ void SetContentCommandLineFlags(bool single_process) {
       base::CommandLine::ForCurrentProcess();
 
 #if defined(CASTANETS)
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      service_manager::switches::kNoSandbox);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoZygote);
-  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
-      switches::kNumRasterThreads, "4");
-  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kLang,
-                                                            "en-US");
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      switches::kIgnoreGpuBlacklist);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      switches::kDisableGpuDriverBugWorkarounds);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      switches::kDisableFrameRateLimit);
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
-      switches::kDisallowNonExactResourceReuse);
+  if (base::Castanets::IsEnabled()) {
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        service_manager::switches::kNoSandbox);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(switches::kNoZygote);
+    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
+        switches::kNumRasterThreads, "4");
+    base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(switches::kLang,
+                                                              "en-US");
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        switches::kIgnoreGpuBlacklist);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        switches::kDisableGpuDriverBugWorkarounds);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        switches::kDisableFrameRateLimit);
+    base::CommandLine::ForCurrentProcess()->AppendSwitch(
+        switches::kDisallowNonExactResourceReuse);
+  }
 #endif
   if (single_process) {
     // Need to ensure the command line flag is consistent as a lot of chrome

--- a/content/browser/browser_child_process_host_impl.cc
+++ b/content/browser/browser_child_process_host_impl.cc
@@ -67,6 +67,10 @@
 #include "content/public/common/font_cache_win.mojom.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 namespace {
 
@@ -603,8 +607,11 @@ void BrowserChildProcessHostImpl::CreateMetricsAllocator() {
 
 void BrowserChildProcessHostImpl::ShareMetricsAllocatorToProcess() {
 #if defined(CASTANETS)
-  LOG(INFO) << "SKIP!!!!! BrowserChildProcessHostImpl::ShareMetricsAllocatorToProcess";
-  return;
+  if (base::Castanets::IsEnabled()) {
+    LOG(INFO) << "SKIP!!!!! "
+                 "BrowserChildProcessHostImpl::ShareMetricsAllocatorToProcess";
+    return;
+  }
 #else
   if (metrics_allocator_) {
     HistogramController::GetInstance()->SetHistogramMemory<ChildProcessHost>(

--- a/content/browser/frame_host/frame_tree_node.cc
+++ b/content/browser/frame_host/frame_tree_node.cc
@@ -34,6 +34,9 @@
 #include "third_party/blink/public/mojom/frame/user_activation_update_types.mojom.h"
 #include "third_party/blink/public/mojom/security_context/insecure_request_policy.mojom.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
 namespace content {
 
 namespace {
@@ -446,7 +449,7 @@ bool FrameTreeNode::CommitFramePolicy(
 void FrameTreeNode::TransferNavigationRequestOwnership(
     RenderFrameHostImpl* render_frame_host) {
 #if defined(CASTANETS)
-  if (!navigation_request_) {
+  if (base::Castanets::IsEnabled() && !navigation_request_) {
     LOG(WARNING) << "NavigationRequest is null";
     return;
   }

--- a/content/browser/frame_host/render_frame_host_manager.cc
+++ b/content/browser/frame_host/render_frame_host_manager.cc
@@ -70,6 +70,10 @@
 #include "ui/gfx/mac/scoped_cocoa_disable_screen_updates.h"
 #endif  // defined(OS_MACOSX)
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 
 namespace {
@@ -702,7 +706,7 @@ RenderFrameHostImpl* RenderFrameHostManager::GetFrameHostForNavigation(
 #if defined(CASTANETS)
   // FIXME: Currently once use_current_rfh is false, browser seem to be creating
   // new channel for renderer ignoring the already connected renderer.
-  if (1/* || use_current_rfh*/) {
+  if (1 /*|| base::Castanets::IsEnabled() || use_current_rfh*/) {
     // GetFrameHostForNavigation will be called more than once during a
     // navigation (currently twice, on request and when it's about to commit in
     // the renderer). In the follow up calls an existing pending WebUI should

--- a/content/browser/renderer_host/render_process_host_impl.cc
+++ b/content/browser/renderer_host/render_process_host_impl.cc
@@ -296,6 +296,10 @@
 #include "content/public/common/profiling_utils.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 
 namespace {
@@ -3460,7 +3464,7 @@ void RenderProcessHostImpl::PropagateBrowserCommandLineToRenderer(
     switches::kIpcFuzzerTestcase,
 #endif
 #if defined(CASTANETS)
-    switches::kServerAddress,
+    switches::kEnableCastanets,
 #endif
   };
   renderer_cmd->CopySwitchesFrom(browser_cmd, kSwitchNames,
@@ -4513,8 +4517,12 @@ RenderProcessHost* RenderProcessHostImpl::GetProcessHostForSiteInstance(
 
 void RenderProcessHostImpl::CreateSharedRendererHistogramAllocator() {
 #if defined(CASTANETS)
-  LOG(INFO) << "SKIP!!!!! RenderProcessHostImpl::CreateSharedRendererHistogramAllocator";
-  return;
+  if (base::Castanets::IsEnabled()) {
+    LOG(INFO)
+        << "SKIP!!!!! "
+           "RenderProcessHostImpl::CreateSharedRendererHistogramAllocator";
+    return;
+  }
 #else
   // Create a persistent memory segment for renderer histograms only if
   // they're active in the browser.

--- a/content/public/browser/content_browser_client.cc
+++ b/content/public/browser/content_browser_client.cc
@@ -57,6 +57,10 @@
 #include "url/gurl.h"
 #include "url/origin.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace content {
 
 std::unique_ptr<BrowserMainParts> ContentBrowserClient::CreateBrowserMainParts(
@@ -262,9 +266,13 @@ ContentBrowserClient::GetOriginsRequiringDedicatedProcess() {
 }
 
 bool ContentBrowserClient::ShouldEnableStrictSiteIsolation() {
-#if defined(OS_ANDROID)  || defined(CASTANETS)
+#if defined(OS_ANDROID)
   return false;
 #else
+#if defined(CASTANETS)
+  if (base::Castanets::IsEnabled())
+    return false;
+#endif
   return true;
 #endif
 }

--- a/content/public/common/use_zoom_for_dsf_policy.cc
+++ b/content/public/common/use_zoom_for_dsf_policy.cc
@@ -12,6 +12,10 @@
 #include "base/feature_list.h"
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace {
 
 #if defined(OS_WIN)
@@ -26,7 +30,8 @@ const base::Feature kUseZoomForDsfEnabledByDefault{
 
 bool IsUseZoomForDSFEnabledByDefault() {
 #if defined(CASTANETS)
-  return false;
+  if (base::Castanets::IsEnabled())
+    return false;
 #endif
 #if defined(OS_LINUX) || defined(OS_FUCHSIA)
   return true;

--- a/content/test/test_render_frame.cc
+++ b/content/test/test_render_frame.cc
@@ -234,7 +234,7 @@ class MockFrameHost : public mojom::FrameHost {
     }
   }
 
-#if defined(OS_ANDROID)
+#if defined(OS_ANDROID) || defined(CASTANETS)
   void UpdateUserGestureCarryoverInfo() override {}
 #endif
 

--- a/gpu/command_buffer/client/cmd_buffer_helper.cc
+++ b/gpu/command_buffer/client/cmd_buffer_helper.cc
@@ -23,6 +23,7 @@
 
 #if defined(CASTANETS)
 #include "base/command_line.h"
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -206,7 +207,8 @@ void CommandBufferHelper::Flush() {
 
   if (HaveRingBuffer()) {
 #if defined(CASTANETS)
-    SyncSharedMemoryForCommands();
+    if (base::Castanets::IsEnabled())
+      SyncSharedMemoryForCommands();
 #endif
     last_flush_time_ = base::TimeTicks::Now();
     last_flush_put_ = put_;
@@ -230,7 +232,8 @@ void CommandBufferHelper::OrderingBarrier() {
 
   if (HaveRingBuffer()) {
 #if defined(CASTANETS)
-    SyncSharedMemoryForCommands();
+    if (base::Castanets::IsEnabled())
+      SyncSharedMemoryForCommands();
 #endif
     last_ordering_barrier_put_ = put_;
     command_buffer_->OrderingBarrier(put_);

--- a/gpu/command_buffer/client/implementation_base.cc
+++ b/gpu/command_buffer/client/implementation_base.cc
@@ -18,6 +18,10 @@
 #include "gpu/command_buffer/client/shared_memory_limits.h"
 #include "gpu/command_buffer/common/sync_token.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace gpu {
 
 #if !defined(_MSC_VER)
@@ -261,19 +265,20 @@ gpu::ContextResult ImplementationBase::Initialize(
 void ImplementationBase::WaitForCmd() {
   TRACE_EVENT0("gpu", "ImplementationBase::WaitForCmd");
 #if defined(CASTANETS)
-  // Synchronize the result because some commands require initialization.
-  mojo::SyncSharedMemory(transfer_buffer_->shared_memory_guid(),
-                         GetResultShmOffset(), kMaxSizeOfSimpleResult);
-  // Call this api to synchronize the result shared memory.
-  helper_->SyncResultData(GetResultShmId(), GetResultShmOffset(),
-                          kMaxSizeOfSimpleResult);
-  helper_->Finish();
+  if (base::Castanets::IsEnabled()) {
+    // Synchronize the result because some commands require initialization.
+    mojo::SyncSharedMemory(transfer_buffer_->shared_memory_guid(),
+                           GetResultShmOffset(), kMaxSizeOfSimpleResult);
+    // Call this api to synchronize the result shared memory.
+    helper_->SyncResultData(GetResultShmId(), GetResultShmOffset(),
+                            kMaxSizeOfSimpleResult);
+    helper_->Finish();
 
-  // Wait for command execution result.
-  mojo::WaitSyncSharedMemory(transfer_buffer_->shared_memory_guid());
-#else
-  helper_->Finish();
+    // Wait for command execution result.
+    mojo::WaitSyncSharedMemory(transfer_buffer_->shared_memory_guid());
+  } else
 #endif
+    helper_->Finish();
 }
 
 int32_t ImplementationBase::GetResultShmId() {

--- a/gpu/command_buffer/client/mapped_memory.h
+++ b/gpu/command_buffer/client/mapped_memory.h
@@ -20,6 +20,7 @@
 
 #if defined(CASTANETS)
 #include "base/command_line.h"
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -87,8 +88,9 @@ class GPU_EXPORT MemoryChunk {
   void FreePendingToken(void* pointer, uint32_t token) {
     allocator_.FreePendingToken(pointer, token);
 #if defined(CASTANETS)
-    if (std::string("renderer") ==
-        base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
+    if (base::Castanets::IsEnabled() &&
+        (std::string("renderer") ==
+         base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type"))) {
       mojo::SyncSharedMemory(shm_->backing()->GetGUID(), GetOffset(pointer),
                              allocator_.GetBlockSize(pointer));
     }

--- a/gpu/command_buffer/client/transfer_buffer.cc
+++ b/gpu/command_buffer/client/transfer_buffer.cc
@@ -17,6 +17,7 @@
 
 #if defined(CASTANETS)
 #include "base/command_line.h"
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -94,8 +95,9 @@ void TransferBuffer::DiscardBlock(void* p) {
 void TransferBuffer::FreePendingToken(void* p, unsigned int token) {
   ring_buffer_->FreePendingToken(p, token);
 #if defined(CASTANETS)
-  if (std::string("renderer") ==
-      base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type")) {
+  if (base::Castanets::IsEnabled() &&
+      (std::string("renderer") ==
+       base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("type"))) {
     mojo::SyncSharedMemory(shared_memory_guid(), GetOffset(p),
                            ring_buffer_->GetBlockSize(p));
   }

--- a/gpu/command_buffer/service/command_buffer_service.cc
+++ b/gpu/command_buffer/service/command_buffer_service.cc
@@ -17,6 +17,7 @@
 #include "gpu/command_buffer/service/transfer_buffer_manager.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -65,7 +66,7 @@ void CommandBufferService::Flush(int32_t put_offset,
   }
 
 #if defined(CASTANETS)
-  if (ring_buffer_ && ring_buffer_->backing())
+  if (base::Castanets::IsEnabled() && ring_buffer_ && ring_buffer_->backing())
     mojo::WaitSyncSharedMemory(ring_buffer_->backing()->GetGUID());
 #endif
 

--- a/gpu/command_buffer/service/common_decoder.cc
+++ b/gpu/command_buffer/service/common_decoder.cc
@@ -16,6 +16,7 @@
 #include "ui/gfx/ipc/color/gfx_param_traits.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -345,10 +346,12 @@ error::Error CommonDecoder::HandleGetBucketStart(
     memcpy(data, bucket->GetData(0, size), size);
   }
 #if defined(CASTANETS)
-  scoped_refptr<gpu::Buffer> buffer =
-      command_buffer_service_->GetTransferBuffer(data_memory_id);
-  mojo::SyncSharedMemory(buffer->backing()->GetGUID(), data_memory_offset,
-                         data_memory_size);
+  if (base::Castanets::IsEnabled()) {
+    scoped_refptr<gpu::Buffer> buffer =
+        command_buffer_service_->GetTransferBuffer(data_memory_id);
+    mojo::SyncSharedMemory(buffer->backing()->GetGUID(), data_memory_offset,
+                           data_memory_size);
+  }
 #endif
   return error::kNoError;
 }
@@ -375,9 +378,11 @@ error::Error CommonDecoder::HandleGetBucketData(uint32_t immediate_data_size,
   }
   memcpy(data, src, size);
 #if defined(CASTANETS)
-  scoped_refptr<gpu::Buffer> buffer =
-      command_buffer_service_->GetTransferBuffer(args.shared_memory_id);
-  mojo::SyncSharedMemory(buffer->backing()->GetGUID(), offset, size);
+  if (base::Castanets::IsEnabled()) {
+    scoped_refptr<gpu::Buffer> buffer =
+        command_buffer_service_->GetTransferBuffer(args.shared_memory_id);
+    mojo::SyncSharedMemory(buffer->backing()->GetGUID(), offset, size);
+  }
 #endif
   return error::kNoError;
 }

--- a/ipc/ipc_message_utils.cc
+++ b/ipc/ipc_message_utils.cc
@@ -49,6 +49,7 @@
 #endif
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "base/memory/shared_memory_helper.h"
 #endif
 
@@ -1023,8 +1024,9 @@ bool ParamTraits<base::subtle::PlatformSharedMemoryRegion>::Read(
     }
   }
 #if defined(CASTANETS)
-  if (static_cast<internal::PlatformFileAttachment*>(attachment.get())->file()
-      == -1) {
+  if (base::Castanets::IsEnabled() &&
+      (static_cast<internal::PlatformFileAttachment*>(attachment.get())
+           ->file() == -1)) {
     base::SharedMemoryCreateOptions options;
     options.size = size;
     options.share_read_only =

--- a/media/renderers/video_resource_updater.cc
+++ b/media/renderers/video_resource_updater.cc
@@ -54,6 +54,7 @@
 #include "ui/gl/trace_util.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -1013,10 +1014,12 @@ VideoFrameExternalResources VideoResourceUpdater::CreateForSoftwarePlanes(
                                media::kNoTransformation, nullptr);
 #if defined(CASTANETS)
         // Compute the memory size with a RGBA_8888 format.
-        size_t memory_bytes = software_resource->resource_size().width() *
-                              software_resource->resource_size().height() * 4;
-        mojo::SyncSharedMemory(software_resource->GetSharedMemoryGuid(), 0,
-                               memory_bytes);
+        if (base::Castanets::IsEnabled()) {
+          size_t memory_bytes = software_resource->resource_size().width() *
+                                software_resource->resource_size().height() * 4;
+          mojo::SyncSharedMemory(software_resource->GetSharedMemoryGuid(), 0,
+                                 memory_bytes);
+        }
 #endif
 
       } else {

--- a/media/video/gpu_memory_buffer_video_frame_pool.cc
+++ b/media/video/gpu_memory_buffer_video_frame_pool.cc
@@ -40,6 +40,7 @@
 #include "ui/gl/trace_util.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "mojo/public/cpp/system/sync.h"
 #endif
 
@@ -695,9 +696,11 @@ void GpuMemoryBufferVideoFramePool::PoolImpl::OnCopiesDone(
   for (const auto& plane_resource : frame_resources->plane_resources) {
     if (plane_resource.gpu_memory_buffer) {
 #if defined(CASTANETS)
-      gfx::GpuMemoryBuffer *buffer = plane_resource.gpu_memory_buffer.get();
-      mojo::SyncSharedMemory(buffer->CloneHandle().region.GetGUID(), 0,
-                             buffer->CloneHandle().region.GetSize());
+      if (base::Castanets::IsEnabled()) {
+        gfx::GpuMemoryBuffer* buffer = plane_resource.gpu_memory_buffer.get();
+        mojo::SyncSharedMemory(buffer->CloneHandle().region.GetGUID(), 0,
+                               buffer->CloneHandle().region.GetSize());
+      }
 #endif
       plane_resource.gpu_memory_buffer->Unmap();
       plane_resource.gpu_memory_buffer->SetColorSpace(

--- a/mojo/core/broker_host.cc
+++ b/mojo/core/broker_host.cc
@@ -18,6 +18,10 @@
 #include <windows.h>
 #endif
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace mojo {
 namespace core {
 
@@ -73,15 +77,15 @@ bool BrokerHost::SendChannel(PlatformHandle handle) {
       CreateBrokerMessage(BrokerMessageType::INIT, 1, 0, &data);
   data->pipe_name_length = 0;
 #else
+  Channel::MessagePtr message;
 #if defined(CASTANETS)
-  InitData* data;
-  Channel::MessagePtr message =
-      CreateBrokerMessage(BrokerMessageType::INIT, 1, 0, &data);
-  data->port = -1;
-#else
-  Channel::MessagePtr message =
-      CreateBrokerMessage(BrokerMessageType::INIT, 1, nullptr);
+  if (base::Castanets::IsEnabled()) {
+    InitData* data;
+    message = CreateBrokerMessage(BrokerMessageType::INIT, 1, 0, &data);
+    data->port = -1;
+  } else
 #endif
+    message = CreateBrokerMessage(BrokerMessageType::INIT, 1, nullptr);
 #endif
   std::vector<PlatformHandleInTransit> handles(1);
   handles[0] = PlatformHandleInTransit(std::move(handle));

--- a/mojo/core/broker_posix.cc
+++ b/mojo/core/broker_posix.cc
@@ -115,7 +115,7 @@ base::WritableSharedMemoryRegion Broker::GetWritableSharedMemoryRegion(
     return base::WritableSharedMemoryRegion();
   }
 
-#if !defined(OS_POSIX) || defined(OS_ANDROID) || \
+#if !defined(OS_POSIX) || (defined(OS_ANDROID) && !defined(CASTANETS)) || \
     (defined(OS_MACOSX) && !defined(OS_IOS))
   // Non-POSIX systems, as well as Android, and non-iOS Mac, only use a single
   // handle to represent a writable region.

--- a/mojo/core/core.cc
+++ b/mojo/core/core.cc
@@ -43,6 +43,7 @@
 #include "mojo/core/watcher_dispatcher.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "base/memory/shared_memory_tracker.h"
 #endif // defined(CASTANETS)
 
@@ -1409,15 +1410,17 @@ MojoResult Core::SendInvitation(
                                          connection_name);
   } else {
 #if defined(CASTANETS)
-    if (transport_endpoint->type ==
-        MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_TCP_CLIENT) {
-      connection_params.SetTcpClient(
-          std::string(options->tcp_address, options->tcp_address_length),
-          options->tcp_port);
-    } else if (transport_endpoint->type ==
-               MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER) {
-      if (transport_endpoint->secure_connection)
-        connection_params.SetSecure();
+    if (base::Castanets::IsEnabled()) {
+      if (transport_endpoint->type ==
+          MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_TCP_CLIENT) {
+        connection_params.SetTcpClient(
+            std::string(options->tcp_address, options->tcp_address_length),
+            options->tcp_port);
+      } else if (transport_endpoint->type ==
+                 MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER) {
+        if (transport_endpoint->secure_connection)
+          connection_params.SetSecure();
+      }
     }
 #endif
     if (transport_endpoint->type ==
@@ -1495,16 +1498,18 @@ MojoResult Core::AcceptInvitation(
     connection_params.set_leak_endpoint(true);
   }
 #if defined(CASTANETS)
-  if (transport_endpoint->type ==
-      MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_TCP_CLIENT) {
-    connection_params.SetTcpClient(
-        std::string(transport_endpoint->tcp_address,
-                    transport_endpoint->tcp_address_length),
-        transport_endpoint->tcp_port);
-  } else if (transport_endpoint->type ==
-             MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER) {
-    if (transport_endpoint->secure_connection)
-      connection_params.SetSecure();
+  if (base::Castanets::IsEnabled()) {
+    if (transport_endpoint->type ==
+        MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_TCP_CLIENT) {
+      connection_params.SetTcpClient(
+          std::string(transport_endpoint->tcp_address,
+                      transport_endpoint->tcp_address_length),
+          transport_endpoint->tcp_port);
+    } else if (transport_endpoint->type ==
+               MOJO_INVITATION_TRANSPORT_TYPE_CHANNEL_SERVER) {
+      if (transport_endpoint->secure_connection)
+        connection_params.SetSecure();
+    }
   }
 #endif
   bool is_isolated =

--- a/mojo/core/data_pipe_consumer_dispatcher.cc
+++ b/mojo/core/data_pipe_consumer_dispatcher.cc
@@ -23,6 +23,7 @@
 #include "mojo/public/c/system/data_pipe.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "base/memory/castanets_memory_mapping.h"
 #include "base/memory/shared_memory_helper.h"
 #include "base/memory/shared_memory_tracker.h"
@@ -107,7 +108,8 @@ MojoResult DataPipeConsumerDispatcher::ReadData(
     void* elements,
     uint32_t* num_bytes) {
 #if defined(CASTANETS)
-  node_controller_->WaitSyncSharedBuffer(ring_buffer_mapping_.guid());
+  if (base::Castanets::IsEnabled())
+    node_controller_->WaitSyncSharedBuffer(ring_buffer_mapping_.guid());
 #endif
   base::AutoLock lock(lock_);
 
@@ -187,7 +189,8 @@ MojoResult DataPipeConsumerDispatcher::ReadData(
   if (discard || !peek) {
     read_offset_ = (read_offset_ + bytes_to_read) % options_.capacity_num_bytes;
 #if defined(CASTANETS)
-    unrolled_read_offset_ += bytes_to_read;
+    if (base::Castanets::IsEnabled())
+      unrolled_read_offset_ += bytes_to_read;
 #endif
     bytes_available_ -= bytes_to_read;
 
@@ -206,7 +209,8 @@ MojoResult DataPipeConsumerDispatcher::BeginReadData(
     const void** buffer,
     uint32_t* buffer_num_bytes) {
 #if defined(CASTANETS)
-  node_controller_->WaitSyncSharedBuffer(ring_buffer_mapping_.guid());
+  if (base::Castanets::IsEnabled())
+    node_controller_->WaitSyncSharedBuffer(ring_buffer_mapping_.guid());
 #endif
   base::AutoLock lock(lock_);
   if (!shared_ring_buffer_.IsValid() || in_transit_)
@@ -230,17 +234,19 @@ MojoResult DataPipeConsumerDispatcher::BeginReadData(
       std::min(bytes_available_, options_.capacity_num_bytes - read_offset_);
 
 #if defined(CASTANETS)
-  scoped_refptr<base::CastanetsMemoryMapping> mapping =
-      base::SharedMemoryTracker::GetInstance()->FindMappedMemory(
-          ring_buffer_mapping_.guid());
-  if (mapping && mapping->current_size() &&
-      mapping->current_size() < (unrolled_read_offset_ + bytes_to_read)) {
-    VLOG(2) << ring_buffer_mapping_.guid()
-            << " is not fully received, received size: "
-            << mapping->current_size()
-            << ", but trying to read: " << bytes_to_read
-            << " bytes from offset: " << unrolled_read_offset_;
-    return MOJO_RESULT_SHOULD_WAIT;
+  if (base::Castanets::IsEnabled()) {
+    scoped_refptr<base::CastanetsMemoryMapping> mapping =
+        base::SharedMemoryTracker::GetInstance()->FindMappedMemory(
+            ring_buffer_mapping_.guid());
+    if (mapping && mapping->current_size() &&
+        mapping->current_size() < (unrolled_read_offset_ + bytes_to_read)) {
+      VLOG(2) << ring_buffer_mapping_.guid()
+              << " is not fully received, received size: "
+              << mapping->current_size()
+              << ", but trying to read: " << bytes_to_read
+              << " bytes from offset: " << unrolled_read_offset_;
+      return MOJO_RESULT_SHOULD_WAIT;
+    }
   }
 #endif
 
@@ -278,7 +284,8 @@ MojoResult DataPipeConsumerDispatcher::EndReadData(uint32_t num_bytes_read) {
     read_offset_ =
         (read_offset_ + num_bytes_read) % options_.capacity_num_bytes;
 #if defined(CASTANETS)
-    unrolled_read_offset_ += num_bytes_read;
+    if (base::Castanets::IsEnabled())
+      unrolled_read_offset_ += num_bytes_read;
 #endif
 
     DCHECK_GE(bytes_available_, num_bytes_read);
@@ -364,8 +371,10 @@ bool DataPipeConsumerDispatcher::EndSerialize(
 
 #if defined(CASTANETS)
 #if DISABLE_MULTI_CONNECTION_CHANGES
-  base::SharedMemoryTracker::GetInstance()->AddFDInTransit(
-      guid, platform_handles[0].GetFD().get());
+  if (base::Castanets::IsEnabled()) {
+    base::SharedMemoryTracker::GetInstance()->AddFDInTransit(
+        guid, platform_handles[0].GetFD().get());
+  }
 #endif
 #endif
   return true;
@@ -422,28 +431,29 @@ DataPipeConsumerDispatcher::Deserialize(const void* data,
   if (node_controller->node()->GetPort(ports[0], &port) != ports::OK)
     return nullptr;
 
-#if defined(CASTANETS)
   base::subtle::PlatformSharedMemoryRegion::ScopedPlatformHandle region_handle;
-  if (handles[0].GetFD().get() < 0) {
-    base::SharedMemoryCreateOptions options;
-    options.size = static_cast<size_t>(state->options.capacity_num_bytes);
-    auto new_region = base::CreateAnonymousSharedMemoryIfNeeded(
-        base::UnguessableToken::Deserialize(state->buffer_guid_high,
-                                            state->buffer_guid_low),
-        options);
-    region_handle = new_region.PassPlatformHandle();
-  } else {
+#if defined(CASTANETS)
+  if (base::Castanets::IsEnabled()) {
+    if (handles[0].GetFD().get() < 0) {
+      base::SharedMemoryCreateOptions options;
+      options.size = static_cast<size_t>(state->options.capacity_num_bytes);
+      auto new_region = base::CreateAnonymousSharedMemoryIfNeeded(
+          base::UnguessableToken::Deserialize(state->buffer_guid_high,
+                                              state->buffer_guid_low),
+          options);
+      region_handle = new_region.PassPlatformHandle();
+    } else {
 #if DISABLE_MULTI_CONNECTION_CHANGES
     base::SharedMemoryTracker::GetInstance()->MapInternalMemory(
         handles[0].GetFD().get());
 #endif
     region_handle = CreateSharedMemoryRegionHandleFromPlatformHandles(
         std::move(handles[0]), PlatformHandle());
-  }
-#else
-  auto region_handle = CreateSharedMemoryRegionHandleFromPlatformHandles(
-      std::move(handles[0]), PlatformHandle());
+    }
+  } else
 #endif
+    region_handle = CreateSharedMemoryRegionHandleFromPlatformHandles(
+        std::move(handles[0]), PlatformHandle());
   auto region = base::subtle::PlatformSharedMemoryRegion::Take(
       std::move(region_handle),
       base::subtle::PlatformSharedMemoryRegion::Mode::kUnsafe,
@@ -466,7 +476,8 @@ DataPipeConsumerDispatcher::Deserialize(const void* data,
     base::AutoLock lock(dispatcher->lock_);
     dispatcher->read_offset_ = state->read_offset;
 #if defined(CASTANETS)
-    dispatcher->unrolled_read_offset_ = state->read_offset;
+    if (base::Castanets::IsEnabled())
+      dispatcher->unrolled_read_offset_ = state->read_offset;
 #endif
     dispatcher->bytes_available_ = state->bytes_available;
     dispatcher->new_data_available_ = state->bytes_available > 0;

--- a/mojo/core/data_pipe_producer_dispatcher.cc
+++ b/mojo/core/data_pipe_producer_dispatcher.cc
@@ -21,6 +21,10 @@
 #include "mojo/core/user_message_impl.h"
 #include "mojo/public/c/system/data_pipe.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace mojo {
 namespace core {
 
@@ -241,7 +245,8 @@ MojoResult DataPipeProducerDispatcher::EndWriteData(
     base::AutoUnlock unlock(lock_);
     NotifyWrite(num_bytes_written);
 #if defined(CASTANETS)
-    SyncData(num_bytes_written);
+    if (base::Castanets::IsEnabled())
+      SyncData(num_bytes_written);
 #endif
   }
 

--- a/mojo/core/node_controller.h
+++ b/mojo/core/node_controller.h
@@ -393,8 +393,8 @@ class MOJO_SYSTEM_IMPL_EXPORT NodeController : public ports::NodeDelegate,
 #if !defined(OS_MACOSX) && !defined(OS_NACL_SFI) && !defined(OS_FUCHSIA)
   // Broker for sync shared buffer creation on behalf of broker clients.
 #if defined(CASTANETS)
-  scoped_refptr<BrokerCastanets> broker_;
-
+  scoped_refptr<BrokerCastanets> broker_castanets_;
+  std::unique_ptr<Broker> broker_;
   base::Lock broker_hosts_lock_;
   std::unordered_map<base::ProcessHandle, scoped_refptr<BrokerCastanets>>
       broker_hosts_;

--- a/mojo/core/shared_buffer_dispatcher.cc
+++ b/mojo/core/shared_buffer_dispatcher.cc
@@ -22,6 +22,7 @@
 #include "mojo/public/c/system/platform_handle.h"
 
 #if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
 #include "base/memory/shared_memory_helper.h"
 #include "base/memory/shared_memory_tracker.h"
 #endif // defined(CASTANETS)
@@ -188,21 +189,15 @@ scoped_refptr<SharedBufferDispatcher> SharedBufferDispatcher::Deserialize(
       mode, static_cast<size_t>(serialized_state->num_bytes), guid);
 
 #if defined(CASTANETS)
-  if (!region.IsValid()) {
-    base::SharedMemoryCreateOptions options;
-    options.size = static_cast<size_t>(serialized_state->num_bytes);
-    // TODO: Check why read only mode crashes
-#if 0
-    if (mode == base::subtle::PlatformSharedMemoryRegion::Mode::kReadOnly) {
-      options.share_read_only = true;
+  if (base::Castanets::IsEnabled()) {
+    if (!region.IsValid()) {
+      base::SharedMemoryCreateOptions options;
+      options.size = static_cast<size_t>(serialized_state->num_bytes);
+      region = base::CreateAnonymousSharedMemoryIfNeeded(guid, options);
+    } else {
+      base::SharedMemoryTracker::GetInstance()->MapInternalMemory(
+          region.GetPlatformHandle().fd);
     }
-#endif
-    region = base::CreateAnonymousSharedMemoryIfNeeded(guid, options);
-#if DISABLE_MULTI_CONNECTION_CHANGES
-  } else {
-    base::SharedMemoryTracker::GetInstance()->MapInternalMemory(
-        region.GetPlatformHandle().fd);
-#endif
   }
 #endif
 
@@ -389,8 +384,10 @@ bool SharedBufferDispatcher::EndSerialize(void* destination,
     handles[1] = std::move(platform_handles[1]);
 #if defined(CASTANETS)
 #if DISABLE_MULTI_CONNECTION_CHANGES
-    base::SharedMemoryTracker::GetInstance()->AddFDInTransit(
-        guid, handles[0].GetFD().get());
+    if (base::Castanets::IsEnabled()) {
+      base::SharedMemoryTracker::GetInstance()->AddFDInTransit(
+          guid, handles[0].GetFD().get());
+    }
 #endif
 #endif
     return true;
@@ -405,8 +402,10 @@ bool SharedBufferDispatcher::EndSerialize(void* destination,
 
 #if defined(CASTANETS)
 #if DISABLE_MULTI_CONNECTION_CHANGES
-  base::SharedMemoryTracker::GetInstance()->AddFDInTransit(
-      guid, handles[0].GetFD().get());
+  if (base::Castanets::IsEnabled()) {
+    base::SharedMemoryTracker::GetInstance()->AddFDInTransit(
+        guid, handles[0].GetFD().get());
+  }
 #endif
 #endif
   return true;

--- a/mojo/public/cpp/platform/named_platform_channel_posix.cc
+++ b/mojo/public/cpp/platform/named_platform_channel_posix.cc
@@ -16,6 +16,10 @@
 #include "base/rand_util.h"
 #include "base/strings/string_number_conversions.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace mojo {
 
 namespace {
@@ -82,7 +86,7 @@ PlatformChannelServerEndpoint NamedPlatformChannel::CreateServerEndpoint(
     const Options& options,
     ServerName* server_name) {
 #if defined(CASTANETS)
-  if (options.port > -1) {
+  if (base::Castanets::IsEnabled() && (options.port > -1)) {
     uint16_t port = options.port;
     return PlatformChannelServerEndpoint(CreateTCPServerHandle(port, &port));
   }

--- a/third_party/blink/renderer/platform/fonts/skia/font_cache_skia.cc
+++ b/third_party/blink/renderer/platform/fonts/skia/font_cache_skia.cc
@@ -55,6 +55,10 @@
 #include "third_party/skia/include/core/SkStream.h"
 #include "third_party/skia/include/core/SkTypeface.h"
 
+#if defined(CASTANETS)
+#include "base/distributed_chromium_util.h"
+#endif
+
 namespace blink {
 
 AtomicString ToAtomicString(const SkString& str) {
@@ -199,9 +203,15 @@ sk_sp<SkTypeface> FontCache::CreateTypeface(
   // TODO(fuchsia): Revisit this and other font code for Fuchsia.
 
   if (creation_params.CreationType() == kCreateFontByFciIdAndTtcIndex) {
-#if !defined(CASTANETS)
+#if defined(CASTANETS)
     // fontconfigInterfaceId() of browser will not be known by renderer in
     // distributed chromium scenario. So lets go by filename.
+    if (!base::Castanets::IsEnabled() &&
+        Platform::Current()->GetSandboxSupport()) {
+      return SkTypeface_Factory::FromFontConfigInterfaceIdAndTtcIndex(
+          creation_params.FontconfigInterfaceId(), creation_params.TtcIndex());
+    }
+#else
     if (Platform::Current()->GetSandboxSupport()) {
       return SkTypeface_Factory::FromFontConfigInterfaceIdAndTtcIndex(
           creation_params.FontconfigInterfaceId(), creation_params.TtcIndex());


### PR DESCRIPTION
This change adds runtime flag to enable castanets.
Runtime flags --enable-forking, --server-address has been removed.
Castanets can be verified as below,

Standalone mode:
chrome <url>

Castanets mode:
Browser: chrome <url> --enable-castanets
Renderer: chrome --type=renderer --enable-castanets=<IP Address>

Signed-off-by: v-saha <v.saha@samsung.com>