### PR TITLE
Add mojo FocusedNodeChangedParams similar to efl port.

### DIFF
--- a/content/browser/frame_host/render_frame_host_delegate.h
+++ b/content/browser/frame_host/render_frame_host_delegate.h
@@ -353,7 +353,13 @@ class CONTENT_EXPORT RenderFrameHostDelegate {
   // coordinate space.
   virtual void OnFocusedElementChangedInFrame(
       RenderFrameHostImpl* frame,
-      const gfx::Rect& bounds_in_root_view) {}
+      const gfx::Rect& bounds_in_root_view
+#if defined(CASTANETS)
+      ,
+      blink::mojom::FocusedNodeChangedParamsPtr params
+#endif
+  ) {
+  }
 
   // The page is trying to open a new page (e.g. a popup window). The window
   // should be created associated the process of |opener|, but it should not

--- a/content/browser/frame_host/render_frame_host_impl.cc
+++ b/content/browser/frame_host/render_frame_host_impl.cc
@@ -4482,16 +4482,27 @@ void RenderFrameHostImpl::OnSelectionChanged(const base::string16& text,
 
 void RenderFrameHostImpl::FocusedElementChanged(
     bool is_editable_element,
-    const gfx::Rect& bounds_in_frame_widget) {
+    const gfx::Rect& bounds_in_frame_widget
+#if defined(CASTANETS)
+    ,
+    blink::mojom::FocusedNodeChangedParamsPtr params
+#endif
+) {
   if (!GetView())
     return;
 
   has_focused_editable_element_ = is_editable_element;
   // First convert the bounds to root view.
   delegate_->OnFocusedElementChangedInFrame(
-      this, gfx::Rect(GetView()->TransformPointToRootCoordSpace(
-                          bounds_in_frame_widget.origin()),
-                      bounds_in_frame_widget.size()));
+      this,
+      gfx::Rect(GetView()->TransformPointToRootCoordSpace(
+                    bounds_in_frame_widget.origin()),
+                bounds_in_frame_widget.size())
+#if defined(CASTANETS)
+          ,
+      std::move(params)
+#endif
+  );
 }
 
 void RenderFrameHostImpl::DidReceiveFirstUserActivation() {

--- a/content/browser/frame_host/render_frame_host_impl.h
+++ b/content/browser/frame_host/render_frame_host_impl.h
@@ -1579,7 +1579,12 @@ class CONTENT_EXPORT RenderFrameHostImpl
       std::vector<blink::mojom::FaviconURLPtr> favicon_urls) override;
   void DownloadURL(blink::mojom::DownloadURLParamsPtr params) override;
   void FocusedElementChanged(bool is_editable_element,
-                             const gfx::Rect& bounds_in_frame_widget) override;
+                             const gfx::Rect& bounds_in_frame_widget
+#if defined(CASTANETS)
+                             ,
+                             blink::mojom::FocusedNodeChangedParamsPtr params
+#endif
+                             ) override;
   void ShowPopupMenu(
       mojo::PendingRemote<blink::mojom::PopupMenuClient> popup_client,
       const gfx::Rect& bounds,

--- a/content/browser/web_contents/web_contents_impl.cc
+++ b/content/browser/web_contents/web_contents_impl.cc
@@ -6458,7 +6458,12 @@ void WebContentsImpl::OnAdvanceFocus(RenderFrameHostImpl* source_rfh) {
 
 void WebContentsImpl::OnFocusedElementChangedInFrame(
     RenderFrameHostImpl* frame,
-    const gfx::Rect& bounds_in_root_view) {
+    const gfx::Rect& bounds_in_root_view
+#if defined(CASTANETS)
+    ,
+    blink::mojom::FocusedNodeChangedParamsPtr params
+#endif
+) {
   RenderWidgetHostViewBase* root_view =
       static_cast<RenderWidgetHostViewBase*>(GetRenderWidgetHostView());
   if (!root_view || !frame->GetView())

--- a/content/browser/web_contents/web_contents_impl.h
+++ b/content/browser/web_contents/web_contents_impl.h
@@ -628,7 +628,12 @@ class CONTENT_EXPORT WebContentsImpl : public WebContents,
   RenderFrameHost* GetFocusedFrameIncludingInnerWebContents() override;
   void OnFocusedElementChangedInFrame(
       RenderFrameHostImpl* frame,
-      const gfx::Rect& bounds_in_root_view) override;
+      const gfx::Rect& bounds_in_root_view
+#if defined(CASTANETS)
+      ,
+      blink::mojom::FocusedNodeChangedParamsPtr params
+#endif
+      ) override;
   void OnAdvanceFocus(RenderFrameHostImpl* source_rfh) override;
   RenderFrameHostDelegate* CreateNewWindow(
       RenderFrameHost* opener,

--- a/third_party/blink/public/mojom/frame/frame.mojom
+++ b/third_party/blink/public/mojom/frame/frame.mojom
@@ -120,6 +120,12 @@ struct TextAutosizerPageInfo {
   float device_scale_adjustment;
 };
 
+struct FocusedNodeChangedParams {
+  bool is_radio_or_checkbox_input_node;
+  int32 password_input_minlength;
+  bool is_content_editable;
+};
+
 // Implemented in Browser, this interface defines frame-specific methods that
 // will be invoked from the render process (e.g. content::RenderFrameHostImpl).
 //
@@ -358,8 +364,10 @@ interface LocalFrameHost {
   // The second parameter is the newly focused element's bounds relative to
   // local root's view, and it will be an empty bounds if there is no focused
   // element.
+
   FocusedElementChanged(bool is_editable_element,
-                        gfx.mojom.Rect bounds_in_frame_widget);
+                        gfx.mojom.Rect bounds_in_frame_widget,
+                        FocusedNodeChangedParams params);
 
   // Show a popup menu using native controls on Mac or Android.
   // The popup menu is hidden when the mojo channel is closed.

--- a/third_party/blink/renderer/core/exported/web_frame_test.cc
+++ b/third_party/blink/renderer/core/exported/web_frame_test.cc
@@ -13309,7 +13309,12 @@ class TestFocusedElementChangedLocalFrameHost : public FakeLocalFrameHost {
 
   // FakeLocalFrameHost:
   void FocusedElementChanged(bool is_editable_element,
-                             const gfx::Rect& bounds_in_frame_widget) override {
+                             const gfx::Rect& bounds_in_frame_widget
+#if defined(CASTANETS)
+                             ,
+                             blink::mojom::FocusedNodeChangedParamsPtr params
+#endif
+                             ) override {
     did_notify_ = true;
   }
 

--- a/third_party/blink/renderer/core/testing/fake_local_frame_host.cc
+++ b/third_party/blink/renderer/core/testing/fake_local_frame_host.cc
@@ -162,7 +162,13 @@ void FakeLocalFrameHost::DownloadURL(
 
 void FakeLocalFrameHost::FocusedElementChanged(
     bool is_editable_element,
-    const gfx::Rect& bounds_in_frame_widget) {}
+    const gfx::Rect& bounds_in_frame_widget
+#if defined(CASTANETS)
+    ,
+    blink::mojom::FocusedNodeChangedParamsPtr params
+#endif
+) {
+}
 
 void FakeLocalFrameHost::ShowPopupMenu(
     mojo::PendingRemote<mojom::blink::PopupMenuClient> popup_client,

--- a/third_party/blink/renderer/core/testing/fake_local_frame_host.h
+++ b/third_party/blink/renderer/core/testing/fake_local_frame_host.h
@@ -97,7 +97,12 @@ class FakeLocalFrameHost : public mojom::blink::LocalFrameHost {
       WTF::Vector<blink::mojom::blink::FaviconURLPtr> favicon_urls) override;
   void DownloadURL(mojom::blink::DownloadURLParamsPtr params) override;
   void FocusedElementChanged(bool is_editable_element,
-                             const gfx::Rect& bounds_in_frame_widget) override;
+                             const gfx::Rect& bounds_in_frame_widget
+#if defined(CASTANETS)
+                             ,
+                             blink::mojom::FocusedNodeChangedParamsPtr params
+#endif
+                             ) override;
   void ShowPopupMenu(
       mojo::PendingRemote<mojom::blink::PopupMenuClient> popup_client,
       const gfx::Rect& bounds,


### PR DESCRIPTION
This changes adds mojo FocusedNodeChangedParams to
FocusedElementChanged method similar to efl port.

Signed-off-by: Suhaspoornachandra <s.poornachan@samsung.com>